### PR TITLE
Add the integration tests in the parsec repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,11 +388,21 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_toml 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parsec-client-test 0.1.0 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.0)",
  "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parsec-client-test"
+version = "0.1.0"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.0#4190bd546ce24a8ddd762c7a199e51e970412660"
+dependencies = [
+ "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)",
 ]
 
 [[package]]
@@ -822,6 +832,7 @@ dependencies = [
 "checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
 "checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum parsec-client-test 0.1.0 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.0)" = "<none>"
 "checksum parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)" = "<none>"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ rand = "0.7.0"
 base64 = "0.10.1"
 uuid = "0.7.4"
 
+[dev-dependencies]
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.0"  }
+
 [build-dependencies]
 bindgen = "0.50.0"
 cargo_toml = "0.7.0"

--- a/ci/all.sh
+++ b/ci/all.sh
@@ -30,10 +30,11 @@
 ##############
 cargo build || exit 1
 
-##############
-# Unit tests #
-##############
-cargo test || exit 1
+############################
+# Unit tests and doc tests #
+############################
+cargo test --lib || exit 1
+cargo test --doc || exit 1
 
 #################
 # Static checks #
@@ -48,9 +49,7 @@ cargo run &
 SERVER_PID=$!
 sleep 5
 
-pushd $1 || exit 1
 cargo test --test normal || exit 1
-popd
 
 kill $SERVER_PID
 
@@ -61,9 +60,7 @@ cargo run &
 SERVER_PID=$!
 sleep 5
 
-pushd $1 || exit 1
 cargo test --test persistent-before || exit 1
-popd
 
 kill $SERVER_PID
 
@@ -77,8 +74,6 @@ cargo run &
 SERVER_PID=$!
 sleep 5
 
-pushd $1 || exit 1
 cargo test --test persistent-after || exit 1
-popd
 
 kill $SERVER_PID

--- a/tests/normal.rs
+++ b/tests/normal.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This module combines all tests that can be run without having to restart the service.
+mod normal_tests;

--- a/tests/normal_tests/asym_sign_verify.rs
+++ b/tests/normal_tests/asym_sign_verify.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::TestClient;
+    use parsec_interface::requests::ProviderID;
+    use parsec_interface::requests::{ResponseStatus, Result};
+
+    const HASH: [u8; 32] = [
+        0x69, 0x3E, 0xDB, 0x1B, 0x22, 0x79, 0x03, 0xF4, 0xC0, 0xBF, 0xD6, 0x91, 0x76, 0x37, 0x84,
+        0xA2, 0x94, 0x8E, 0x92, 0x50, 0x35, 0xC2, 0x8C, 0x5C, 0x3C, 0xCA, 0xFE, 0x18, 0xE8, 0x81,
+        0x37, 0x78,
+    ];
+
+    #[test]
+    fn asym_sign_no_key() {
+        let key_name = String::from("asym_sign_no_key");
+        let mut client = TestClient::new();
+        client.set_provider(Some(ProviderID::MbedProvider));
+        let status = client
+            .sign(key_name, HASH.to_vec())
+            .expect_err("Key should not exist.");
+        assert_eq!(status, ResponseStatus::KeyDoesNotExist);
+    }
+
+    #[test]
+    fn asym_verify_no_key() {
+        let key_name = String::from("asym_verify_no_key");
+        let signature = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let mut client = TestClient::new();
+        client.set_provider(Some(ProviderID::MbedProvider));
+        let status = client
+            .verify(key_name, HASH.to_vec(), signature)
+            .expect_err("Verification should have failed");
+        assert_eq!(status, ResponseStatus::KeyDoesNotExist);
+    }
+
+    #[test]
+    fn asym_sign_and_verify_rsa_pkcs() -> Result<()> {
+        let key_name = String::from("asym_sign_and_verify_rsa_pkcs");
+        let mut client = TestClient::new();
+        client.set_provider(Some(ProviderID::MbedProvider));
+
+        client.create_rsa_sign_key(key_name.clone())?;
+
+        let signature = client.sign(key_name.clone(), HASH.to_vec())?;
+
+        client.verify(key_name.clone(), HASH.to_vec(), signature)
+    }
+
+    #[test]
+    fn asym_verify_fail() -> Result<()> {
+        let key_name = String::from("asym_verify_fail");
+        let signature = vec![0xff; 128];
+        let mut client = TestClient::new();
+        client.set_provider(Some(ProviderID::MbedProvider));
+
+        client.create_rsa_sign_key(key_name.clone())?;
+
+        client
+            .verify(key_name.clone(), HASH.to_vec(), signature)
+            .expect_err("Verification should have failed");
+
+        Ok(())
+    }
+}

