### PR TITLE
Add a MAINTAINERS file

### DIFF
--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -1,0 +1,56 @@
+# parsec maintainers file
+#
+# This file lists the maintainers of the parallaxsecond/parsec project.
+#
+# Its structure is inspired from the maintainers files in the Docker Github
+# repositories. Please see the MAINTAINERS file in docker/opensource for more
+# information.
+
+[maintainers]
+
+# Core maintainers of the project.
+
+    [maintainers.core]
+    people = [
+      "adamparco",
+      "heavypackets",
+      "hug-dev",
+      "ionut-arm",
+      "justincormack",
+      "paulhowardarm",
+    ]
+
+[people]
+
+# A reference list of all people associated with the project.
+
+    [people.adamparco]
+    Name = "Adam Parco"
+    Email = "adam.parco@docker.com"
+    GitHub = "adamparco"
+
+    [people.heavypackets]
+    Name = "Sabree Blackmon"
+    Email = "sabree.blackmon@docker.com"
+    GitHub = "heavypackets"
+
+    [people.hug-dev]
+    Name = "Hugues de Valon"
+    Email = "hugues.devalon@arm.com"
+    GitHub = "hug-dev"
+
+    [people.ionut-arm]
+    Name = "Ionut Mihalcea"
+    Email = "ionut.mihalcea@docker.com"
+    GitHub = "ionut-arm"
+
+    [people.justincormack]
+    Name = "Justin Cormack"
+    Email = "justin.cormack@docker.com"
+    GitHub = "justincormack"
+
+    [people.paulhowardarm]
+    Name = "Paul Howard"
+    Email = "paul.howard@arm.com"
+    GitHub = "paulhowardarm"
+


### PR DESCRIPTION
This commit adds a MAINTAINERS file as a .toml so it can be parsed
programmatically.

Change-Id: Iee9b8f471857b69baf44d94e024faf2328e40070
Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>