### PR TITLE
Add a TPM provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,23 +15,14 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
 name = "arc-swap"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92"
-
-[[package]]
-name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
+checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 
 [[package]]
 name = "atty"
@@ -40,7 +31,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -82,11 +73,10 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
+checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 dependencies = [
- "autocfg",
  "byteorder",
  "serde",
 ]
@@ -111,8 +101,38 @@ dependencies = [
  "quote 0.6.13",
  "regex",
  "shlex",
- "which",
+ "which 2.0.1",
 ]
+
+[[package]]
+name = "bindgen"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "cfg-if",
+ "clang-sys",
+ "clap",
+ "env_logger 0.7.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which 3.1.0",
+]
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
@@ -153,22 +173,22 @@ checksum = "bed092b004819e731a68f8a99afb6e07ddb9160810beafbe9d68b952ff09c73a"
 dependencies = [
  "serde",
  "serde_derive",
- "toml 0.5.4",
+ "toml 0.5.5",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.46"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
+checksum = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 
 [[package]]
 name = "cexpr"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
+checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 dependencies = [
- "nom 4.2.3",
+ "nom",
 ]
 
 [[package]]
@@ -185,7 +205,7 @@ checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.5.2",
+ "libloading",
 ]
 
 [[package]]
@@ -210,16 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "der-parser"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c1dadf64f59a8b2ee2ca254c64bca0f665015613c5b7234b8873138f519764"
-dependencies = [
- "nom 5.0.1",
- "rusticata-macros",
 ]
 
 [[package]]