--- a/tests/normal_tests/auth.rs
+++ b/tests/normal_tests/auth.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::TestClient;
+    use parsec_interface::requests::ProviderID;
+    use parsec_interface::requests::{ResponseStatus, Result};
+
+    #[test]
+    fn two_auths_same_key_name() -> Result<()> {
+        let key_name = String::from("two_auths_same_key_name");
+        let mut client = TestClient::new();
+        client.set_provider(Some(ProviderID::MbedProvider));
+        let auth1 = String::from("first_client").into_bytes();
+        let auth2 = String::from("second_client").into_bytes();
+
+        client.set_auth(auth1.clone());
+        client.create_rsa_sign_key(key_name.clone())?;
+
+        client.set_auth(auth2.clone());
+        client.create_rsa_sign_key(key_name.clone())
+    }
+
+    #[test]
+    fn delete_wrong_key() -> Result<()> {
+        let key_name = String::from("delete_wrong_key");
+        let mut client = TestClient::new();
+        client.set_provider(Some(ProviderID::MbedProvider));
+        let auth1 = String::from("first_client").into_bytes();
+        let auth2 = String::from("second_client").into_bytes();
+
+        client.set_auth(auth1.clone());
+        client.create_rsa_sign_key(key_name.clone())?;
+
+        client.set_auth(auth2.clone());
+        let status = client
+            .destroy_key(key_name.clone())
+            .expect_err("Destroying key should have failed");
+        assert_eq!(status, ResponseStatus::KeyDoesNotExist);
+
+        Ok(())
+    }
+}

