### PR TITLE
Upgrade dependency on Mbed Crypto to v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parsec-client-test 0.1.3 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.4)",
+ "parsec-client-test 0.1.5 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.5)",
  "parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.2.0)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sd-notify 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -431,8 +431,8 @@ dependencies = [
 
 [[package]]
 name = "parsec-client-test"
-version = "0.1.3"
-source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.4#5601b1fec07666febfcee54f953f95332d811008"
+version = "0.1.5"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.5#24964b0961c3a2d51fd567594f4c4c51a325739f"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -906,7 +906,7 @@ dependencies = [
 "checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-"checksum parsec-client-test 0.1.3 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.4)" = "<none>"
+"checksum parsec-client-test 0.1.5 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.5)" = "<none>"
 "checksum parsec-interface 0.1.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.2.0)" = "<none>"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ env_logger = "0.7.1"
 log = { version = "0.4.8", features = ["serde"] }
 
 [dev-dependencies]
-parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.4" }
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.5" }
 num_cpus = "1.10.1"
 
 [build-dependencies]
@@ -34,7 +34,7 @@ toml = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
 
 [package.metadata.config]
-mbed-crypto-version = "mbedcrypto-1.1.0"
+mbed-crypto-version = "mbedcrypto-2.0.0"
 
 [features]
 default = ["mbed"]

--- a/src/providers/mbed_provider/constants.rs
+++ b/src/providers/mbed_provider/constants.rs
@@ -38,7 +38,9 @@ pub const PSA_ERROR_INVALID_PADDING: psa_status_t = -150;
 pub const PSA_ERROR_INSUFFICIENT_DATA: psa_status_t = -143;
 pub const PSA_ERROR_INVALID_HANDLE: psa_status_t = -136;
 
-pub const PSA_MAX_PERSISTENT_KEY_IDENTIFIER: psa_key_id_t = 0xfffe_ffff;
+pub const PSA_MAX_KEY_BITS: usize = 0xfff8;
+pub const PSA_KEY_BITS_TOO_LARGE: psa_key_bits_t = 0xffff;
+pub const PSA_MAX_PERSISTENT_KEY_IDENTIFIER: psa_key_id_t = 0x3fff_ffff;
 pub const PSA_KEY_SLOT_COUNT: isize = 32;
 pub const EMPTY_KEY_HANDLE: psa_key_handle_t = 0;
 pub const PSA_KEY_TYPE_NONE: psa_key_type_t = 0x0000_0000;


### PR DESCRIPTION
Bumping dependency version of Mbed Crypto to [2.0.0](https://github.com/ARMmbed/mbed-crypto/releases/tag/mbedcrypto-2.0.0). Also making all changes required to keep the service functional. This included a change in the client library, bumping that to `0.1.5`.

This resolves #38 