### PR TITLE
Add a PKCS 11 provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,953 +4,1329 @@
 name = "aho-corasick"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "arc-swap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
 
 [[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "backtrace"
 version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 dependencies = [
- "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys",
+ "cfg-if",
+ "libc",
+ "rustc-demangle",
 ]
 
 [[package]]
 name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "libc",
 ]
 
 [[package]]
 name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
 ]
 
 [[package]]
 name = "bincode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "byteorder",
+ "serde",
 ]
 
 [[package]]
 name = "bindgen"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0e5a5f74b2bafe0b39379f616b5975e08bcaca4e779c078d5c31324147e9ba"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "cexpr",
+ "cfg-if",
+ "clang-sys",
+ "clap",
+ "env_logger 0.6.2",
+ "fxhash",
+ "lazy_static",
+ "log",
+ "peeking_take_while",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "regex",
+ "shlex",
+ "which",
 ]
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "bytes"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "iovec",
 ]
 
 [[package]]
 name = "c2-chacha"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 dependencies = [
- "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86",
 ]
 
 [[package]]
 name = "cargo_toml"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed092b004819e731a68f8a99afb6e07ddb9160810beafbe9d68b952ff09c73a"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_derive",
+ "toml 0.5.4",
 ]
 
 [[package]]
 name = "cc"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 
 [[package]]
 name = "cexpr"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 dependencies = [
- "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.2.3",
 ]
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clang-sys"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 dependencies = [
- "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob",
+ "libc",
+ "libloading 0.5.2",
 ]
 
 [[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "der-parser"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c1dadf64f59a8b2ee2ca254c64bca0f665015613c5b7234b8873138f519764"
+dependencies = [
+ "nom 5.0.1",
+ "rusticata-macros",
 ]
 
 [[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
 name = "failure"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 dependencies = [
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace",
 ]
 
 [[package]]
 name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
 ]
 
 [[package]]
 name = "getrandom"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 dependencies = [
- "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation",
 ]
 
 [[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error",
 ]
 
 [[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "itertools"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
 dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "rustc_version",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+
+[[package]]
+name = "libloading"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd38073de8f7965d0c17d30546d4bb6da311ab428d1c7a3fc71dff7f9d4979b9"
+dependencies = [
+ "kernel32-sys",
+ "lazy_static",
+ "winapi 0.2.8",
+]
 
 [[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc",
+ "winapi 0.3.8",
 ]
+
+[[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "serde",
 ]
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 
 [[package]]
 name = "multimap"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
 name = "num"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 dependencies = [
- "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.2.3",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.4.6",
+ "rustc-serialize",
 ]
 
 [[package]]
 name = "num-bigint"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c3f34cdd24f334cb265d9bf8bfa8a241920d026916785747a92f0e55541a1a"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8552a8edd6289764deab155204f86ccf3b0027e10f960a55d5a53deaf6688c"
+dependencies = [
+ "autocfg",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.6.5",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
 name = "num-complex"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-derive"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
 name = "num-integer"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-rational"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "num-bigint 0.2.3",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+]
+
+[[package]]
+name = "oid"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293d5f18898078ea69ba1c84f3688d1f2b6744df8211da36197153157cee7055"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "parsec"
 version = "0.1.0"
 dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bindgen 0.50.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_toml 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parsec-client-test 0.1.6 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.6)",
- "parsec-interface 0.2.1 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.2.1)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sd-notify 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64",
+ "bindgen",
+ "cargo_toml",
+ "der-parser",
+ "env_logger 0.7.1",
+ "log",
+ "nom 5.0.1",
+ "num-bigint-dig",
+ "num_cpus",
+ "parsec-client-test",
+ "parsec-interface",
+ "pkcs11",
+ "rand 0.7.2",
+ "sd-notify",
+ "serde",
+ "serde_asn1_der",
+ "signal-hook",
+ "std-semaphore",
+ "threadpool",
+ "toml 0.4.10",
+ "uuid",
 ]
 
 [[package]]
 name = "parsec-client-test"
-version = "0.1.6"
-source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.6#d0fe7faad9915b102b71320a797294d8a3920f33"
+version = "0.1.7"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.7#9136549b91b2d3a9377acb7229e2f68f4d090e66"
 dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parsec-interface 0.2.1 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.2.1)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "num",
+ "parsec-interface",
+ "rand 0.7.2",
 ]
 
 [[package]]
 name = "parsec-interface"
-version = "0.2.1"
-source = "git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.2.1#ac48ecd1950486413f82061718d09577f9deb106"
+version = "0.3.0"
+source = "git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.3.0#ac5bfe8c24d39c68155cda636b97d02b8bb6db28"
 dependencies = [
- "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode",
+ "bytes",
+ "num",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-build",
+ "serde",
+ "uuid",
 ]
 
 [[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "petgraph"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 dependencies = [
- "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset",
+]
+
+[[package]]
+name = "pkcs11"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff403ab0d15638fc795f4e2122e77e007fdcf17db7fee38f225f173c6e4cc1c3"
+dependencies = [
+ "libloading 0.4.3",
+ "num-bigint 0.1.44",
 ]
 
 [[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "prost"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "bytes",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
 name = "prost-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure",
+ "itertools",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
 name = "prost-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "prost",
 ]
 
 [[package]]
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 
 [[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
 ]
 
 [[package]]
 name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "rand"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+ "libc",
+ "rand_chacha 0.2.1",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "rand_chacha"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 dependencies = [
- "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 dependencies = [
- "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 
 [[package]]
 name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2fec406dbe9a6def54a66dadbfa387c7f60e903691b208160d5e9c4586dff9"
+dependencies = [
+ "nom 5.0.1",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
 name = "sd-notify"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef40838bbb143707f8309b1e92e6ba3225287592968ba6f6e3b6de4a9816486"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
 dependencies = [
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_asn1_der"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/serde_asn1_der?rev=ec1035879034ac9f09f1242fb49ed04c9aecdcae#ec1035879034ac9f09f1242fb49ed04c9aecdcae"
+dependencies = [
+ "num-bigint-dig",
+ "oid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defbb8a83d7f34cc8380751eeb892b825944222888aff18996ea7901f24aec88"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "syn 1.0.7",
 ]
 
 [[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb543aecec4ba8b867f41284729ddfdb7e8fcd70ec3d7d37fca3007a4b53675f"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]
 name = "signal-hook-registry"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
 dependencies = [
- "arc-swap 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arc-swap",
+ "libc",
 ]
+
+[[package]]
+name = "smallvec"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 
 [[package]]
 name = "std-semaphore"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
 
 [[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
 name = "syn"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "rand 0.7.2",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "termcolor"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 dependencies = [
- "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wincolor",
 ]
 
 [[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width",
 ]
 
 [[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
 ]
 
 [[package]]
 name = "threadpool"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 dependencies = [
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus",
 ]
 
 [[package]]
 name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "toml"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04dffffeac90885436d23c692517bb5b8b3f8863e4afc15023628d067d667b7"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
 ]
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 
 [[package]]
 name = "unicode-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 
 [[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "wasi"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "which"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 dependencies = [
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure",
+ "libc",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8",
 ]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincolor"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8",
+ "winapi-util",
 ]
-
-[metadata]
-"checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum arc-swap 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92"
-"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
-"checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
-"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
-"checksum bindgen 0.50.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cb0e5a5f74b2bafe0b39379f616b5975e08bcaca4e779c078d5c31324147e9ba"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cargo_toml 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bed092b004819e731a68f8a99afb6e07ddb9160810beafbe9d68b952ff09c73a"
-"checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
-"checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
-"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-"checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
-"checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
-"checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
-"checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
-"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
-"checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
-"checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-"checksum num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
-"checksum num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9c3f34cdd24f334cb265d9bf8bfa8a241920d026916785747a92f0e55541a1a"
-"checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
-"checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
-"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
-"checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
-"checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
-"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-"checksum parsec-client-test 0.1.6 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.6)" = "<none>"
-"checksum parsec-interface 0.2.1 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.2.1)" = "<none>"
-"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-"checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
-"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
-"checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
-"checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
-"checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
-"checksum prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
-"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
-"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
-"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-"checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
-"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
-"checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum sd-notify 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aef40838bbb143707f8309b1e92e6ba3225287592968ba6f6e3b6de4a9816486"
-"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
-"checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
-"checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-"checksum signal-hook 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cb543aecec4ba8b867f41284729ddfdb7e8fcd70ec3d7d37fca3007a4b53675f"
-"checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
-"checksum std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
-"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
-"checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
-"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
-"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
-"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
-"checksum toml 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c04dffffeac90885436d23c692517bb5b8b3f8863e4afc15023628d067d667b7"
-"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
-"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "parsec"
 version = "0.1.0"
-authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
+authors = ["Paul Howard <paul.howard@arm.com>",
+           "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"
 
@@ -10,7 +11,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.2.1" }
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.3.0" }
 rand = "0.7.2"
 base64 = "0.10.1"
 uuid = "0.7.4"
@@ -22,9 +23,15 @@ toml = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
 env_logger = "0.7.1"
 log = { version = "0.4.8", features = ["serde"] }
+pkcs11 = { version = "0.4.0", optional = true }
+# Using a fork of the serde_asn1_der crate to have big integer support. Check https://github.com/KizzyCode/serde_asn1_der/issues/1
+serde_asn1_der = { git = "https://github.com/Devolutions/serde_asn1_der", rev = "ec1035879034ac9f09f1242fb49ed04c9aecdcae", optional = true, features = ["extra_types"] }
+der-parser = "3.0.2"
+nom = "5.0.1"
+num-bigint-dig = "0.5"
 
 [dev-dependencies]
-parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.6" }
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.7" }
 num_cpus = "1.10.1"
 
 [build-dependencies]
@@ -37,6 +44,6 @@ serde = { version = "1.0", features = ["derive"] }
 mbed-crypto-version = "mbedcrypto-2.0.0"
 
 [features]
-default = ["mbed"]
+default = ["mbed", "pkcs11-provider"]
 mbed = []
-
+pkcs11-provider = ["pkcs11", "serde_asn1_der"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ This project uses the following third party crates:
 * sd-notify (MIT and Apache-2.0)
 * log (MIT and Apache-2.0)
 * env\_logger (MIT and Apache-2.0)
+* pkcs11 (Apache-2.0)
+* a fork of serde\_asn1\_der at `https://github.com/Devolutions/serde_asn1_der` (BSD-3-Clause and MIT)
+* num-bigint-dig (MIT and Apache-2.0)
 
 This project uses the following third party libraries:
 * [Mbed Crypto](https://github.com/ARMmbed/mbed-crypto) (Apache-2.0)

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-# PARSEC Service Configuration File
+# Parsec Configuration File
 
 # (Required) Core settings apply to the service as a whole rather than to individual components within it.
 [core_settings]
@@ -46,3 +46,16 @@ provider_type = "MbedProvider"
 
 # (Required) Name of key ID manager that will support this provider.
 key_id_manager = "on-disk-manager"
+
+# Example of a PKCS 11 provider configuration
+#[[provider]]
+#provider_type = "Pkcs11Provider"
+#key_id_manager = "on-disk-manager"
+# (Required for this provider) Path to the location of the dynamic library loaded by this provider.
+# For the PKCS 11 provider, this library implements the PKCS 11 API on the target platform.
+#library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
+# (Required) PKCS 11 slot that will be used by Parsec.
+#slot_number = 123456789
+# (Optional) User pin for authentication with the specific slot. If not set, no authentication will
+# be used.
+#user_pin = "123456"

--- a/src/front/listener.rs
+++ b/src/front/listener.rs
@@ -21,12 +21,12 @@ pub trait ReadWrite: std::io::Read + std::io::Write {}
 // Automatically implements ReadWrite for all types that implement Read and Write.
 impl<T: std::io::Read + std::io::Write> ReadWrite for T {}
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub enum ListenerType {
     DomainSocket,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct ListenerConfig {
     pub listener_type: ListenerType,
     pub timeout: u64,

--- a/src/key_id_managers/mod.rs
+++ b/src/key_id_managers/mod.rs
@@ -25,12 +25,12 @@ use std::fmt;
 
 pub mod on_disk_manager;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub enum KeyIdManagerType {
     OnDisk,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct KeyIdManagerConfig {
     pub name: String,
     pub manager_type: KeyIdManagerType,
@@ -50,7 +50,7 @@ impl fmt::Display for KeyTriple {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Application Name: \"{}\"\nProvider ID: {}\nKey Name: \"{}\"",
+            "Application Name: \"{}\", Provider ID: {}, Key Name: \"{}\"",
             self.app_name, self.provider_id, self.key_name
         )
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -17,26 +17,34 @@ use serde::Deserialize;
 
 pub mod core_provider;
 
+#[cfg(feature = "pkcs11-provider")]
+pub mod pkcs11_provider;
+
 #[cfg(feature = "mbed")]
 pub mod mbed_provider;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub enum ProviderType {
     MbedProvider,
+    Pkcs11Provider,
 }
 
 impl ProviderType {
     pub fn to_provider_id(&self) -> ProviderID {
         match self {
             ProviderType::MbedProvider => ProviderID::MbedProvider,
+            ProviderType::Pkcs11Provider => ProviderID::Pkcs11Provider,
         }
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct ProviderConfig {
     pub provider_type: ProviderType,
     pub key_id_manager: String,
+    pub library_path: Option<String>,
+    pub slot_number: Option<usize>,
+    pub user_pin: Option<String>,
 }
 
 use crate::authenticators::ApplicationName;

--- a/src/providers/pkcs11_provider/mod.rs
+++ b/src/providers/pkcs11_provider/mod.rs
@@ -1,0 +1,979 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use super::Provide;
+use crate::authenticators::ApplicationName;
+use crate::key_id_managers::{KeyTriple, ManageKeyIDs};
+use log::{error, info, warn};
+use parsec_interface::operations::key_attributes::*;
+use parsec_interface::operations::ProviderInfo;
+use parsec_interface::operations::{OpAsymSign, ResultAsymSign};
+use parsec_interface::operations::{OpAsymVerify, ResultAsymVerify};
+use parsec_interface::operations::{OpCreateKey, ResultCreateKey};
+use parsec_interface::operations::{OpDestroyKey, ResultDestroyKey};
+use parsec_interface::operations::{OpExportPublicKey, ResultExportPublicKey};
+use parsec_interface::operations::{OpImportKey, ResultImportKey};
+use parsec_interface::operations::{OpListOpcodes, ResultListOpcodes};
+use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
+use pkcs11::types::{
+    CKF_OS_LOCKING_OK, CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK, CKR_SIGNATURE_INVALID, CKU_USER,
+    CK_ATTRIBUTE, CK_C_INITIALIZE_ARGS, CK_MECHANISM, CK_OBJECT_HANDLE, CK_SESSION_HANDLE,
+    CK_SLOT_ID,
+};
+use pkcs11::Ctx;
+use serde::{Deserialize, Serialize};
+use serde_asn1_der::asn1_wrapper::*;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, RwLock};
+use uuid::Uuid;
+extern crate num_bigint_dig as num_bigint;
+use num_bigint::{BigInt, Sign};
+
+type LocalIdStore = HashSet<[u8; 4]>;
+
+const SUPPORTED_OPCODES: [Opcode; 7] = [
+    Opcode::CreateKey,
+    Opcode::DestroyKey,
+    Opcode::AsymSign,
+    Opcode::AsymVerify,
+    Opcode::ImportKey,
+    Opcode::ExportPublicKey,
+    Opcode::ListOpcodes,
+];
+
+// Public exponent value for all RSA keys.
+const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
+
+pub struct Pkcs11Provider {
+    key_id_store: Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>,
+    // TODO: the local ID store is currently only used to prevent creating a key that does not
+    // exist, it should also act as a cache for non-desctrucitve operations. Same for Mbed Crypto.
+    local_ids: RwLock<LocalIdStore>,
+    // The authentication state is common to all sessions. A counter of logged in sessions is used
+    // to keep track of current logged in sessions, ignore logging in if the user is already
+    // logged in and only log out when no other session is.
+    // The mutex is both used to have interior mutability on the counter and to create a critical
+    // section inside login/logout functions. The clippy warning is ignored here to not have one
+    // Mutex<()> and an AtomicUsize which would make the code more complicated. Maybe a better
+    // way exists.
+    #[allow(clippy::mutex_atomic)]
+    logged_sessions_counter: Mutex<usize>,
+    backend: Ctx,
+    slot_number: CK_SLOT_ID,
+    // Some PKCS 11 devices do not need a pin, the None variant means that.
+    user_pin: Option<String>,
+}
+
+// The RSA Public Key data are DER encoded with the following representation:
+// RSAPublicKey ::= SEQUENCE {
+//     modulus            INTEGER,  -- n
+//     publicExponent     INTEGER   -- e
+// }
+#[derive(Serialize, Deserialize, Debug)]
+struct RsaPublicKey {
+    modulus: IntegerAsn1,
+    public_exponent: IntegerAsn1,
+}
+
+// For PKCS 11, a key pair consists of two independant public and private keys. Both will share the
+// same key ID.
+enum KeyPairType {
+    PublicKey,
+    PrivateKey,
+    Any,
+}
+
+// Representation of a PKCS 11 session.
+struct Session<'a> {
+    provider: &'a Pkcs11Provider,
+    session_handle: CK_SESSION_HANDLE,
+    // This information is necessary to log out when dropped.
+    is_logged_in: bool,
+}
+
+#[derive(PartialEq)]
+enum ReadWriteSession {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl Session<'_> {
+    fn new(provider: &Pkcs11Provider, read_write: ReadWriteSession) -> Result<Session> {
+        info!("Opening session on slot {}", provider.slot_number);
+
+        let mut session_flags = CKF_SERIAL_SESSION;
+        if read_write == ReadWriteSession::ReadWrite {
+            session_flags |= CKF_RW_SESSION;
+        }
+
+        match provider
+            .backend
+            .open_session(provider.slot_number, session_flags, None, None)
+        {
+            Ok(session_handle) => {
+                let mut session = Session {
+                    provider,
+                    session_handle,
+                    is_logged_in: false,
+                };
+
+                // The stress tests revealed bugs when sessions were concurrently running and some
+                // of them where logging in and out during their execution. These bugs seemed to
+                // disappear when *all* sessions are logged in by default.
+                // See https://github.com/opendnssec/SoftHSMv2/issues/509 for reference.
+                // This has security implications and should be disclosed.
+                session.login()?;
+
+                Ok(session)
+            }
+            Err(e) => {
+                error!(
+                    "Error opening session for slot {}: {}.",
+                    provider.slot_number, e
+                );
+                Err(ResponseStatus::PsaErrorCommunicationFailure)
+            }
+        }
+    }
+
+    fn session_handle(&self) -> CK_SESSION_HANDLE {
+        self.session_handle
+    }
+
+    fn login(&mut self) -> Result<()> {
+        #[allow(clippy::mutex_atomic)]
+        let mut logged_sessions_counter = self
+            .provider
+            .logged_sessions_counter
+            .lock()
+            .expect("Error while locking mutex.");
+
+        if self.is_logged_in {
+            info!(
+                "This session ({}) has already requested authentication.",
+                self.session_handle
+            );
+            Ok(())
+        } else if *logged_sessions_counter > 0 {
+            info!(
+                "Logging in ignored as {} sessions are already requiring authentication.",
+                *logged_sessions_counter
+            );
+            *logged_sessions_counter += 1;
+            self.is_logged_in = true;
+            Ok(())
+        } else if let Some(user_pin) = self.provider.user_pin.as_ref() {
+            match self
+                .provider
+                .backend
+                .login(self.session_handle, CKU_USER, Some(user_pin))
+            {
+                Ok(_) => {
+                    info!("Logging in session {}.", self.session_handle);
+                    *logged_sessions_counter += 1;
+                    self.is_logged_in = true;
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("Login operation failed with {}", e);
+                    Err(ResponseStatus::PsaErrorHardwareFailure)
+                }
+            }
+        } else {
+            warn!("Authentication requested but the provider has no user pin set!");
+            Ok(())
+        }
+    }
+
+    fn logout(&mut self) -> Result<()> {
+        #[allow(clippy::mutex_atomic)]
+        let mut logged_sessions_counter = self
+            .provider
+            .logged_sessions_counter
+            .lock()
+            .expect("Error while locking mutex.");
+
+        if !self.is_logged_in {
+            info!("Session {} has already logged out.", self.session_handle);
+            Ok(())
+        } else if *logged_sessions_counter == 0 {
+            info!("The user is already logged out, ignoring.");
+            Ok(())
+        } else if *logged_sessions_counter == 1 {
+            // Only this session requires authentication.
+            match self.provider.backend.logout(self.session_handle) {
+                Ok(_) => {
+                    info!("Logged out in session {}.", self.session_handle);
+                    *logged_sessions_counter -= 1;
+                    self.is_logged_in = false;
+                    Ok(())
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to log out from session {} due to error {}. Continuing...",
+                        self.session_handle, e
+                    );
+                    Err(ResponseStatus::PsaErrorHardwareFailure)
+                }
+            }
+        } else {
+            info!(
+                "{} sessions are still requiring authentication, not logging out.",
+                *logged_sessions_counter
+            );
+            *logged_sessions_counter -= 1;
+            self.is_logged_in = false;
+            Ok(())
+        }
+    }
+}
+
+impl Drop for Session<'_> {
+    fn drop(&mut self) {
+        if self.logout().is_err() {
+            error!("Error while logging out. Continuing...");
+        }
+        match self.provider.backend.close_session(self.session_handle) {
+            Ok(_) => info!("Session {} closed.", self.session_handle),
+            // Treat this as best effort.
+            Err(e) => error!(
+                "Failed to close session {} due to error {}. Continuing...",
+                self.session_handle, e
+            ),
+        }
+    }
+}
+
+/// Gets a key identifier from the Key ID Manager.
+fn get_key_id(key_triple: &KeyTriple, store_handle: &dyn ManageKeyIDs) -> Result<[u8; 4]> {
+    match store_handle.get(key_triple) {
+        Ok(Some(key_id)) => {
+            if key_id.len() == 4 {
+                let mut dst = [0; 4];
+                dst.copy_from_slice(key_id);
+                Ok(dst)
+            } else {
+                error!("Stored Key ID is not valid.");
+                Err(ResponseStatus::KeyIDManagerError)
+            }
+        }
+        Ok(None) => Err(ResponseStatus::KeyDoesNotExist),
+        Err(string) => {
+            error!("Key ID Manager error: {}", string);
+            Err(ResponseStatus::KeyIDManagerError)
+        }
+    }
+}
+
+fn create_key_id(
+    key_triple: KeyTriple,
+    store_handle: &mut dyn ManageKeyIDs,
+    local_ids_handle: &mut LocalIdStore,
+) -> Result<[u8; 4]> {
+    let mut key_id = rand::random::<[u8; 4]>();
+    while local_ids_handle.contains(&key_id) {
+        key_id = rand::random::<[u8; 4]>();
+    }
+    match store_handle.insert(key_triple.clone(), key_id.to_vec()) {
+        Ok(insert_option) => {
+            if insert_option.is_some() {
+                warn!("Overwriting Key triple mapping ({})", key_triple);
+            }
+            local_ids_handle.insert(key_id);
+
+            Ok(key_id)
+        }
+        Err(string) => {
+            error!("Key ID Manager error: {}", string);
+            Err(ResponseStatus::KeyIDManagerError)
+        }
+    }
+}
+
+fn remove_key_id(
+    key_triple: &KeyTriple,
+    key_id: [u8; 4],
+    store_handle: &mut dyn ManageKeyIDs,
+    local_ids_handle: &mut LocalIdStore,
+) -> Result<()> {
+    match store_handle.remove(key_triple) {
+        Ok(_) => {
+            local_ids_handle.remove(&key_id);
+            Ok(())
+        }
+        Err(string) => {
+            error!("Key ID Manager error: {}", string);
+            Err(ResponseStatus::KeyIDManagerError)
+        }
+    }
+}
+
+fn key_id_exists(key_triple: &KeyTriple, store_handle: &dyn ManageKeyIDs) -> Result<bool> {
+    match store_handle.exists(key_triple) {
+        Ok(val) => Ok(val),
+        Err(string) => {
+            error!("Key ID Manager error: {}", string);
+            Err(ResponseStatus::KeyIDManagerError)
+        }
+    }
+}
+
+impl Pkcs11Provider {
+    /// Creates and initialise a new instance of Pkcs11Provider.
+    /// Checks if there are not more keys stored in the Key ID Manager than in the PKCS 11 library
+    /// and if there are, delete them. Adds Key IDs currently in use in the local IDs store.
+    /// Returns `None` if the initialisation failed.
+    fn new(
+        key_id_store: Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>,
+        backend: Ctx,
+        slot_number: usize,
+        user_pin: Option<String>,
+    ) -> Option<Pkcs11Provider> {
+        #[allow(clippy::mutex_atomic)]
+        let pkcs11_provider = Pkcs11Provider {
+            key_id_store,
+            local_ids: RwLock::new(HashSet::new()),
+            logged_sessions_counter: Mutex::new(0),
+            backend,
+            slot_number,
+            user_pin,
+        };
+        {
+            // The local scope allows to drop store_handle and local_ids_handle in order to return
+            // the pkcs11_provider.
+            let mut store_handle = pkcs11_provider
+                .key_id_store
+                .write()
+                .expect("Key store lock poisoned");
+            let mut local_ids_handle = pkcs11_provider
+                .local_ids
+                .write()
+                .expect("Local ID lock poisoned");
+            let mut to_remove: Vec<KeyTriple> = Vec::new();
+            // Go through all PKCS 11 key triple to key ID mappings and check if they are still
+            // present.
+            // Delete those who are not present and add to the local_store the ones present.
+            match store_handle.get_all(ProviderID::Pkcs11Provider) {
+                Ok(key_triples) => {
+                    let session =
+                        Session::new(&pkcs11_provider, ReadWriteSession::ReadOnly).ok()?;
+
+                    for key_triple in key_triples.iter().cloned() {
+                        let key_id = match get_key_id(key_triple, &*store_handle) {
+                            Ok(key_id) => key_id,
+                            Err(response_status) => {
+                                error!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...", key_triple, response_status);
+                                continue;
+                            }
+                        };
+                        match pkcs11_provider.find_key(
+                            session.session_handle(),
+                            key_id,
+                            KeyPairType::Any,
+                        ) {
+                            Ok(_) => {
+                                warn!(
+                                    "Key {} found in the PKCS 11 library, adding it.",
+                                    key_triple
+                                );
+                                local_ids_handle.insert(key_id);
+                            }
+                            Err(ResponseStatus::PsaErrorDoesNotExist) => {
+                                warn!(
+                                    "Key {} not found in the PKCS 11 library, deleting it.",
+                                    key_triple
+                                );
+                                to_remove.push(key_triple.clone());
+                            }
+                            Err(e) => {
+                                error!("Error finding key objects: {}.", e);
+                                return None;
+                            }
+                        }
+                    }
+                }
+                Err(string) => {
+                    error!("Key ID Manager error: {}", string);
+                    return None;
+                }
+            };
+            for key_triple in to_remove.iter() {
+                if let Err(string) = store_handle.remove(key_triple) {
+                    error!("Key ID Manager error: {}", string);
+                    return None;
+                }
+            }
+        }
+
+        Some(pkcs11_provider)
+    }
+
+    /// Find the PKCS 11 object handle corresponding to the key ID and the key type (public or
+    /// private key) given as parameters for the current session.
+    fn find_key(
+        &self,
+        session: CK_SESSION_HANDLE,
+        key_id: [u8; 4],
+        key_type: KeyPairType,
+    ) -> Result<CK_OBJECT_HANDLE> {
+        let mut template = vec![CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id)];
+        match key_type {
+            KeyPairType::PublicKey => template.push(
+                CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
+                    .with_ck_ulong(&pkcs11::types::CKO_PUBLIC_KEY),
+            ),
+            KeyPairType::PrivateKey => template.push(
+                CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
+                    .with_ck_ulong(&pkcs11::types::CKO_PRIVATE_KEY),
+            ),
+            KeyPairType::Any => (),
+        }
+
+        if let Err(e) = self.backend.find_objects_init(session, &template) {
+            error!("Object enumeration init failed with {}", e);
+            Err(ResponseStatus::PsaErrorHardwareFailure)
+        } else {
+            match self.backend.find_objects(session, 1) {
+                Ok(objects) => {
+                    if let Err(e) = self.backend.find_objects_final(session) {
+                        error!("Object enumeration final failed with {}", e);
+                        Err(ResponseStatus::PsaErrorHardwareFailure)
+                    } else if objects.is_empty() {
+                        Err(ResponseStatus::PsaErrorDoesNotExist)
+                    } else {
+                        Ok(objects[0])
+                    }
+                }
+                Err(e) => {
+                    error!("Finding objects failed with {}", e);
+                    Err(ResponseStatus::PsaErrorHardwareFailure)
+                }
+            }
+        }
+    }
+}
+
+impl Provide for Pkcs11Provider {
+    fn list_opcodes(&self, _op: OpListOpcodes) -> Result<ResultListOpcodes> {
+        Ok(ResultListOpcodes {
+            opcodes: SUPPORTED_OPCODES.iter().copied().collect(),
+        })
+    }
+
+    fn describe(&self) -> ProviderInfo {
+        ProviderInfo {
+            // Assigned UUID for this provider: 30e39502-eba6-4d60-a4af-c518b7f5e38f
+            uuid: Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap(),
+            description: String::from("PKCS #11 provider, interfacing with a PKCS #11 library."),
+            vendor: String::from("OASIS Standard."),
+            version_maj: 0,
+            version_min: 1,
+            version_rev: 0,
+            id: ProviderID::Pkcs11Provider,
+        }
+    }
+
+    fn create_key(&self, app_name: ApplicationName, op: OpCreateKey) -> Result<ResultCreateKey> {
+        info!("Pkcs11 Provider - Create Key");
+
+        if op.key_attributes.key_type != KeyType::RsaKeypair
+            || op.key_attributes.algorithm != Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None)
+        {
+            error!("The PKCS 11 provider currently only supports creating RSA key pairs for signing and verifying.");
+            return Err(ResponseStatus::UnsupportedOperation);
+        }
+
+        let key_name = op.key_name;
+        // This should never panic on 32 bits or more machines.
+        let key_size = std::convert::TryFrom::try_from(op.key_attributes.key_size).unwrap();
+
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11Provider, key_name);
+        let mut store_handle = self.key_id_store.write().expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        if key_id_exists(&key_triple, &*store_handle)? {
+            return Err(ResponseStatus::KeyAlreadyExists);
+        }
+        let key_id = create_key_id(
+            key_triple.clone(),
+            &mut *store_handle,
+            &mut local_ids_handle,
+        )?;
+
+        let mech = CK_MECHANISM {
+            mechanism: pkcs11::types::CKM_RSA_PKCS_KEY_PAIR_GEN,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+
+        let mut priv_template: Vec<CK_ATTRIBUTE> = Vec::new();
+        let mut pub_template: Vec<CK_ATTRIBUTE> = Vec::new();
+
+        priv_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_SIGN).with_bool(&pkcs11::types::CK_TRUE));
+        priv_template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
+        priv_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
+
+        pub_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_VERIFY).with_bool(&pkcs11::types::CK_TRUE));
+        pub_template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
+        pub_template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT).with_bytes(&PUBLIC_EXPONENT),
+        );
+        pub_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS_BITS).with_ck_ulong(&key_size));
+        pub_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
+        pub_template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PRIVATE).with_bool(&pkcs11::types::CK_FALSE),
+        );
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite).or_else(|err| {
+            error!("Error creating a new session: {}.", err);
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            Err(err)
+        })?;
+
+        info!(
+            "Generating RSA key pair in session {}",
+            session.session_handle()
+        );
+
+        match self.backend.generate_key_pair(
+            session.session_handle(),
+            &mech,
+            &pub_template,
+            &priv_template,
+        ) {
+            Ok(_key) => Ok(ResultCreateKey {}),
+            Err(e) => {
+                error!("Generate Key Pair operation failed with {}", e);
+                remove_key_id(
+                    &key_triple,
+                    key_id,
+                    &mut *store_handle,
+                    &mut local_ids_handle,
+                )?;
+                Err(ResponseStatus::PsaErrorHardwareFailure)
+            }
+        }
+    }
+
+    fn import_key(&self, app_name: ApplicationName, op: OpImportKey) -> Result<ResultImportKey> {
+        info!("Pkcs11 Provider - Import Key");
+
+        if op.key_attributes.key_type != KeyType::RsaPublicKey
+            || op.key_attributes.algorithm != Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None)
+        {
+            error!("The PKCS 11 provider currently only supports importing RSA public key for verifying.");
+            return Err(ResponseStatus::UnsupportedOperation);
+        }
+
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11Provider, key_name);
+        let mut store_handle = self.key_id_store.write().expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        if key_id_exists(&key_triple, &*store_handle)? {
+            return Err(ResponseStatus::KeyAlreadyExists);
+        }
+        let key_id = create_key_id(
+            key_triple.clone(),
+            &mut *store_handle,
+            &mut local_ids_handle,
+        )?;
+
+        let mut template: Vec<CK_ATTRIBUTE> = Vec::new();
+
+        let public_key: RsaPublicKey = serde_asn1_der::from_bytes(&op.key_data).unwrap();
+
+        let (_, modulus_object) = &public_key.modulus.to_bytes_be();
+        let (_, exponent_object) = &public_key.public_exponent.to_bytes_be();
+
+        template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
+                .with_ck_ulong(&pkcs11::types::CKO_PUBLIC_KEY),
+        );
+        template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_KEY_TYPE).with_ck_ulong(&pkcs11::types::CKK_RSA),
+        );
+        template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
+        template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS).with_bytes(modulus_object));
+        template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT).with_bytes(exponent_object),
+        );
+        template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_VERIFY).with_bool(&pkcs11::types::CK_TRUE));
+        template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite).or_else(|err| {
+            error!("Error creating a new session: {}.", err);
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            Err(err)
+        })?;
+
+        info!(
+            "Importing RSA public key in session {}",
+            session.session_handle()
+        );
+
+        match self
+            .backend
+            .create_object(session.session_handle(), &template)
+        {
+            Ok(_key) => Ok(ResultImportKey {}),
+            Err(e) => {
+                error!("Import operation failed with {}", e);
+                remove_key_id(
+                    &key_triple,
+                    key_id,
+                    &mut *store_handle,
+                    &mut local_ids_handle,
+                )?;
+                Err(ResponseStatus::PsaErrorHardwareFailure)
+            }
+        }
+    }
+
+    fn export_public_key(
+        &self,
+        app_name: ApplicationName,
+        op: OpExportPublicKey,
+    ) -> Result<ResultExportPublicKey> {
+        info!("Pkcs11 Provider - Export Public Key");
+
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11Provider, key_name);
+        let store_handle = self.key_id_store.read().expect("Key store lock poisoned");
+        let key_id = get_key_id(&key_triple, &*store_handle)?;
+
+        let session = Session::new(self, ReadWriteSession::ReadOnly)?;
+        info!(
+            "Export RSA public key in session {}",
+            session.session_handle()
+        );
+
+        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PublicKey)?;
+        info!("Located key for export.");
+
+        let mut size_attrs: Vec<CK_ATTRIBUTE> = Vec::new();
+        size_attrs.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS));
+        size_attrs.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT));
+
+        // Get the length of the attributes to retrieve.
+        let (modulus_len, public_exponent_len) =
+            match self
+                .backend
+                .get_attribute_value(session.session_handle(), key, &mut size_attrs)
+            {
+                Ok((rv, attrs)) => {
+                    if rv != CKR_OK {
+                        error!("Error when extracting attribute: {}.", rv);
+                        Err(ResponseStatus::PsaErrorCommunicationFailure)
+                    } else {
+                        Ok((attrs[0].ulValueLen, attrs[1].ulValueLen))
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to read attributes from public key. Error: {}", e);
+                    Err(ResponseStatus::PsaErrorCommunicationFailure)
+                }
+            }?;
+
+        let mut modulus: Vec<pkcs11::types::CK_BYTE> = Vec::new();
+        let mut public_exponent: Vec<pkcs11::types::CK_BYTE> = Vec::new();
+        modulus.resize(modulus_len, 0);
+        public_exponent.resize(public_exponent_len, 0);
+
+        let mut extract_attrs: Vec<CK_ATTRIBUTE> = Vec::new();
+        extract_attrs
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS).with_bytes(modulus.as_mut_slice()));
+        extract_attrs.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT)
+                .with_bytes(public_exponent.as_mut_slice()),
+        );
+
+        match self
+            .backend
+            .get_attribute_value(session.session_handle(), key, &mut extract_attrs)
+        {
+            Ok(res) => {
+                let (rv, attrs) = res;
+                if rv != CKR_OK {
+                    error!("Error when extracting attribute: {}.", rv);
+                    Err(ResponseStatus::PsaErrorCommunicationFailure)
+                } else {
+                    let key = RsaPublicKey {
+                        modulus: IntegerAsn1(BigInt::from_bytes_be(
+                            Sign::Plus,
+                            &attrs[0].get_bytes(),
+                        )),
+                        public_exponent: IntegerAsn1(BigInt::from_bytes_be(
+                            Sign::Plus,
+                            &attrs[1].get_bytes(),
+                        )),
+                    };
+                    let key_data = serde_asn1_der::to_vec(&key).or_else(|err| {
+                        error!("Could not serialise key elements: {}.", err);
+                        Err(ResponseStatus::PsaErrorCommunicationFailure)
+                    })?;
+                    Ok(ResultExportPublicKey { key_data })
+                }
+            }
+            Err(e) => {
+                error!("Failed to read attributes from public key. Error: {}", e);
+                Err(ResponseStatus::PsaErrorCommunicationFailure)
+            }
+        }
+    }
+
+    fn destroy_key(&self, app_name: ApplicationName, op: OpDestroyKey) -> Result<ResultDestroyKey> {
+        info!("Pkcs11 Provider - Destroy Key");
+
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11Provider, key_name);
+        let mut store_handle = self.key_id_store.write().expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        let key_id = get_key_id(&key_triple, &*store_handle)?;
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
+        info!(
+            "Deleting RSA keypair in session {}",
+            session.session_handle()
+        );
+
+        match self.find_key(session.session_handle(), key_id, KeyPairType::Any) {
+            Ok(key) => {
+                match self.backend.destroy_object(session.session_handle(), key) {
+                    Ok(_) => info!("Private part of the key destroyed successfully."),
+                    Err(e) => {
+                        error!("Failed to destroy private part of the key. Error: {}", e);
+                        return Err(ResponseStatus::PsaErrorGenericError);
+                    }
+                };
+            }
+            Err(e) => {
+                error!("Error destroying key: {}", e);
+                return Err(e);
+            }
+        };
+
+        // Second key is optional.
+        match self.find_key(session.session_handle(), key_id, KeyPairType::Any) {
+            Ok(key) => {
+                match self.backend.destroy_object(session.session_handle(), key) {
+                    Ok(_) => info!("Private part of the key destroyed successfully."),
+                    Err(e) => {
+                        error!("Failed to destroy private part of the key. Error: {}", e);
+                        return Err(ResponseStatus::PsaErrorGenericError);
+                    }
+                };
+            }
+            // A second key is optional.
+            Err(ResponseStatus::PsaErrorDoesNotExist) => (),
+            Err(e) => {
+                error!("Error destroying key: {}", e);
+                return Err(e);
+            }
+        };
+
+        remove_key_id(
+            &key_triple,
+            key_id,
+            &mut *store_handle,
+            &mut local_ids_handle,
+        )?;
+
+        Ok(ResultDestroyKey {})
+    }
+
+    fn asym_sign(&self, app_name: ApplicationName, op: OpAsymSign) -> Result<ResultAsymSign> {
+        info!("Pkcs11 Provider - Asym Sign");
+
+        let key_name = op.key_name;
+        let hash = op.hash;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11Provider, key_name);
+        let store_handle = self.key_id_store.read().expect("Key store lock poisoned");
+        let key_id = get_key_id(&key_triple, &*store_handle)?;
+
+        let mech = pkcs11::types::CK_MECHANISM {
+            mechanism: pkcs11::types::CKM_RSA_PKCS,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
+        info!("Asymmetric sign in session {}", session.session_handle());
+
+        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PrivateKey)?;
+        info!("Located signing key.");
+
+        match self.backend.sign_init(session.session_handle(), &mech, key) {
+            Ok(_) => {
+                info!("Signing operation initialized.");
+                match self.backend.sign(session.session_handle(), &hash) {
+                    Ok(signature) => Ok(ResultAsymSign { signature }),
+                    Err(e) => {
+                        error!("Failed to execute signing operation. Error: {}", e);
+                        Err(ResponseStatus::PsaErrorGenericError)
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to initialize signing operation. Error: {}", e);
+                Err(ResponseStatus::PsaErrorGenericError)
+            }
+        }
+    }
+
+    fn asym_verify(&self, app_name: ApplicationName, op: OpAsymVerify) -> Result<ResultAsymVerify> {
+        info!("Pkcs11 Provider - Asym Verify");
+
+        let key_name = op.key_name;
+        let hash = op.hash;
+        let signature = op.signature;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11Provider, key_name);
+        let store_handle = self.key_id_store.read().expect("Key store lock poisoned");
+        let key_id = get_key_id(&key_triple, &*store_handle)?;
+
+        let mech = pkcs11::types::CK_MECHANISM {
+            mechanism: pkcs11::types::CKM_RSA_PKCS,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
+        info!("Asymmetric verify in session {}", session.session_handle());
+
+        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PublicKey)?;
+        info!("Located public key.");
+
+        match self
+            .backend
+            .verify_init(session.session_handle(), &mech, key)
+        {
+            Ok(_) => {
+                info!("Verify operation initialized.");
+                match self
+                    .backend
+                    .verify(session.session_handle(), &hash, &signature)
+                {
+                    Ok(_) => Ok(ResultAsymVerify {}),
+                    Err(e) => match e {
+                        pkcs11::errors::Error::Pkcs11(CKR_SIGNATURE_INVALID) => {
+                            info!("Signature verification failed.");
+                            Err(ResponseStatus::PsaErrorInvalidSignature)
+                        }
+                        err => {
+                            error!("Failed to execute verify operation. Error: {}", err);
+                            Err(ResponseStatus::PsaErrorGenericError)
+                        }
+                    },
+                }
+            }
+            Err(e) => {
+                error!("Failed to initialize signing operation. Error: {}", e);
+                Err(ResponseStatus::PsaErrorGenericError)
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Pkcs11ProviderBuilder {
+    key_id_store: Option<Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>>,
+    pkcs11_library_path: Option<String>,
+    slot_number: Option<usize>,
+    user_pin: Option<String>,
+}
+
+impl Pkcs11ProviderBuilder {
+    pub fn new() -> Pkcs11ProviderBuilder {
+        Pkcs11ProviderBuilder {
+            key_id_store: None,
+            pkcs11_library_path: None,
+            slot_number: None,
+            user_pin: None,
+        }
+    }
+
+    pub fn with_key_id_store(
+        mut self,
+        key_id_store: Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>,
+    ) -> Pkcs11ProviderBuilder {
+        self.key_id_store = Some(key_id_store);
+
+        self
+    }
+
+    pub fn with_pkcs11_library_path(
+        mut self,
+        pkcs11_library_path: String,
+    ) -> Pkcs11ProviderBuilder {
+        self.pkcs11_library_path = Some(pkcs11_library_path);
+
+        self
+    }
+
+    pub fn with_slot_number(mut self, slot_number: usize) -> Pkcs11ProviderBuilder {
+        self.slot_number = Some(slot_number);
+
+        self
+    }
+
+    pub fn with_user_pin(mut self, user_pin: Option<String>) -> Pkcs11ProviderBuilder {
+        self.user_pin = user_pin;
+
+        self
+    }
+
+    pub fn build(self) -> Pkcs11Provider {
+        let library_path = self
+            .pkcs11_library_path
+            .expect("Missing PKCS 11 library path");
+        info!(
+            "Building a PKCS 11 provider with library \'{}\'",
+            library_path
+        );
+        let slot_number = self
+            .slot_number
+            .expect("The slot number of the device is needed to communicate with PKCS 11 library.");
+        let mut backend = Ctx::new(library_path).unwrap();
+        let mut args = CK_C_INITIALIZE_ARGS::new();
+        // Allow the PKCS 11 library to use OS native locking mechanism.
+        args.CreateMutex = None;
+        args.DestroyMutex = None;
+        args.LockMutex = None;
+        args.UnlockMutex = None;
+        args.flags = CKF_OS_LOCKING_OK;
+        backend.initialize(Some(args)).unwrap();
+        Pkcs11Provider::new(
+            self.key_id_store.expect("Missing key ID store"),
+            backend,
+            slot_number,
+            self.user_pin,
+        )
+        .expect("Failed to initialise PKCS 11 Provider")
+    }
+}

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -63,7 +63,10 @@ kill $SERVER_PID
 # key name of "Test Key". It contains a valid PSA Key ID.
 # It is tested in test "should_have_been_deleted".
 mkdir -p mappings/cm9vdA==/1 || exit 1
+# For Mbed Provider
 printf '\xe0\x19\xb2\x5c' > mappings/cm9vdA==/1/VGVzdCBLZXk\=
+# For PKCS 11 Provider
+printf '\xe0\x19\xb2\x5c' > mappings/cm9vdA==/2/VGVzdCBLZXk\=
 
 RUST_BACKTRACE=1 RUST_LOG=info cargo run &
 SERVER_PID=$!
@@ -78,6 +81,6 @@ kill $SERVER_PID
 RUST_BACKTRACE=1 RUST_LOG=info cargo run &
 SERVER_PID=$!
 
-cargo test --test stress_test || exit 1
+RUST_LOG=info cargo test --test stress_test || exit 1
 
 kill $SERVER_PID

--- a/tests/normal_tests/auth.rs
+++ b/tests/normal_tests/auth.rs
@@ -15,14 +15,12 @@
 #[cfg(test)]
 mod tests {
     use parsec_client_test::TestClient;
-    use parsec_interface::requests::ProviderID;
     use parsec_interface::requests::{ResponseStatus, Result};
 
     #[test]
     fn two_auths_same_key_name() -> Result<()> {
         let key_name = String::from("two_auths_same_key_name");
         let mut client = TestClient::new();
-        client.set_provider(Some(ProviderID::MbedProvider));
         let auth1 = String::from("first_client").into_bytes();
         let auth2 = String::from("second_client").into_bytes();
 
@@ -37,7 +35,6 @@ mod tests {
     fn delete_wrong_key() -> Result<()> {
         let key_name = String::from("delete_wrong_key");
         let mut client = TestClient::new();
-        client.set_provider(Some(ProviderID::MbedProvider));
         let auth1 = String::from("first_client").into_bytes();
         let auth2 = String::from("second_client").into_bytes();
 

--- a/tests/normal_tests/create_destroy_key.rs
+++ b/tests/normal_tests/create_destroy_key.rs
@@ -20,11 +20,11 @@ mod tests {
     #[test]
     fn create_and_destroy() -> Result<()> {
         let mut client = TestClient::new();
+        client.do_not_destroy_keys();
         let key_name = String::from("create_and_destroy");
 
         client.create_rsa_sign_key(key_name.clone())?;
-
-        client.destroy_key(key_name)
+        client.destroy_key(key_name.clone())
     }
 
     #[test]

--- a/tests/normal_tests/describe_assets.rs
+++ b/tests/normal_tests/describe_assets.rs
@@ -19,17 +19,23 @@ mod tests {
     use parsec_interface::requests::Result;
     use std::collections::HashSet;
 
+    //TODO: put those two first tests in a separate target which is executed with an
+    //appropriate config file so that all providers are there.
+
     #[test]
+    #[ignore]
     fn list_providers() {
         let mut client = TestClient::new();
         let providers = client.list_providers().expect("list providers failed");
-        assert_eq!(providers.len(), 2);
+        assert_eq!(providers.len(), 3);
         let ids: HashSet<ProviderID> = providers.iter().map(|p| p.id).collect();
         assert!(ids.contains(&ProviderID::CoreProvider));
         assert!(ids.contains(&ProviderID::MbedProvider));
+        assert!(ids.contains(&ProviderID::Pkcs11Provider));
     }
 
     #[test]
+    #[ignore]
     fn list_opcodes() {
         let mut client = TestClient::new();
         client.set_provider(Some(ProviderID::MbedProvider));

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -19,6 +19,8 @@ mod tests {
 
     #[test]
     fn stress_test() {
+        env_logger::init();
+
         let config = StressTestConfig {
             no_threads: num_cpus::get(),
             req_per_thread: 250,


### PR DESCRIPTION
This provider will interface with a PKCS 11 dynamic library to
communicate with a PKCS 11 device.
Add PKCS 11 configuration for the user to enter the path of the dynamic
PKCS 11 library to load, the slot number where the device is and the
user pin of that device.
Removes provider-dependant information in the tests: they shoudl be
generic no matter what provider is currently used.
The PKCS 11 provider currently only supports RSA Key pair generation,
importing and exporting public keys, signing and verifying with those
RSA keys.

Co-authored-by: Paul Howard <paul.howard@arm.com>
Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>