--- a/tests/normal_tests/basic.rs
+++ b/tests/normal_tests/basic.rs
@@ -1,0 +1,148 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::RequestTestClient;
+    use parsec_client_test::TestClient;
+    use parsec_interface::requests::request::RawHeader;
+    use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus};
+
+    #[test]
+    fn invalid_version() {
+        let mut client = RequestTestClient::new();
+        let mut req_hdr = RawHeader::new();
+
+        req_hdr.provider = ProviderID::CoreProvider as u8;
+        req_hdr.opcode = Opcode::Ping as u16;
+        req_hdr.version_maj = 0xff;
+
+        let resp = client
+            .send_raw_request(req_hdr, Vec::new())
+            .expect("Failed to read Response");
+        assert_eq!(resp.header.status, ResponseStatus::VersionTooBig);
+        assert_eq!(resp.header.opcode, Opcode::Ping);
+    }
+
+    #[test]
+    fn invalid_provider() {
+        let mut client = RequestTestClient::new();
+        let mut req_hdr = RawHeader::new();
+
+        req_hdr.provider = 0xff;
+        req_hdr.opcode = Opcode::Ping as u16;
+        req_hdr.version_maj = 0xff;
+
+        let resp = client
+            .send_raw_request(req_hdr, Vec::new())
+            .expect("Failed to read Response");
+        assert_eq!(resp.header.status, ResponseStatus::ProviderDoesNotExist);
+        assert_eq!(resp.header.opcode, Opcode::Ping);
+    }
+
+    #[test]
+    fn invalid_content_type() {
+        let mut client = RequestTestClient::new();
+        let mut req_hdr = RawHeader::new();
+
+        req_hdr.provider = ProviderID::CoreProvider as u8;
+        req_hdr.opcode = Opcode::Ping as u16;
+        req_hdr.version_maj = 1;
+        req_hdr.content_type = 0xff;
+
+        let resp = client
+            .send_raw_request(req_hdr, Vec::new())
+            .expect("Failed to read Response");
+        assert_eq!(resp.header.status, ResponseStatus::ContentTypeNotSupported);
+        assert_eq!(resp.header.opcode, Opcode::Ping);
+    }
+
+    #[test]
+    fn invalid_accept_type() {
+        let mut client = RequestTestClient::new();
+        let mut req_hdr = RawHeader::new();
+
+        req_hdr.provider = ProviderID::CoreProvider as u8;
+        req_hdr.opcode = Opcode::Ping as u16;
+        req_hdr.version_maj = 1;
+
+        req_hdr.accept_type = 0xff;
+
+        let resp = client
+            .send_raw_request(req_hdr, Vec::new())
+            .expect("Failed to read Response");
+        assert_eq!(resp.header.status, ResponseStatus::AcceptTypeNotSupported);
+        assert_eq!(resp.header.opcode, Opcode::Ping);
+    }
+
+    #[test]
+    fn invalid_body_len() {
+        let mut client = RequestTestClient::new();
+        let mut req_hdr = RawHeader::new();
+
+        req_hdr.provider = ProviderID::CoreProvider as u8;
+        req_hdr.opcode = Opcode::Ping as u16;
+        req_hdr.version_maj = 1;
+
+        req_hdr.body_len = 0xff_ff;
+
+        let resp = client
+            .send_raw_request(req_hdr, Vec::new())
+            .expect("Failed to read Response");
+        assert_eq!(resp.header.status, ResponseStatus::ConnectionError);
+    }
+
+    #[test]
+    fn invalid_auth_len() {
+        let mut client = RequestTestClient::new();
+        let mut req_hdr = RawHeader::new();
+
+        req_hdr.provider = ProviderID::CoreProvider as u8;
+        req_hdr.opcode = Opcode::Ping as u16;
+        req_hdr.version_maj = 1;
+
+        req_hdr.auth_len = 0xff_ff;
+
+        let resp = client
+            .send_raw_request(req_hdr, Vec::new())
+            .expect("Failed to read Response");
+        assert_eq!(resp.header.status, ResponseStatus::ConnectionError);
+    }
+
+    #[test]
+    fn invalid_opcode() {
+        let mut client = RequestTestClient::new();
+        let mut req_hdr = RawHeader::new();
+
+        req_hdr.provider = ProviderID::CoreProvider as u8;
+        req_hdr.opcode = 0xff_ff;
+        req_hdr.version_maj = 1;
+
+        let resp = client
+            .send_raw_request(req_hdr, Vec::new())
+            .expect("Failed to read Response");
+        assert_eq!(resp.header.status, ResponseStatus::OpcodeDoesNotExist);
+    }
+
+    #[test]
+    fn wrong_provider_core() {
+        let mut client = TestClient::new();
+        client.set_provider(Some(ProviderID::CoreProvider));
+
+        let response_status = client
+            .destroy_key(String::new())
+            .expect_err("Core Provider should not support DestroyKey operation!");
+        assert_eq!(response_status, ResponseStatus::UnsupportedOperation);
+    }
+}

--- a/tests/normal_tests/create_destroy_key.rs
+++ b/tests/normal_tests/create_destroy_key.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::TestClient;
+    use parsec_interface::requests::{ResponseStatus, Result};
+
+    #[test]
+    fn create_and_destroy() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("create_and_destroy");
+
+        client.create_rsa_sign_key(key_name.clone())?;
+
+        client.destroy_key(key_name)
+    }
+
+    #[test]
+    fn create_twice() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("create_twice");
+
+        client.create_rsa_sign_key(key_name.clone())?;
+        let status = client
+            .create_rsa_sign_key(key_name.clone())
+            .expect_err("A key with the same name can not be created twice.");
+        assert_eq!(status, ResponseStatus::KeyAlreadyExists);
+
+        Ok(())
+    }
+
+    #[test]
+    fn destroy_without_create() {
+        let mut client = TestClient::new();
+        let key_name = String::from("destroy_without_create");
+
+        let status = client
+            .destroy_key(key_name)
+            .expect_err("The key should not already exist.");
+        assert_eq!(status, ResponseStatus::KeyDoesNotExist);
+    }
+
+    #[test]
+    fn create_destroy_and_operation() -> Result<()> {
+        let mut client = TestClient::new();
+        let hash = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let key_name = String::from("create_destroy_and_operation");
+
+        client.create_rsa_sign_key(key_name.clone())?;
+
+        client.destroy_key(key_name.clone())?;
+
+        let status = client
+            .sign(key_name, hash)
+            .expect_err("The key used by this operation should have been deleted.");
+        assert_eq!(status, ResponseStatus::KeyDoesNotExist);
+
+        Ok(())
+    }
+
+    #[test]
+    fn create_destroy_twice() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("create_destroy_twice_1");
+        let key_name_2 = String::from("create_destroy_twice_2");
+
+        client.create_rsa_sign_key(key_name.clone())?;
+        client.create_rsa_sign_key(key_name_2.clone())?;
+
+        client.destroy_key(key_name)?;
+        client.destroy_key(key_name_2)
+    }
+}

