### PR TITLE
Add SIGHUP signal handling to reload configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,22 +47,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: cargo build --verbose
-    - name: Tests executed before the shutdown
-      run: |
+    - run: |
         RUST_BACKTRACE=1 RUST_LOG=info cargo run &
         SERVER_PID=$!
         cargo test --test persistent-before
-        kill $SERVER_PID
-    # Create a fake mapping file for the root application, the Mbed Provider and
-    # a key name of "Test Key". It contains a valid PSA Key ID.
-    # It is tested in test "should_have_been_deleted".
-    - name: Create a fake mapping file
-      run: |
+        # Create a fake mapping file for the root application, the Mbed Provider and
+        # a key name of "Test Key". It contains a valid PSA Key ID.
+        # It is tested in test "should_have_been_deleted".
         mkdir -p mappings/cm9vdA==/1 || exit 1
         printf '\xe0\x19\xb2\x5c' > mappings/cm9vdA==/1/VGVzdCBLZXk\=
-    - name: Tests executed after the shutdown
-      run: |
-        RUST_BACKTRACE=1 RUST_LOG=info cargo run &
+        kill -s SIGHUP $SERVER_PID
         cargo test --test persistent-after
 
   stress-test:

--- a/src/providers/mbed_provider/mod.rs
+++ b/src/providers/mbed_provider/mod.rs
@@ -482,6 +482,14 @@ impl Provide for MbedProvider {
     }
 }
 
+impl Drop for MbedProvider {
+    fn drop(&mut self) {
+        unsafe {
+            psa_crypto_binding::mbedtls_psa_crypto_free();
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct MbedProviderBuilder {
     key_id_store: Option<Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>>,

--- a/src/providers/pkcs11_provider/mod.rs
+++ b/src/providers/pkcs11_provider/mod.rs
@@ -900,6 +900,14 @@ impl Provide for Pkcs11Provider {
     }
 }
 
+impl Drop for Pkcs11Provider {
+    fn drop(&mut self) {
+        if let Err(e) = self.backend.finalize() {
+            error!("Error when dropping the PKCS 11 provider: {}", e);
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct Pkcs11ProviderBuilder {
     key_id_store: Option<Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>>,

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -39,25 +39,15 @@ cargo test --doc || exit 1
 cargo fmt --all -- --check || exit 1
 cargo clippy || exit 1
 
-############################
-# Normal Integration tests #
-############################
+#####################
+# Integration tests #
+#####################
 RUST_BACKTRACE=1 RUST_LOG=info cargo run &
 SERVER_PID=$!
 
 cargo test --test normal || exit 1
 
-kill $SERVER_PID
-
-#################################
-# Persistence Integration tests #
-#################################
-RUST_BACKTRACE=1 RUST_LOG=info cargo run &
-SERVER_PID=$!
-
 cargo test --test persistent-before || exit 1
-
-kill $SERVER_PID
 
 # Create a fake mapping file for the root application, the Mbed Provider and a
 # key name of "Test Key". It contains a valid PSA Key ID.
@@ -68,18 +58,10 @@ printf '\xe0\x19\xb2\x5c' > mappings/cm9vdA==/1/VGVzdCBLZXk\=
 # For PKCS 11 Provider
 printf '\xe0\x19\xb2\x5c' > mappings/cm9vdA==/2/VGVzdCBLZXk\=
 
-RUST_BACKTRACE=1 RUST_LOG=info cargo run &
-SERVER_PID=$!
+# Trigger a configuration reload to load the new mappings.
+kill -s SIGHUP $SERVER_PID
 
 cargo test --test persistent-after || exit 1
-
-kill $SERVER_PID
-
-################
-# Stress tests #
-################
-RUST_BACKTRACE=1 RUST_LOG=info cargo run &
-SERVER_PID=$!
 
 RUST_LOG=info cargo test --test stress_test || exit 1
 


### PR DESCRIPTION
Following daemon(7), it is recommended that systemd daemons reload the
configuration files when SIGHUP is received. This commit implements that
by dropping the Parsec structures and re-instanciating them with the new
configuration.
Adds a Drop trait implementation on the providers for them to
unitialize/free the memory structures of their backends when they are
dropped.
Modifies the test script and CI workflow to use reloading.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>