### PR TITLE
Add SIGTERM handler for a graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +406,7 @@ dependencies = [
  "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -631,6 +637,24 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "signal-hook"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arc-swap 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "std-semaphore"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +838,7 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arc-swap 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
@@ -884,6 +909,8 @@ dependencies = [
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+"checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"
+"checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
 "checksum std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"
 
+[[bin]]
+name = "parsec"
+path = "src/bin/main.rs"
+
 [dependencies]
 parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.1.0"  }
 rand = "0.7.2"
@@ -12,6 +16,7 @@ base64 = "0.10.1"
 uuid = "0.7.4"
 threadpool = "1.7.1"
 std-semaphore = "0.1.0"
+signal-hook = "0.1.10"
 
 [dev-dependencies]
 parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.2"  }

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This project uses the following third party crates:
 * threadpool (Apache-2.0)
 * std-semaphore (MIT and Apache-2.0)
 * num_cpus (MIT and Apache-2.0)
+* signal-hook (MIT and Apache-2.0)
 
 This project uses the following third party libraries:
 * [Mbed Crypto](https://github.com/ARMmbed/mbed-crypto) (Apache-2.0)

--- a/src/front/listener.rs
+++ b/src/front/listener.rs
@@ -21,16 +21,14 @@ pub trait ReadWrite: std::io::Read + std::io::Write {}
 impl<T: std::io::Read + std::io::Write> ReadWrite for T {}
 
 pub trait Listen {
-    /// Initialise the internals of the listener.
-    fn init(&mut self);
-
     /// Set the timeout on read and write calls on any stream returned by this listener.
     fn set_timeout(&mut self, duration: Duration);
 
-    /// Blocking call that waits for incoming connections and returns a stream (a Read and Write
-    /// trait object). Requests are read from the stream and responses are written to it.
-    /// Streams returned by this method should have a timeout period as set by the `set_timeout`
-    /// method.
+    /// Non-blocking call that gets the next client connection and returns a stream
+    /// (a Read and Write trait object). Requests are read from the stream and responses are written
+    /// to it. Streams returned by this method should have a timeout period as set by the
+    /// `set_timeout` method.
+    /// If no connections are present, return `None`.
     /// If there are any errors in establishing the connection other than the missing
     /// initialization, the implementation should log them and return `None`.
     /// `Send` is needed because the stream is moved to a thread.
@@ -38,5 +36,5 @@ pub trait Listen {
     /// # Panics
     ///
     /// If the listener has not been initialised before, with the `init` method.
-    fn wait_on_connection(&self) -> Option<Box<dyn ReadWrite + Send>>;
+    fn accept(&self) -> Option<Box<dyn ReadWrite + Send>>;
 }


### PR DESCRIPTION
Changes the wait_for_connection function in the Listen trait to be
non-blocking. That allows checking in the main loop if the SIGTERM
signal has been raised.

Testing:
```shell
[hugdev@localhost parsec]$ ./target/debug/parsec &
[1] 11951
[hugdev@localhost parsec]$ kill 11951
[hugdev@localhost parsec]$ SIGTERM signal received.
Shutting down PARSEC, waiting for all threads to finish.

[1]+  Done                    ./target/debug/parsec

```