--- a/tests/normal_tests/describe_assets.rs
+++ b/tests/normal_tests/describe_assets.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::TestClient;
+    use parsec_interface::requests::ProviderID;
+    use parsec_interface::requests::Result;
+    use std::collections::HashSet;
+
+    #[test]
+    fn list_providers() {
+        let mut client = TestClient::new();
+        let providers = client.list_providers().expect("list providers failed");
+        assert_eq!(providers.len(), 2);
+        let ids: HashSet<ProviderID> = providers.iter().map(|p| p.id).collect();
+        assert!(ids.contains(&ProviderID::CoreProvider));
+        assert!(ids.contains(&ProviderID::MbedProvider));
+    }
+
+    #[test]
+    fn list_opcodes() {
+        let mut client = TestClient::new();
+        client.set_provider(Some(ProviderID::MbedProvider));
+        let opcodes = client
+            .list_opcodes(ProviderID::MbedProvider)
+            .expect("list providers failed");
+        assert_eq!(opcodes.len(), 7);
+    }
+
+    #[cfg(feature = "testing")]
+    #[test]
+    fn mangled_list_providers() {
+        let mut client = RequestTestClient::new();
+        let mut req = Request::new();
+        req.header.version_maj = 1;
+        req.header.provider = ProviderID::CoreProvider;
+        req.header.opcode = Opcode::ListProviders;
+
+        req.body = RequestBody::_from_bytes(vec![0x11, 0x22, 0x33, 0x44, 0x55]);
+
+        let resp = client.send_request(req).expect("Failed to read response");
+        assert_eq!(resp.header.status, ResponseStatus::DeserializingBodyFailed);
+    }
+
+    #[test]
+    fn sign_verify_with_provider_discovery() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("sign_verify_with_provider_discovery");
+        client.create_rsa_sign_key(key_name.clone())
+    }
+}

--- a/tests/normal_tests/export_public_key.rs
+++ b/tests/normal_tests/export_public_key.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::TestClient;
+    use parsec_interface::operations::key_attributes::*;
+    use parsec_interface::requests::{ResponseStatus, Result};
+
+    #[test]
+    fn export_public_key() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("export_public_key");
+
+        client.create_rsa_sign_key(key_name.clone())?;
+
+        client.export_public_key(key_name.clone())?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn export_without_create() {
+        let mut client = TestClient::new();
+        let key_name = String::from("export_without_create");
+        let status = client
+            .export_public_key(key_name)
+            .expect_err("Key should not exist.");
+        assert_eq!(status, ResponseStatus::KeyDoesNotExist);
+    }
+
+    #[test]
+    fn import_and_export_public_key() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("import_and_export_public_key");
+        let key_data = vec![
+            48, 129, 137, 2, 129, 129, 0, 153, 165, 220, 135, 89, 101, 254, 229, 28, 33, 138, 247,
+            20, 102, 253, 217, 247, 246, 142, 107, 51, 40, 179, 149, 45, 117, 254, 236, 161, 109,
+            16, 81, 135, 72, 112, 132, 150, 175, 128, 173, 182, 122, 227, 214, 196, 130, 54, 239,
+            93, 5, 203, 185, 233, 61, 159, 156, 7, 161, 87, 48, 234, 105, 161, 108, 215, 211, 150,
+            168, 156, 212, 6, 63, 81, 24, 101, 72, 160, 97, 243, 142, 86, 10, 160, 122, 8, 228,
+            178, 252, 35, 209, 222, 228, 16, 143, 99, 143, 146, 241, 186, 187, 22, 209, 86, 141,
+            24, 159, 12, 146, 44, 111, 254, 183, 54, 229, 109, 28, 39, 22, 141, 173, 85, 26, 58, 9,
+            128, 27, 57, 131, 2, 3, 1, 0, 1,
+        ];
+        client.import_key(
+            key_name.clone(),
+            KeyType::RsaPublicKey,
+            Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None),
+            key_data.clone(),
+        )?;
+
+        assert_eq!(key_data, client.export_public_key(key_name.clone())?);
+
+        Ok(())
+    }
+}

