### PR TITLE
Add locking around key handle operations in mbed provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -625,6 +626,11 @@ dependencies = [
 [[package]]
 name = "shlex"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "std-semaphore"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -876,6 +882,7 @@ dependencies = [
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+"checksum std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "158521e6f544e7e3dcfc370ac180794aa38cb34a1b1e07609376d4adcf429b93"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rand = "0.7.0"
 base64 = "0.10.1"
 uuid = "0.7.4"
 threadpool = "1.7.1"
+std-semaphore = "0.1.0"
 
 [dev-dependencies]
 parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.1"  }

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This project uses the following third party crates:
 * base64 (MIT and Apache-2.0)
 * uuid (Apache-2.0)
 * threadpool (Apache-2.0)
+* std-semaphore (MIT and Apache-2.0)
 
 This project uses the following third party libraries:
 * [Mbed Crypto](https://github.com/ARMmbed/mbed-crypto) (Apache-2.0)

--- a/src/providers/mbed_provider/constants.rs
+++ b/src/providers/mbed_provider/constants.rs
@@ -38,6 +38,7 @@ pub const PSA_ERROR_INVALID_PADDING: psa_status_t = -150;
 pub const PSA_ERROR_INSUFFICIENT_DATA: psa_status_t = -143;
 pub const PSA_ERROR_INVALID_HANDLE: psa_status_t = -136;
 
+pub const PSA_KEY_SLOT_COUNT: isize = 32;
 pub const EMPTY_KEY_HANDLE: psa_key_handle_t = 0;
 pub const PSA_KEY_TYPE_NONE: psa_key_type_t = 0x0000_0000;
 pub const PSA_KEY_TYPE_VENDOR_FLAG: psa_key_type_t = 0x8000_0000;


### PR DESCRIPTION
Add a mutex around create, open and close key operations.
Add a semaphore to wrap all function call that use keys.

Fixes #40 