### PR TITLE
Ensure the safety of unsafe blocks

### DIFF
--- a/tests/all_providers/config.toml
+++ b/tests/all_providers/config.toml
@@ -1,5 +1,4 @@
 [core_settings]
-log_level = "error"
 # The CI already timestamps the logs
 log_timestamp = false
 

--- a/tests/per_provider/provider_cfg/mbed-crypto/config.toml
+++ b/tests/per_provider/provider_cfg/mbed-crypto/config.toml
@@ -1,5 +1,4 @@
 [core_settings]
-log_level = "error"
 # The CI already timestamps the logs
 log_timestamp = false
 

--- a/tests/per_provider/provider_cfg/pkcs11/config.toml
+++ b/tests/per_provider/provider_cfg/pkcs11/config.toml
@@ -1,5 +1,4 @@
 [core_settings]
-log_level = "error"
 # The CI already timestamps the logs
 log_timestamp = false
 

--- a/tests/per_provider/provider_cfg/tpm/config.toml
+++ b/tests/per_provider/provider_cfg/tpm/config.toml
@@ -1,5 +1,4 @@
 [core_settings]
-log_level = "error"
 # The CI already timestamps the logs
 log_timestamp = false
 


### PR DESCRIPTION
Checks all unsafe uses and comment why it is safe to use unsafe in the
specific context.
Refactors the utils module to make it easier to prove safety.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>