### PR TITLE
Replace most panicking behaviours with Result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,42 +488,43 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parsec-client-test 0.1.10 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.10)",
- "parsec-interface 0.4.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.4.0)",
+ "parsec-client-test 0.1.11 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.11)",
+ "parsec-interface 0.5.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.5.0)",
  "picky-asn1 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "picky-asn1-der 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkcs11 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sd-notify 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tss-esapi 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tss-esapi 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parsec-client-test"
-version = "0.1.10"
-source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.10#97f013c3583dd1d7b49fb20eaf6f2dcdbf011cca"
+version = "0.1.11"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.11#823e405025dc366d123793772aca93a61f3cd984"
 dependencies = [
  "derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parsec-interface 0.4.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.4.0)",
+ "parsec-interface 0.5.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.5.0)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parsec-interface"
-version = "0.4.0"
-source = "git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.4.0#da449c86ced11f25e5e3b7f927a83912c09d8652"
+version = "0.5.0"
+source = "git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.5.0#5782510dbb9515b7105b6f89456fbb89f6a49707"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -593,7 +594,7 @@ dependencies = [
  "proc-macro-error-attr 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -604,7 +605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn-mid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -783,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -842,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -988,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1139,8 +1140,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum oid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "293d5f18898078ea69ba1c84f3688d1f2b6744df8211da36197153157cee7055"
-"checksum parsec-client-test 0.1.10 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.10)" = "<none>"
-"checksum parsec-interface 0.4.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.4.0)" = "<none>"
+"checksum parsec-client-test 0.1.11 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.11)" = "<none>"
+"checksum parsec-interface 0.5.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.5.0)" = "<none>"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum picky-asn1 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "462cc017444f8183daf4765fb682023c1c5ce68a649df4a5ce2830ef3f653a6d"
@@ -1170,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a0538bd897e17257b0128d2fd95c2ed6df939374073a36166051a79e2eb7986"
+"checksum rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 "checksum sd-notify 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aef40838bbb143707f8309b1e92e6ba3225287592968ba6f6e3b6de4a9816486"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
@@ -1178,7 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-"checksum signal-hook 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "7a9c17dd3ba2d36023a5c9472ecddeda07e27fd0b05436e8c1e0c8f178185652"
+"checksum signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum std-semaphore 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
@@ -1195,7 +1196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-"checksum tss-esapi 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5173356a28214d0de16cc1f8efb47c6f80c12e2d78f8c6225d120aedd81dbd"
+"checksum tss-esapi 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3b539f6041adee649c4d7a3fd9f7b38add791cf3c22d741434918c47f017d6"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.4.0" }
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.5.0" }
 rand = "0.7.2"
 base64 = "0.10.1"
 uuid = "0.7.4"
@@ -26,13 +26,13 @@ log = { version = "0.4.8", features = ["serde"] }
 pkcs11 = { version = "0.4.0", optional = true }
 picky-asn1-der = { version = "0.2.2", optional = true }
 picky-asn1 = { version = "0.2.1", optional = true }
-tss-esapi = { version = "1.0.1", optional = true }
+tss-esapi = { version = "2.0.0", optional = true }
 bincode = "1.1.4"
 structopt = "0.3.5"
 derivative = "1.0.3"
 
 [dev-dependencies]
-parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.10" }
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.11" }
 num_cpus = "1.10.1"
 
 [build-dependencies]

--- a/src/back/backend_handler.rs
+++ b/src/back/backend_handler.rs
@@ -21,6 +21,7 @@ use parsec_interface::requests::{
     request::RequestHeader, Request, Response, ResponseStatus, Result,
 };
 use parsec_interface::requests::{BodyType, ProviderID};
+use std::io::{Error, ErrorKind};
 
 /// Component responsible for unmarshalling requests, passing the operation
 /// to the provider and marshalling the result.
@@ -222,15 +223,29 @@ impl BackEndHandlerBuilder {
         self
     }
 
-    pub fn build(self) -> BackEndHandler {
-        BackEndHandler {
-            provider: self.provider.expect("Provider missing"),
-            converter: self.converter.expect("Converter missing"),
-            provider_id: self.provider_id.expect("Provider ID missing"),
-            content_type: self.content_type.expect("Content type missing"),
-            accept_type: self.accept_type.expect("Accept type missing"),
-            version_min: self.version_min.expect("Version min missing"),
-            version_maj: self.version_maj.expect("Version maj missing"),
-        }
+    pub fn build(self) -> std::io::Result<BackEndHandler> {
+        Ok(BackEndHandler {
+            provider: self
+                .provider
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "provider is missing"))?,
+            converter: self
+                .converter
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "converter is missing"))?,
+            provider_id: self
+                .provider_id
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "provider_id is missing"))?,
+            content_type: self
+                .content_type
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "content_type is missing"))?,
+            accept_type: self
+                .accept_type
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "accept_type is missing"))?,
+            version_min: self
+                .version_min
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "version_min is missing"))?,
+            version_maj: self
+                .version_maj
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "version_maj is missing"))?,
+        })
     }
 }

