### PR TITLE
Keep key ID within bounds for Mbed provider

### DIFF
--- a/src/providers/mbed_provider/constants.rs
+++ b/src/providers/mbed_provider/constants.rs
@@ -38,6 +38,7 @@ pub const PSA_ERROR_INVALID_PADDING: psa_status_t = -150;
 pub const PSA_ERROR_INSUFFICIENT_DATA: psa_status_t = -143;
 pub const PSA_ERROR_INVALID_HANDLE: psa_status_t = -136;
 
+pub const PSA_MAX_PERSISTENT_KEY_IDENTIFIER: psa_key_id_t = 0xfffe_ffff;
 pub const PSA_KEY_SLOT_COUNT: isize = 32;
 pub const EMPTY_KEY_HANDLE: psa_key_handle_t = 0;
 pub const PSA_KEY_TYPE_NONE: psa_key_type_t = 0x0000_0000;

--- a/src/providers/mbed_provider/mod.rs
+++ b/src/providers/mbed_provider/mod.rs
@@ -107,7 +107,10 @@ fn create_key_id(
     local_ids_handle: &mut LocalIdStore,
 ) -> Result<psa_crypto_binding::psa_key_id_t> {
     let mut key_id = rand::random::<psa_crypto_binding::psa_key_id_t>();
-    while local_ids_handle.contains(&key_id) {
+    while local_ids_handle.contains(&key_id)
+        && key_id != 0
+        && key_id < constants::PSA_MAX_PERSISTENT_KEY_IDENTIFIER
+    {
         key_id = rand::random::<psa_crypto_binding::psa_key_id_t>();
     }
     match store_handle.insert(key_triple.clone(), key_id.to_ne_bytes().to_vec()) {


### PR DESCRIPTION
Adding bound checks for key IDs