@@ -311,6 +321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,21 +349,11 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 dependencies = [
  "either",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -357,34 +366,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-core"
-version = "0.4.6"
+name = "lazycell"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
-dependencies = [
- "arrayvec",
- "cfg-if",
- "rustc_version",
- "ryu",
- "static_assertions",
-]
+checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.65"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
-
-[[package]]
-name = "libloading"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd38073de8f7965d0c17d30546d4bb6da311ab428d1c7a3fc71dff7f9d4979b9"
-dependencies = [
- "kernel32-sys",
- "lazy_static",
- "winapi 0.2.8",
-]
+checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 
 [[package]]
 name = "libloading"
@@ -393,7 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -419,6 +410,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
+name = "mbox"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3ae5479d6f010bca840f945a5ca2f3c343a74cccc98fcd13d62e176cf22361"
+dependencies = [
+ "libc",
+ "rustc_version",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,12 +433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,40 +443,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618b63422da4401283884e6668d39f819a106ef51f5f59b81add00075da35ca"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
 name = "num"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4825417e1e1406b3782a8ce92f4d53f26ec055e3622e1881ca8e9f5f9e08db"
 dependencies = [
- "num-bigint 0.2.3",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-dependencies = [
- "num-integer",
- "num-traits",
- "rand 0.4.6",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -561,26 +534,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 dependencies = [
  "autocfg",
- "num-bigint 0.2.3",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+checksum = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+checksum = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
 dependencies = [
+ "hermit-abi",
  "libc",
 ]
 
@@ -598,12 +572,11 @@ name = "parsec"
 version = "0.1.0"
 dependencies = [
  "base64",
- "bindgen",
+ "bincode",
+ "bindgen 0.50.1",
  "cargo_toml",
- "der-parser",
  "env_logger 0.7.1",
  "log",
- "nom 5.0.1",
  "num-bigint-dig",
  "num_cpus",
  "parsec-client-test",
@@ -617,13 +590,14 @@ dependencies = [
  "std-semaphore",
  "threadpool",
  "toml 0.4.10",
+ "tss-esapi",
  "uuid",
 ]
 
 [[package]]
 name = "parsec-client-test"
-version = "0.1.7"
-source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.7#9136549b91b2d3a9377acb7229e2f68f4d090e66"
+version = "0.1.8"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.8#afdb05fe45b8b312cf243d04713140538e040be8"
 dependencies = [
  "log",
  "num",
@@ -633,8 +607,8 @@ dependencies = [
 
 [[package]]
 name = "parsec-interface"
-version = "0.3.0"
-source = "git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.3.0#ac5bfe8c24d39c68155cda636b97d02b8bb6db28"
+version = "0.4.0"
+source = "git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.4.0#da449c86ced11f25e5e3b7f927a83912c09d8652"
 dependencies = [
  "bincode",
  "bytes",
@@ -664,12 +638,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs11"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff403ab0d15638fc795f4e2122e77e007fdcf17db7fee38f225f173c6e4cc1c3"
+checksum = "c20593a99fe08068cbe2b59001527f36021d6ad53ac5f2d8793fcf2fe94015a0"
 dependencies = [
- "libloading 0.4.3",
- "num-bigint 0.1.44",
+ "libloading",
+ "num-bigint",
 ]
 
 [[package]]
@@ -722,7 +696,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which",
+ "which 2.0.1",
 ]
 
 [[package]]
@@ -774,19 +748,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -801,7 +762,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -896,7 +857,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -910,7 +871,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -971,7 +932,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -981,10 +942,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
+name = "rustc-hash"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "rustc_version"
@@ -994,21 +958,6 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
-
-[[package]]
-name = "rusticata-macros"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2fec406dbe9a6def54a66dadbfa387c7f60e903691b208160d5e9c4586dff9"
-dependencies = [
- "nom 5.0.1",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 
 [[package]]
 name = "sd-notify"
@@ -1033,9 +982,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
+checksum = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
 dependencies = [
  "serde_derive",
 ]
@@ -1062,13 +1011,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
+checksum = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
 dependencies = [
  "proc-macro2 1.0.6",
  "quote 1.0.2",
- "syn 1.0.7",
+ "syn 1.0.11",
 ]
 
 [[package]]
@@ -1079,9 +1028,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb543aecec4ba8b867f41284729ddfdb7e8fcd70ec3d7d37fca3007a4b53675f"
+checksum = "7a9c17dd3ba2d36023a5c9472ecddeda07e27fd0b05436e8c1e0c8f178185652"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1089,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
  "arc-swap",
  "libc",
@@ -1113,10 +1062,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "static_assertions"
-version = "0.3.4"
+name = "stable_deref_trait"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "std-semaphore"
@@ -1143,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.7"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
+checksum = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 dependencies = [
  "proc-macro2 1.0.6",
  "quote 1.0.2",
@@ -1163,7 +1112,7 @@ dependencies = [
  "rand 0.7.2",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -1213,24 +1162,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04dffffeac90885436d23c692517bb5b8b3f8863e4afc15023628d067d667b7"
+checksum = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
+name = "tss-esapi"
+version = "0.4.0"
+source = "git+https://github.com/parallaxsecond/rust-tss-esapi?tag=0.4.0#68ab83440f06d8a2fe2e5ade4da79434c5508038"
+dependencies = [
+ "bindgen 0.52.0",
+ "bitfield",
+ "log",
+ "mbox",
+ "serde",
+]
+
+[[package]]
 name = "unicode-segmentation"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
@@ -1279,10 +1240,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.2.8"
+name = "which"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+checksum = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"
@@ -1293,12 +1257,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1312,7 +1270,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi",
 ]
 
 [[package]]
@@ -1327,6 +1285,6 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi",
  "winapi-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.3.0" }
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.4.0" }
 rand = "0.7.2"
 base64 = "0.10.1"
 uuid = "0.7.4"
@@ -26,12 +26,12 @@ log = { version = "0.4.8", features = ["serde"] }
 pkcs11 = { version = "0.4.0", optional = true }
 # Using a fork of the serde_asn1_der crate to have big integer support. Check https://github.com/KizzyCode/serde_asn1_der/issues/1
 serde_asn1_der = { git = "https://github.com/Devolutions/serde_asn1_der", rev = "ec1035879034ac9f09f1242fb49ed04c9aecdcae", optional = true, features = ["extra_types"] }
-der-parser = "3.0.2"
-nom = "5.0.1"
 num-bigint-dig = "0.5"
+tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi", tag = "0.4.0", optional = true }
+bincode = "1.1.4"
 
 [dev-dependencies]
-parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.7" }
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.8" }
 num_cpus = "1.10.1"
 
 [build-dependencies]
@@ -47,3 +47,4 @@ mbed-crypto-version = "mbedcrypto-2.0.0"
 default = ["mbed-crypto-provider", "pkcs11-provider"]
 mbed-crypto-provider = []
 pkcs11-provider = ["pkcs11", "serde_asn1_der"]
+tpm-provider = ["tss-esapi", "serde_asn1_der"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This project uses the following third party crates:
 * pkcs11 (Apache-2.0)
 * a fork of serde\_asn1\_der at `https://github.com/Devolutions/serde_asn1_der` (BSD-3-Clause and MIT)
 * num-bigint-dig (MIT and Apache-2.0)
+* bincode (MIT)
 
 This project uses the following third party libraries:
 * [Mbed Crypto](https://github.com/ARMmbed/mbed-crypto) (Apache-2.0)

--- a/config.toml
+++ b/config.toml
@@ -59,3 +59,13 @@ key_id_manager = "on-disk-manager"
 # (Optional) User pin for authentication with the specific slot. If not set, no authentication will
 # be used.
 #user_pin = "123456"
+
+# Example of a TPM provider configuration
+#[[provider]]
+#provider_type = "TpmProvider"
+#key_id_manager = "on-disk-manager"
+# (Required) TPM TCTI device to use with this provider. Options are:
+# - "device": uses the TPM device on /dev/tpm0
+# - "mssim": uses the simulation TPM with the socket
+# - "tabrmd": uses the TPM2 Access Broker & Resource Management Daemon
+#tcti = "mssim"

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -23,10 +23,14 @@ pub mod pkcs11_provider;
 #[cfg(feature = "mbed-crypto-provider")]
 pub mod mbed_provider;
 
+#[cfg(feature = "tpm-provider")]
+pub mod tpm_provider;
+
 #[derive(Deserialize, Debug)]
 pub enum ProviderType {
     MbedProvider,
     Pkcs11Provider,
+    TpmProvider,
 }
 
 impl ProviderType {
@@ -34,6 +38,7 @@ impl ProviderType {
         match self {
             ProviderType::MbedProvider => ProviderID::MbedProvider,
             ProviderType::Pkcs11Provider => ProviderID::Pkcs11Provider,
+            ProviderType::TpmProvider => ProviderID::TpmProvider,
         }
     }
 }
@@ -45,6 +50,7 @@ pub struct ProviderConfig {
     pub library_path: Option<String>,
     pub slot_number: Option<usize>,
     pub user_pin: Option<String>,
+    pub tcti: Option<String>,
 }
 
 use crate::authenticators::ApplicationName;

--- a/src/providers/tpm_provider/mod.rs
+++ b/src/providers/tpm_provider/mod.rs
@@ -1,0 +1,461 @@
+// Copyright (c) 2019, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//          http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use super::Provide;
+use crate::authenticators::ApplicationName;
+use crate::key_id_managers::{KeyTriple, ManageKeyIDs};
+use log::{error, info};
+use parsec_interface::operations::key_attributes::*;
+use parsec_interface::operations::ProviderInfo;
+use parsec_interface::operations::{OpAsymSign, ResultAsymSign};
+use parsec_interface::operations::{OpAsymVerify, ResultAsymVerify};
+use parsec_interface::operations::{OpCreateKey, ResultCreateKey};
+use parsec_interface::operations::{OpDestroyKey, ResultDestroyKey};
+use parsec_interface::operations::{OpExportPublicKey, ResultExportPublicKey};
+use parsec_interface::operations::{OpImportKey, ResultImportKey};
+use parsec_interface::operations::{OpListOpcodes, ResultListOpcodes};
+use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
+use serde::{Deserialize, Serialize};
+use serde_asn1_der::asn1_wrapper::*;
+use std::sync::{Arc, Mutex, RwLock};
+use tss_esapi::{
+    constants::TPM2_ALG_SHA256, response_code::Tss2ResponseCodeKind, utils::AsymSchemeUnion,
+    utils::Signature, utils::TpmsContext, Tcti,
+};
+use uuid::Uuid;
+extern crate num_bigint_dig as num_bigint;
+use num_bigint::{BigInt, Sign};
+
+const SUPPORTED_OPCODES: [Opcode; 7] = [
+    Opcode::CreateKey,
+    Opcode::DestroyKey,
+    Opcode::AsymSign,
+    Opcode::AsymVerify,
+    Opcode::ImportKey,
+    Opcode::ExportPublicKey,
+    Opcode::ListOpcodes,
+];
+
+const ROOT_KEY_SIZE: usize = 2048;
+const ROOT_KEY_AUTH_SIZE: usize = 32;
+
+pub struct TpmProvider {
+    // The Mutex is needed both because interior mutability is needed to the ESAPI Context
+    // structure that is shared between threads and because two threads are not allowed the same
+    // ESAPI context simultaneously.
+    esapi_context: Mutex<tss_esapi::TransientObjectContext>,
+    // The Key ID Manager stores the key context and its associated authValue (a PasswordContext
+    // structure).
+    key_id_store: Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>,
+}
+
+// Public exponent value for all RSA keys.
+const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
+const AUTH_VAL_LEN: usize = 32;
+
+// The RSA Public Key data are DER encoded with the following representation:
+// RSAPublicKey ::= SEQUENCE {
+//     modulus            INTEGER,  -- n
+//     publicExponent     INTEGER   -- e
+// }
+#[derive(Serialize, Deserialize, Debug)]
+struct RsaPublicKey {
+    modulus: IntegerAsn1,
+    public_exponent: IntegerAsn1,
+}
+
+// The PasswordContext is what is stored by the Key ID Manager.
+#[derive(Serialize, Deserialize)]
+struct PasswordContext {
+    context: TpmsContext,
+    auth_value: Vec<u8>,
+}
+
+/// Inserts a new mapping in the Key ID manager that stores the PasswordContext.
+fn insert_password_context(
+    store_handle: &mut dyn ManageKeyIDs,
+    key_triple: KeyTriple,
+    password_context: PasswordContext,
+) -> Result<()> {
+    let error_storing = |e| {
+        error!("Error storing a mapping: {}.", e);
+        Err(ResponseStatus::KeyIDManagerError)
+    };
+    let error_serializing = |e| {
+        error!("Error serializing the PasswordContext: {}.", e);
+        Err(ResponseStatus::KeyIDManagerError)
+    };
+
+    if store_handle
+        .insert(
+            key_triple,
+            bincode::serialize(&password_context).or_else(error_serializing)?,
+        )
+        .or_else(error_storing)?
+        .is_some()
+    {
+        error!("Inserting a mapping in the Key ID Manager that would overwrite an existing one.");
+        Err(ResponseStatus::KeyAlreadyExists)
+    } else {
+        Ok(())
+    }
+}
+
+/// Gets a PasswordContext mapping to the KeyTriple given.
+fn get_password_context(
+    store_handle: &dyn ManageKeyIDs,
+    key_triple: KeyTriple,
+) -> Result<PasswordContext> {
+    let password_context = store_handle.get(&key_triple).or_else(|e| {
+        error!("Error getting a mapping: {}.", e);
+        Err(ResponseStatus::KeyIDManagerError)
+    })?;
+    let password_context = match password_context {
+        Some(context) => context,
+        None => {
+            error!(
+                "Key triple \"{}\" does not exist in the Key ID Manager.",
+                key_triple
+            );
+            return Err(ResponseStatus::KeyDoesNotExist);
+        }
+    };
+    Ok(bincode::deserialize(password_context).or_else(|e| {
+        error!("Error deserializing the PasswordContext: {}.", e);
+        Err(ResponseStatus::KeyIDManagerError)
+    })?)
+}
+
+impl TpmProvider {
+    /// Creates and initialise a new instance of TpmProvider.
+    fn new(
+        key_id_store: Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>,
+        esapi_context: tss_esapi::TransientObjectContext,
+    ) -> Option<TpmProvider> {
+        Some(TpmProvider {
+            esapi_context: Mutex::new(esapi_context),
+            key_id_store,
+        })
+    }
+}
+
+impl Provide for TpmProvider {
+    fn list_opcodes(&self, _op: OpListOpcodes) -> Result<ResultListOpcodes> {
+        Ok(ResultListOpcodes {
+            opcodes: SUPPORTED_OPCODES.iter().copied().collect(),
+        })
+    }
+
+    fn describe(&self) -> ProviderInfo {
+        ProviderInfo {
+            // Assigned UUID for this provider: 1e4954a4-ff21-46d3-ab0c-661eeb667e1d
+            uuid: Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").expect("UUID parsing failed"),
+            description: String::from("TPM provider, interfacing with a library implementing the TCG TSS 2.0 Enhanced System API specification."),
+            vendor: String::from("Trusted Computing Group (TCG)"),
+            version_maj: 0,
+            version_min: 1,
+            version_rev: 0,
+            id: ProviderID::TpmProvider,
+        }
+    }
+
+    fn create_key(&self, app_name: ApplicationName, op: OpCreateKey) -> Result<ResultCreateKey> {
+        if op.key_attributes.key_type != KeyType::RsaKeypair
+            || op.key_attributes.algorithm != Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None)
+        {
+            error!("The TPM provider currently only supports creating RSA key pairs for signing and verifying.");
+            return Err(ResponseStatus::UnsupportedOperation);
+        }
+
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::TpmProvider, key_name);
+        // This should never panic on 32 bits or more machines.
+        let key_size = std::convert::TryFrom::try_from(op.key_attributes.key_size)
+            .expect("Conversion to usize failed.");
+
+        let mut store_handle = self.key_id_store.write().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let (key_context, auth_value) = esapi_context
+            .create_rsa_signing_key(key_size, AUTH_VAL_LEN)
+            .or_else(|e| {
+                error!("Error creating a RSA signing key: {}.", e);
+                Err(ResponseStatus::PsaErrorHardwareFailure)
+            })?;
+
+        insert_password_context(
+            &mut *store_handle,
+            key_triple,
+            PasswordContext {
+                context: key_context,
+                auth_value,
+            },
+        )?;
+
+        Ok(ResultCreateKey {})
+    }
+
+    fn import_key(&self, app_name: ApplicationName, op: OpImportKey) -> Result<ResultImportKey> {
+        if op.key_attributes.key_type != KeyType::RsaPublicKey
+            || op.key_attributes.algorithm != Algorithm::sign(SignAlgorithm::RsaPkcs1v15Sign, None)
+        {
+            error!(
+                "The TPM provider currently only supports importing RSA public key for verifying."
+            );
+            return Err(ResponseStatus::UnsupportedOperation);
+        }
+
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::TpmProvider, key_name);
+        let key_data = op.key_data;
+
+        let mut store_handle = self.key_id_store.write().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let public_key: RsaPublicKey = serde_asn1_der::from_bytes(&key_data).or_else(|err| {
+            error!("Could not deserialise key elements: {}.", err);
+            Err(ResponseStatus::PsaErrorCommunicationFailure)
+        })?;
+        if public_key.public_exponent.to_bytes_be().1 != PUBLIC_EXPONENT {
+            error!("The TPM Provider only supports 0x101 as public exponent for RSA public keys, {:?} given.", public_key.public_exponent.to_bytes_be());
+            return Err(ResponseStatus::UnsupportedOperation);
+        }
+        let key_data = public_key.modulus.to_bytes_be().1;
+
+        let len = key_data.len();
+        if len < 128 {
+            error!(
+                "The TPM provider only supports 1024 bits or bigger RSA public keys ({} bits given).",
+                len * 8
+            );
+            return Err(ResponseStatus::UnsupportedOperation);
+        }
+
+        let pub_key_context = esapi_context
+            .load_external_rsa_public_key(&key_data)
+            .or_else(|e| {
+                error!("Error creating a RSA signing key: {}.", e);
+                Err(ResponseStatus::PsaErrorHardwareFailure)
+            })?;
+
+        insert_password_context(
+            &mut *store_handle,
+            key_triple,
+            PasswordContext {
+                context: pub_key_context,
+                auth_value: Vec::new(),
+            },
+        )?;
+
+        Ok(ResultImportKey {})
+    }
+
+    fn export_public_key(
+        &self,
+        app_name: ApplicationName,
+        op: OpExportPublicKey,
+    ) -> Result<ResultExportPublicKey> {
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::TpmProvider, key_name);
+
+        let store_handle = self.key_id_store.read().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let password_context = get_password_context(&*store_handle, key_triple)?;
+
+        let pub_key_data = esapi_context
+            .read_public_key(password_context.context)
+            .or_else(|e| {
+                error!("Error reading a public key: {}.", e);
+                Err(ResponseStatus::PsaErrorHardwareFailure)
+            })?;
+
+        let key = RsaPublicKey {
+            modulus: IntegerAsn1(BigInt::from_bytes_be(Sign::Plus, &pub_key_data)),
+            public_exponent: IntegerAsn1(BigInt::from_bytes_be(Sign::Plus, &PUBLIC_EXPONENT)),
+        };
+        let key_data = serde_asn1_der::to_vec(&key).or_else(|err| {
+            error!("Could not serialise key elements: {}.", err);
+            Err(ResponseStatus::PsaErrorCommunicationFailure)
+        })?;
+
+        Ok(ResultExportPublicKey { key_data })
+    }
+
+    fn destroy_key(&self, app_name: ApplicationName, op: OpDestroyKey) -> Result<ResultDestroyKey> {
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::TpmProvider, key_name);
+        let mut store_handle = self.key_id_store.write().expect("Key store lock poisoned");
+
+        let error_closure = |e| {
+            error!("Error storing a mapping: {}.", e);
+            Err(ResponseStatus::KeyIDManagerError)
+        };
+        if store_handle
+            .remove(&key_triple)
+            .or_else(error_closure)?
+            .is_none()
+        {
+            error!(
+                "Key triple \"{}\" does not exist in the Key ID Manager.",
+                key_triple
+            );
+            Err(ResponseStatus::KeyDoesNotExist)
+        } else {
+            Ok(ResultDestroyKey {})
+        }
+    }
+
+    fn asym_sign(&self, app_name: ApplicationName, op: OpAsymSign) -> Result<ResultAsymSign> {
+        let key_name = op.key_name;
+        let hash = op.hash;
+        let key_triple = KeyTriple::new(app_name, ProviderID::TpmProvider, key_name);
+
+        let store_handle = self.key_id_store.read().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let len = hash.len();
+        if len > 64 {
+            error!("The buffer given to sign is too big. Its length is {} and maximum authorised is 64.", len);
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        let password_context = get_password_context(&*store_handle, key_triple)?;
+
+        let signature = esapi_context
+            .sign(
+                password_context.context,
+                &password_context.auth_value,
+                &hash,
+            )
+            .or_else(|e| {
+                error!("Error signing: {}.", e);
+                Err(ResponseStatus::PsaErrorHardwareFailure)
+            })?;
+
+        Ok(ResultAsymSign {
+            signature: signature.signature,
+        })
+    }
+
+    fn asym_verify(&self, app_name: ApplicationName, op: OpAsymVerify) -> Result<ResultAsymVerify> {
+        let key_name = op.key_name;
+        let hash = op.hash;
+        let signature = op.signature;
+        let key_triple = KeyTriple::new(app_name, ProviderID::TpmProvider, key_name);
+
+        let store_handle = self.key_id_store.read().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let len = hash.len();
+        if len > 64 {
+            error!("The buffer given to sign is too big. Its length is {} and maximum authorised is 64.", len);
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        let signature = Signature {
+            scheme: AsymSchemeUnion::RSASSA(TPM2_ALG_SHA256),
+            signature,
+        };
+
+        let password_context = get_password_context(&*store_handle, key_triple)?;
+
+        esapi_context
+            .verify_signature(password_context.context, &hash, signature)
+            .or_else(|e| {
+                if e.kind() == Some(Tss2ResponseCodeKind::Signature) {
+                    error!("The verification failed.");
+                    Err(ResponseStatus::PsaErrorInvalidSignature)
+                } else {
+                    error!("Error verifying: {}.", e);
+                    Err(ResponseStatus::PsaErrorHardwareFailure)
+                }
+            })?;
+
+        Ok(ResultAsymVerify {})
+    }
+}
+
+impl Drop for TpmProvider {
+    fn drop(&mut self) {
+        info!("Dropping the TPM Provider.");
+    }
+}
+
+#[derive(Default)]
+pub struct TpmProviderBuilder {
+    key_id_store: Option<Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>>,
+    tcti: Option<Tcti>,
+}
+
+impl TpmProviderBuilder {
+    pub fn new() -> TpmProviderBuilder {
+        TpmProviderBuilder {
+            key_id_store: None,
+            tcti: None,
+        }
+    }
+
+    pub fn with_key_id_store(
+        mut self,
+        key_id_store: Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>,
+    ) -> TpmProviderBuilder {
+        self.key_id_store = Some(key_id_store);
+
+        self
+    }
+
+    pub fn with_tcti(mut self, tcti: &str) -> TpmProviderBuilder {
+        // Convert from a String to the enum.
+        self.tcti = match tcti {
+            "device" => Some(Tcti::Device),
+            "mssim" => Some(Tcti::Mssim),
+            _ => {
+                error!("The string {} does not match a TCTI device.", tcti);
+                None
+            }
+        };
+
+        self
+    }
+
+    pub fn build(self) -> TpmProvider {
+        TpmProvider::new(
+            self.key_id_store.expect("Missing key ID store."),
+            tss_esapi::TransientObjectContext::new(
+                self.tcti.expect("Missing TCTI."),
+                ROOT_KEY_SIZE,
+                ROOT_KEY_AUTH_SIZE,
+                &[],
+            )
+            .expect("Failed to create a new ESAPI transient context"),
+        )
+        .expect("Failed to initialise TPM Provider")
+    }
+}

--- a/tests/persistent-after.rs
+++ b/tests/persistent-after.rs
@@ -18,7 +18,7 @@
 #[cfg(test)]
 mod tests {
     use parsec_client_test::TestClient;
-    use parsec_interface::requests::{ResponseStatus, Result};
+    use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 
     const HASH: [u8; 32] = [
         0x69, 0x3E, 0xDB, 0x1B, 0x22, 0x79, 0x03, 0xF4, 0xC0, 0xBF, 0xD6, 0x91, 0x76, 0x37, 0x84,
@@ -42,7 +42,12 @@ mod tests {
     fn should_have_been_deleted() {
         let mut client = TestClient::new();
 
-        // A fake mapping file was created for this key, it should have been deleted by the Mbed
+        if client.get_cached_provider(Opcode::DestroyKey) == ProviderID::TpmProvider {
+            // This test does not make sense for the TPM Provider.
+            return;
+        }
+
+        // A fake mapping file was created for this key, it should have been deleted by the
         // Provider.
         let key_name = String::from("Test Key");
         assert_eq!(


### PR DESCRIPTION
This provider uses the tss-esapi crate to interface with a TSS 2.0
Enhanced System library.
Adds new configuration entries to select the TPM provider and which
TCTI device to use.
The TPM provider currently only supports RSA key, signing and verifying
operations.

Co-authored-by: Ionut Mihalcea <ionut.mihalcea@arm.com>
Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>