--- a/src/back/dispatcher.rs
+++ b/src/back/dispatcher.rs
@@ -18,6 +18,7 @@ use parsec_interface::requests::request::Request;
 use parsec_interface::requests::ProviderID;
 use parsec_interface::requests::{Response, ResponseStatus};
 use std::collections::HashMap;
+use std::io::{Error, ErrorKind, Result};
 
 /// Component tasked with identifying the backend handler that can
 /// service a request.
@@ -83,9 +84,11 @@ impl DispatcherBuilder {
         self
     }
 
-    pub fn build(self) -> Dispatcher {
-        Dispatcher {
-            backends: self.backends.expect("Backends missing"),
-        }
+    pub fn build(self) -> Result<Dispatcher> {
+        Ok(Dispatcher {
+            backends: self
+                .backends
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "backends is missing"))?,
+        })
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -47,7 +47,7 @@
 use log::info;
 use parsec::utils::{ServiceBuilder, ServiceConfig};
 use signal_hook::{flag, SIGHUP, SIGTERM};
-use std::io::{Error, ErrorKind};
+use std::io::{Error, ErrorKind, Result};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -73,7 +73,7 @@ struct Opts {
 
 const MAIN_LOOP_DEFAULT_SLEEP: u64 = 10;
 
-fn main() -> Result<(), Error> {
+fn main() -> Result<()> {
     // Parsing the command line arguments.
     let opts: Opts = Opts::from_args();
 
@@ -84,22 +84,24 @@ fn main() -> Result<(), Error> {
     let _ = flag::register(SIGTERM, kill_signal.clone())?;
     let _ = flag::register(SIGHUP, reload_signal.clone())?;
 
-    let mut config_file =
-        ::std::fs::read_to_string(opts.config.clone()).expect("Failed to read configuration file");
-    let mut config: ServiceConfig =
-        toml::from_str(&config_file).expect("Failed to parse service configuration");
+    let mut config_file = ::std::fs::read_to_string(opts.config.clone())?;
+    let mut config: ServiceConfig = toml::from_str(&config_file).or_else(|_| {
+        Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Failed to parse service configuration",
+        ))
+    })?;
 
     log_setup(&config);
 
     info!("Parsec started. Configuring the service...");
 
-    let front_end_handler = ServiceBuilder::build_service(&config)
-        .ok_or_else(|| Error::new(ErrorKind::Other, "Parsec can not be configured."))?;
+    let front_end_handler = ServiceBuilder::build_service(&config)?;
     // Multiple threads can not just have a reference of the front end handler because they could
     // outlive the run function. It is needed to give them all ownership of the front end handler
     // through an Arc.
     let mut front_end_handler = Arc::from(front_end_handler);
-    let mut listener = ServiceBuilder::start_listener(config.listener);
+    let mut listener = ServiceBuilder::start_listener(config.listener)?;
     let mut threadpool = ServiceBuilder::build_threadpool(config.core_settings.thread_pool_size);
 
     // Notify systemd that the daemon is ready, the start command will block until this point.
@@ -121,14 +123,15 @@ fn main() -> Result<(), Error> {
             drop(listener);
             drop(threadpool);
 
-            config_file = ::std::fs::read_to_string(opts.config.clone())
-                .expect("Failed to read configuration file");
-            config = toml::from_str(&config_file).expect("Failed to parse service configuration");
-            front_end_handler =
-                Arc::from(ServiceBuilder::build_service(&config).ok_or_else(|| {
-                    Error::new(ErrorKind::Other, "Parsec can not be configured.")
-                })?);
-            listener = ServiceBuilder::start_listener(config.listener);
+            config_file = ::std::fs::read_to_string(opts.config.clone())?;
+            config = toml::from_str(&config_file).or_else(|_| {
+                Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    "Failed to parse service configuration",
+                ))
+            })?;
+            front_end_handler = Arc::from(ServiceBuilder::build_service(&config)?);
+            listener = ServiceBuilder::start_listener(config.listener)?;
             threadpool = ServiceBuilder::build_threadpool(config.core_settings.thread_pool_size);
 
             let _ = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]);

