### PR TITLE
Make sure Cargo features work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,6 @@ serde = { version = "1.0", features = ["derive"] }
 mbed-crypto-version = "mbedcrypto-2.0.0"
 
 [features]
-default = ["mbed", "pkcs11-provider"]
-mbed = []
+default = ["mbed-crypto-provider", "pkcs11-provider"]
+mbed-crypto-provider = []
 pkcs11-provider = ["pkcs11", "serde_asn1_der"]

--- a/build.rs
+++ b/build.rs
@@ -165,7 +165,7 @@ fn main() {
         .expect("Cargo.toml does not contain package metadata.");
     let parsec_config = get_value_from_table(&metadata, CONFIG_TABLE_NAME);
 
-    if cfg!(feature = "mbed") {
+    if cfg!(feature = "mbed-crypto-provider") {
         let mbed_config = config.mbed_config.expect(&format!(
             "Could not find mbed_config table in the {} file.",
             BUILD_CONFIG_FILE_PATH

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -20,7 +20,7 @@ pub mod core_provider;
 #[cfg(feature = "pkcs11-provider")]
 pub mod pkcs11_provider;
 
-#[cfg(feature = "mbed")]
+#[cfg(feature = "mbed-crypto-provider")]
 pub mod mbed_provider;
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Makes sure that Parsec builds with commands like:
```
cargo build --no-default-features --features "mbed-crypto-provider"
cargo build --no-default-features --features "tpm-provider"
```

Also renames the "mbed" features to "mbed-crypto-provider" for
consistency.

Exit the service with an error code if no provider could be instanciated.