### PR TITLE
Improve handling of systemd activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
  "parsec-client-test 0.1.3 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.3)",
  "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.1.0)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sd-notify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sd-notify 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -631,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sd-notify"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -928,7 +928,7 @@ dependencies = [
 "checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum sd-notify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "40b76d9fb089398d0b9c5a365008b3cb3104624fe8143f1a43c9827788a22252"
+"checksum sd-notify 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aef40838bbb143707f8309b1e92e6ba3225287592968ba6f6e3b6de4a9816486"
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ uuid = "0.7.4"
 threadpool = "1.7.1"
 std-semaphore = "0.1.0"
 signal-hook = "0.1.10"
-sd-notify = { version = "0.1.0", optional = true }
+sd-notify = { version = "0.1.1" }
 toml = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
 env_logger = "0.7.1"
@@ -42,4 +42,4 @@ mbed = []
 
 # Feature to compile the PARSEC binary to be executed as a systemd daemon.
 # This feature is only available on Linux.
-systemd-daemon = ["sd-notify"]
+systemd-daemon = []

--- a/README.md
+++ b/README.md
@@ -128,19 +128,19 @@ You will need to understand the [**wire protocol specification**](docs/wire_prot
 The software is provided under Apache-2.0. Contributions to this project are accepted under the same license.
 
 This project uses the following third party crates:
-* serde (Apache-2.0)
+* serde (MIT and Apache-2.0)
 * bindgen (BSD-3-Clause)
 * cargo\_toml (Apache-2.0)
 * toml (MIT and Apache-2.0)
 * rand (MIT and Apache-2.0)
 * base64 (MIT and Apache-2.0)
-* uuid (Apache-2.0)
-* threadpool (Apache-2.0)
+* uuid (MIT and Apache-2.0)
+* threadpool (MIT and Apache-2.0)
 * std-semaphore (MIT and Apache-2.0)
 * num\_cpus (MIT and Apache-2.0)
 * signal-hook (MIT and Apache-2.0)
-* sd-notify (Apache-2.0)
-* log (Apache-2.0)
+* sd-notify (MIT and Apache-2.0)
+* log (MIT and Apache-2.0)
 * env\_logger (MIT and Apache-2.0)
 
 This project uses the following third party libraries:

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -57,7 +57,6 @@ fn main() -> Result<(), Error> {
 
     info!("PARSEC is ready.");
 
-    #[cfg(feature = "systemd-daemon")]
     // Notify systemd that the daemon is ready, the start command will block until this point.
     let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
 


### PR DESCRIPTION
- the `sd-notify` dependency is now mandatory, but should be harmless on non-`systemd` distros
- bumped `sd-notify` dependency
- when socket activation is used:
  * the fd number is computed in a nicer way
  * if more than one fd is received, the initialization fails
  * ~~the socket is marked as non-blocking (it wasn't before)~~
- service activation should also work now (there's nothing special to do)
- a minor refactoring now avoids storing the listener in an `Option`
- changed the panic message when the timeout was not configured
- updated licenses for MIT / Apache-2.0 crates

The `systemd-daemon` feature is still available to configure whether timestamps are included in the logs. That could probably be handled better by checking whether `stderr` is a TTY.

Untested, the build script fails to link on my system even when disabling the `mbed` feature.