### PR TITLE
Use new version of test client to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - run: cargo build --verbose
     - run: |
         cargo run &
-        sleep 5
         cargo test --test normal
 
   integ-test-persistence:
@@ -46,11 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - run: cargo build --verbose
     - name: Tests executed before the shutdown
       run: |
         cargo run &
         SERVER_PID=$!
-        sleep 5
         cargo test --test persistent-before
         kill $SERVER_PID
     # Create a fake mapping file for the root application, the Mbed Provider and
@@ -63,6 +63,5 @@ jobs:
     - name: Tests executed after the shutdown
       run: |
         cargo run &
-        sleep 5
         cargo test --test persistent-after
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_toml 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parsec-client-test 0.1.0 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.0)",
+ "parsec-client-test 0.1.1 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.1)",
  "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -407,8 +407,8 @@ dependencies = [
 
 [[package]]
 name = "parsec-client-test"
-version = "0.1.0"
-source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.0#4190bd546ce24a8ddd762c7a199e51e970412660"
+version = "0.1.1"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.1#100f96a42359df4cfc285502db37b6049b6d5e09"
 dependencies = [
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)",
@@ -850,7 +850,7 @@ dependencies = [
 "checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-"checksum parsec-client-test 0.1.0 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.0)" = "<none>"
+"checksum parsec-client-test 0.1.1 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.1)" = "<none>"
 "checksum parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)" = "<none>"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ uuid = "0.7.4"
 threadpool = "1.7.1"
 
 [dev-dependencies]
-parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.0"  }
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.1"  }
 
 [build-dependencies]
 bindgen = "0.50.0"

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -44,7 +44,6 @@ cargo clippy || exit 1
 ############################
 cargo run &
 SERVER_PID=$!
-sleep 5
 
 cargo test --test normal || exit 1
 
@@ -55,7 +54,6 @@ kill $SERVER_PID
 #################################
 cargo run &
 SERVER_PID=$!
-sleep 5
 
 cargo test --test persistent-before || exit 1
 
@@ -69,7 +67,6 @@ printf '\xe0\x19\xb2\x5c' > mappings/cm9vdA==/1/VGVzdCBLZXk\=
 
 cargo run &
 SERVER_PID=$!
-sleep 5
 
 cargo test --test persistent-after || exit 1
 


### PR DESCRIPTION
The test client will now try again to connect if it first failed.
Added a `cargo build` command before running the service in background
so that this step happens faster.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>