### PR TITLE
Add a command-line option to select configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,7 @@ dependencies = [
  "serde_asn1_der",
  "signal-hook",
  "std-semaphore",
+ "structopt",
  "threadpool",
  "toml 0.4.10",
  "tss-esapi",
@@ -651,6 +652,17 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "proc-macro-error"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
+dependencies = [
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "syn 1.0.11",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1078,6 +1090,29 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
+dependencies = [
+ "clap",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.6",
+ "quote 1.0.2",
+ "syn 1.0.11",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_asn1_der = { git = "https://github.com/Devolutions/serde_asn1_der", rev = 
 num-bigint-dig = "0.5"
 tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi", tag = "0.4.0", optional = true }
 bincode = "1.1.4"
+structopt = "0.3.5"
 
 [dev-dependencies]
 parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.8" }

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This project uses the following third party crates:
 * a fork of serde\_asn1\_der at `https://github.com/Devolutions/serde_asn1_der` (BSD-3-Clause and MIT)
 * num-bigint-dig (MIT and Apache-2.0)
 * bincode (MIT)
+* structopt (MIT and Apache-2.0)
 
 This project uses the following third party libraries:
 * [Mbed Crypto](https://github.com/ARMmbed/mbed-crypto) (Apache-2.0)


### PR DESCRIPTION
Adds a new dependency, structopt, which provides to Parsec a command
line interface with basic --help and --version options.
Also adds the --config (or -c) to select an alternative configuration
file than the one currently in the directory.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>