--- a/tests/normal_tests/import_key.rs
+++ b/tests/normal_tests/import_key.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::TestClient;
+    use parsec_interface::operations::key_attributes::*;
+    use parsec_interface::requests::{ResponseStatus, Result};
+
+    const KEY_DATA: [u8; 140] = [
+        48, 129, 137, 2, 129, 129, 0, 153, 165, 220, 135, 89, 101, 254, 229, 28, 33, 138, 247, 20,
+        102, 253, 217, 247, 246, 142, 107, 51, 40, 179, 149, 45, 117, 254, 236, 161, 109, 16, 81,
+        135, 72, 112, 132, 150, 175, 128, 173, 182, 122, 227, 214, 196, 130, 54, 239, 93, 5, 203,
+        185, 233, 61, 159, 156, 7, 161, 87, 48, 234, 105, 161, 108, 215, 211, 150, 168, 156, 212,
+        6, 63, 81, 24, 101, 72, 160, 97, 243, 142, 86, 10, 160, 122, 8, 228, 178, 252, 35, 209,
+        222, 228, 16, 143, 99, 143, 146, 241, 186, 187, 22, 209, 86, 141, 24, 159, 12, 146, 44,
+        111, 254, 183, 54, 229, 109, 28, 39, 22, 141, 173, 85, 26, 58, 9, 128, 27, 57, 131, 2, 3,
+        1, 0, 1,
+    ];
+
+    #[test]
+    fn import_key() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("import_key");
+
+        client.import_key(
+            key_name.clone(),
+            KeyType::RsaPublicKey,
+            Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None),
+            KEY_DATA.to_vec(),
+        )
+    }
+
+    #[test]
+    fn create_and_import_key() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("create_and_import_key");
+
+        client.create_rsa_sign_key(key_name.clone())?;
+
+        let status = client
+            .import_key(
+                key_name.clone(),
+                KeyType::RsaPublicKey,
+                Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None),
+                KEY_DATA.to_vec(),
+            )
+            .expect_err("Key should have already existed");
+        assert_eq!(status, ResponseStatus::KeyAlreadyExists);
+
+        Ok(())
+    }
+
+    #[test]
+    fn import_key_twice() -> Result<()> {
+        let mut client = TestClient::new();
+        let key_name = String::from("import_key_twice");
+
+        client.import_key(
+            key_name.clone(),
+            KeyType::RsaPublicKey,
+            Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None),
+            KEY_DATA.to_vec(),
+        )?;
+        let status = client
+            .import_key(
+                key_name.clone(),
+                KeyType::RsaPublicKey,
+                Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None),
+                KEY_DATA.to_vec(),
+            )
+            .expect_err("The key with the same name has already been created.");
+        assert_eq!(status, ResponseStatus::KeyAlreadyExists);
+
+        Ok(())
+    }
+}

--- a/tests/normal_tests/mod.rs
+++ b/tests/normal_tests/mod.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+mod asym_sign_verify;
+mod auth;
+mod basic;
+mod create_destroy_key;
+mod describe_assets;
+mod export_public_key;
+mod import_key;
+mod ping;