--- a/src/front/front_end.rs
+++ b/src/front/front_end.rs
@@ -20,6 +20,7 @@ use parsec_interface::requests::AuthType;
 use parsec_interface::requests::ResponseStatus;
 use parsec_interface::requests::{Request, Response};
 use std::collections::HashMap;
+use std::io::{Error, ErrorKind, Result};
 use std::io::{Read, Write};
 
 /// Service component that serializes requests and deserializes responses
@@ -126,10 +127,14 @@ impl FrontEndHandlerBuilder {
         self
     }
 
-    pub fn build(self) -> FrontEndHandler {
-        FrontEndHandler {
-            dispatcher: self.dispatcher.expect("Dispatcher missing"),
-            authenticators: self.authenticators.expect("Authenticators missing"),
-        }
+    pub fn build(self) -> Result<FrontEndHandler> {
+        Ok(FrontEndHandler {
+            dispatcher: self
+                .dispatcher
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "dispatcher is missing"))?,
+            authenticators: self
+                .authenticators
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "authenticators is missing"))?,
+        })
     }
 }

--- a/src/key_id_managers/on_disk_manager/mod.rs
+++ b/src/key_id_managers/on_disk_manager/mod.rs
@@ -326,12 +326,11 @@ impl OnDiskKeyIDManagerBuilder {
         self
     }
 
-    pub fn build(self) -> OnDiskKeyIDManager {
-        OnDiskKeyIDManager::new(
-            self.mappings_dir_path
-                .expect("Mappings directory path is missing"),
-        )
-        .unwrap()
+    pub fn build(self) -> std::io::Result<OnDiskKeyIDManager> {
+        OnDiskKeyIDManager::new(self.mappings_dir_path.ok_or_else(|| {
+            error!("Mappings directory path is missing");
+            Error::new(ErrorKind::InvalidData, "mappings directory path is missing")
+        })?)
     }
 }
 

--- a/src/providers/core_provider/mod.rs
+++ b/src/providers/core_provider/mod.rs
@@ -18,6 +18,7 @@ use parsec_interface::operations::{OpListOpcodes, ResultListOpcodes};
 use parsec_interface::operations::{OpListProviders, ResultListProviders};
 use parsec_interface::operations::{OpPing, ResultPing};
 use parsec_interface::requests::{Opcode, ProviderID, Result};
+use std::io::{Error, ErrorKind};
 use uuid::Uuid;
 
 const SUPPORTED_OPCODES: [Opcode; 3] = [Opcode::ListProviders, Opcode::ListOpcodes, Opcode::Ping];
@@ -104,16 +105,22 @@ impl CoreProviderBuilder {
         self
     }
 
-    pub fn build(self) -> CoreProvider {
+    pub fn build(self) -> std::io::Result<CoreProvider> {
         let mut core_provider = CoreProvider {
-            version_maj: self.version_maj.expect("Version Maj missing"),
-            version_min: self.version_min.expect("Version Min missing"),
-            providers: self.providers.expect("Providers info is missing"),
+            version_maj: self
+                .version_maj
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "version maj is missing"))?,
+            version_min: self
+                .version_min
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "version min is missing"))?,
+            providers: self
+                .providers
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "provider info is missing"))?,
         };
 
         core_provider.providers.push(core_provider.describe());
 
-        core_provider
+        Ok(core_provider)
     }
 }
 


### PR DESCRIPTION
This commit looks at:
* unwrap
* expect
* panic
* unreachable
* unimplemented
functions/macros and tries to replace most of them with returning errors
instead.

Exceptions are:
* inside tests
* when using with read/write locks or mutexes
* env::var method
* converting from u32 to usize
* parsing Uuid

I took the liberty to align all the non-`ResponseStatus` errors to `std::io::Result` errors. I had to choose one of the `ErrorKind` variant and in some cases this choice is maybe bad. Feel free to propose changes. Using `std::io::Result` makes it easy to integrate with other libraries that we use that also return `std::io::Result` but we could also define our own.