### PR TITLE
Add a compile-time option for a daemon binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "parsec-client-test 0.1.1 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.2)",
  "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sd-notify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -611,6 +612,11 @@ dependencies = [
 [[package]]
 name = "rustc-demangle"
 version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sd-notify"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -906,6 +912,7 @@ dependencies = [
 "checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+"checksum sd-notify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "40b76d9fb089398d0b9c5a365008b3cb3104624fe8143f1a43c9827788a22252"
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ uuid = "0.7.4"
 threadpool = "1.7.1"
 std-semaphore = "0.1.0"
 signal-hook = "0.1.10"
+sd-notify = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.2"  }
@@ -34,3 +35,7 @@ mbed-crypto-version = "mbedcrypto-1.1.0"
 [features]
 default = ["mbed"]
 mbed = []
+
+# Feature to compile the PARSEC binary to be executed as a systemd daemon.
+# This feature is only available on Linux.
+systemd-daemon = ["sd-notify"]

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This project uses the following third party crates:
 * std-semaphore (MIT and Apache-2.0)
 * num_cpus (MIT and Apache-2.0)
 * signal-hook (MIT and Apache-2.0)
+* sd-notify (Apache-2.0)
 
 This project uses the following third party libraries:
 * [Mbed Crypto](https://github.com/ARMmbed/mbed-crypto) (Apache-2.0)
@@ -159,6 +160,39 @@ You can execute unit tests with `cargo test --lib`.
 
 The [test client](https://github.com/parallaxsecond/parsec-client-test) is used for integration
 testing. Check that repository for more details.
+
+# **Installing the PARSEC service (Linux only)**
+
+PARSEC can be built and installed as a Linux daemon using systemd. The PARSEC daemon uses socket
+activation which means that the daemon will be automatically started when a client request is
+made on the socket. The daemon is a systemd user daemon run by the `parsec` user.
+
+If your Linux system uses systemd to manage daemons, you can follow these steps.
+
+* Create and log in to a new user named `parsec`
+* In its home directory, pull and install PARSEC as a daemon
+```bash
+$ git pull https://github.com/parallaxsecond/parsec.git
+$ cargo install --features "systemd-daemon" --path parsec
+```
+* Install the systemd unit files and activate the PARSEC socket
+```bash
+$ mkdir -p ~/.config/systemd/user
+$ cp -r systemd-daemon/parsec.service systemd-daemon/parsec.socket ~/.config/systemd/user
+$ systemctl --user enable parsec.socket
+$ systemctl --user start parsec.socket
+```
+
+Every user on the system can now use PARSEC!
+
+You can test it going inside the `parsec` directory and:
+```bash
+$ cargo test --test normal
+```
+Check the logs with:
+```bash
+$ journalclt --user -u parsec
+```
 
 # **Contributing**
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -109,6 +109,10 @@ fn main() -> Result<(), Error> {
 
     let threadpool = Builder::new().build();
 
+    #[cfg(feature = "systemd-daemon")]
+    // Notify systemd that the daemon is ready, the start command will block until this point.
+    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
+
     loop {
         if kill_signal.load(Ordering::Relaxed) {
             println!("SIGTERM signal received.");

--- a/systemd-daemon/parsec.service
+++ b/systemd-daemon/parsec.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=PARSEC Service
+Documentation=https://github.com/parallaxsecond/parsec
+
+[Service]
+Type=notify
+NonBlocking=true
+ExecStart=/home/parsec/.cargo/bin/parsec

--- a/systemd-daemon/parsec.socket
+++ b/systemd-daemon/parsec.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=PARSEC Socket
+Documentation=https://github.com/parallaxsecond/parsec
+
+[Socket]
+ListenStream=/home/parsec/parsec.sock
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
The "systemd-daemon" feature will compile PARSEC to be used as a
systemd, socket activated daemon.
Add systemd unit files and instruction on how to install the service.

Closes #35 

A `Dockerfile` could be added later to install the daemon from a local checkout of `parsec` inside a container and only expose the socket to the host.

@ionut-arm FYI, the systemd unit files contain two hardcoded paths:
* `/home/parsec/.cargo/bin/parsec` for the binary
* `/home/parsec/parsec.sock` for the socket