--- a/tests/normal_tests/ping.rs
+++ b/tests/normal_tests/ping.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::RequestTestClient;
+    use parsec_client_test::TestClient;
+    use parsec_interface::requests::request::{Request, RequestBody};
+    use parsec_interface::requests::Opcode;
+    use parsec_interface::requests::ProviderID;
+    use parsec_interface::requests::{ResponseStatus, Result};
+
+    #[test]
+    fn test_ping() -> Result<()> {
+        let mut client = TestClient::new();
+        let version = client.ping(ProviderID::CoreProvider)?;
+        assert_eq!(version.0, 0);
+        assert_eq!(version.1, 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn mangled_ping() {
+        let mut client = RequestTestClient::new();
+        let mut req = Request::new();
+        req.header.version_maj = 1;
+        req.header.provider = ProviderID::CoreProvider;
+        req.header.opcode = Opcode::Ping;
+
+        req.body = RequestBody::_from_bytes(vec![0x11, 0x22, 0x33, 0x44, 0x55]);
+
+        let resp = client.send_request(req).expect("Failed to read Response");
+        assert_eq!(resp.header.status, ResponseStatus::DeserializingBodyFailed);
+    }
+}

--- a/tests/persistent-after.rs
+++ b/tests/persistent-after.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These functions test for the service persistency to shutdown. They will be executed after the
+// service is shutdown, after the persistent_before tests are executed.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::TestClient;
+    use parsec_interface::requests::{ResponseStatus, Result};
+
+    const HASH: [u8; 32] = [
+        0x69, 0x3E, 0xDB, 0x1B, 0x22, 0x79, 0x03, 0xF4, 0xC0, 0xBF, 0xD6, 0x91, 0x76, 0x37, 0x84,
+        0xA2, 0x94, 0x8E, 0x92, 0x50, 0x35, 0xC2, 0x8C, 0x5C, 0x3C, 0xCA, 0xFE, 0x18, 0xE8, 0x81,
+        0x37, 0x78,
+    ];
+
+    #[test]
+    fn reuse_to_sign() -> Result<()> {
+        let mut client = TestClient::new();
+
+        let key_name = String::from("🤡 Clown's Master Key 🤡");
+
+        let signature = client.sign(key_name.clone(), HASH.to_vec())?;
+
+        client.verify(key_name.clone(), HASH.to_vec(), signature)?;
+        client.destroy_key(key_name)
+    }
+
+    #[test]
+    fn should_have_been_deleted() {
+        let mut client = TestClient::new();
+
+        // A fake mapping file was created for this key, it should have been deleted by the Mbed
+        // Provider.
+        let key_name = String::from("Test Key");
+        assert_eq!(
+            client
+                .destroy_key(key_name)
+                .expect_err("This key should have been destroyed."),
+            ResponseStatus::KeyDoesNotExist
+        );
+    }
+}

--- a/tests/persistent-before.rs
+++ b/tests/persistent-before.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These functions test for the service persistency to shutdown. They will be executed before the
+// service is shutdown and before the persistent_after tests are executed.
+#[cfg(test)]
+mod tests {
+    use parsec_client_test::TestClient;
+    use parsec_interface::requests::Result;
+
+    const HASH: [u8; 32] = [
+        0x69, 0x3E, 0xDB, 0x1B, 0x22, 0x79, 0x03, 0xF4, 0xC0, 0xBF, 0xD6, 0x91, 0x76, 0x37, 0x84,
+        0xA2, 0x94, 0x8E, 0x92, 0x50, 0x35, 0xC2, 0x8C, 0x5C, 0x3C, 0xCA, 0xFE, 0x18, 0xE8, 0x81,
+        0x37, 0x78,
+    ];
+
+    #[test]
+    fn create_and_verify() -> Result<()> {
+        let mut client = TestClient::new();
+        client.do_not_destroy_keys();
+
+        let key_name = String::from("🤡 Clown's Master Key 🤡");
+        client.create_rsa_sign_key(key_name.clone())?;
+        let signature = client.sign(key_name.clone(), HASH.to_vec())?;
+
+        client.verify(key_name.clone(), HASH.to_vec(), signature)
+    }
+}


### PR DESCRIPTION
As the integration tests really test the PARSEC service functionalities
it makes more sense to put them here and use a dependency on
parsec-client-test.
It also makes the CI script easier as there is no need to clone the Test
Client somewhere now.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>