### PR TITLE
Add body length limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derive_arbitrary 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +218,16 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -488,8 +506,8 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parsec-client-test 0.1.11 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.11)",
- "parsec-interface 0.5.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.5.0)",
+ "parsec-client-test 0.1.13 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.13)",
+ "parsec-interface 0.6.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.6.0)",
  "picky-asn1 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "picky-asn1-der 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkcs11 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -507,21 +525,22 @@ dependencies = [
 
 [[package]]
 name = "parsec-client-test"
-version = "0.1.11"
-source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.11#823e405025dc366d123793772aca93a61f3cd984"
+version = "0.1.13"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.13#a6acde21fb310a5da3946073b7ca7a5bbd4add87"
 dependencies = [
  "derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parsec-interface 0.5.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.5.0)",
+ "parsec-interface 0.6.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.6.0)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parsec-interface"
-version = "0.5.0"
-source = "git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.5.0#5782510dbb9515b7105b6f89456fbb89f6a49707"
+version = "0.6.0"
+source = "git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.6.0#0fdae176b87d1d50b2b4b6377a2b6852966862f2"
 dependencies = [
+ "arbitrary 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -927,6 +946,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arbitrary 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16971f2f0ce65c5cf2a1546cc6a0af102ecb11e265ddaa9433fb3e5bfdf676a4"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -1108,6 +1139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "942ca430eef7a3806595a6737bc388bf51adb888d3fc0dd1b50f1c170167ee3a"
+"checksum derive_arbitrary 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "caedd6a71b6d00bdc458ec8ffbfd12689c1ee7ffa69ad9933310aaf2f08f18d8"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
@@ -1140,8 +1172,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum oid 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "293d5f18898078ea69ba1c84f3688d1f2b6744df8211da36197153157cee7055"
-"checksum parsec-client-test 0.1.11 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.11)" = "<none>"
-"checksum parsec-interface 0.5.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.5.0)" = "<none>"
+"checksum parsec-client-test 0.1.13 (git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.13)" = "<none>"
+"checksum parsec-interface 0.6.0 (git+https://github.com/parallaxsecond/parsec-interface-rs?tag=0.6.0)" = "<none>"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum picky-asn1 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "462cc017444f8183daf4765fb682023c1c5ce68a649df4a5ce2830ef3f653a6d"
@@ -1189,6 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum syn-mid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fd3937748a7eccff61ba5b90af1a20dbf610858923a9192ea0ecb0cb77db1d0"
+"checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.5.0" }
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", tag = "0.6.0" }
 rand = "0.7.2"
 base64 = "0.10.1"
 uuid = "0.7.4"
@@ -32,7 +32,7 @@ structopt = "0.3.5"
 derivative = "1.0.3"
 
 [dev-dependencies]
-parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.11" }
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.13" }
 num_cpus = "1.10.1"
 
 [build-dependencies]

--- a/config.toml
+++ b/config.toml
@@ -17,6 +17,10 @@
 # Control whether log entries contain a timestamp.
 #log_timestamp = false
 
+# Decide how large (in bytes) request bodies can be before they get rejected automatically.
+# Defaults to 1MB.
+#body_len_limit = 1048576
+
 # (Required) Configuration for the service IPC listener component.
 [listener]
 # (Required) Type of IPC that the service will support.

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -54,6 +54,9 @@ use {crate::providers::ProviderType, log::info};
 const VERSION_MINOR: u8 = 0;
 const VERSION_MAJOR: u8 = 1;
 
+/// Default value for the limit on the request body size (in bytes) - equal to 1MB
+const DEFAULT_BODY_LEN_LIMIT: usize = 1 << 19;
+
 type KeyIdManager = Arc<RwLock<dyn ManageKeyIDs + Send + Sync>>;
 type Provider = Box<dyn Provide + Send + Sync>;
 
@@ -63,6 +66,7 @@ pub struct CoreSettings {
     pub idle_listener_sleep_duration: Option<u64>,
     pub log_level: Option<LevelFilter>,
     pub log_timestamp: Option<bool>,
+    pub body_len_limit: Option<usize>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -102,6 +106,12 @@ impl ServiceBuilder {
         Ok(FrontEndHandlerBuilder::new()
             .with_dispatcher(dispatcher)
             .with_authenticator(AuthType::Simple, simple_authenticator)
+            .with_body_len_limit(
+                config
+                    .core_settings
+                    .body_len_limit
+                    .unwrap_or(DEFAULT_BODY_LEN_LIMIT),
+            )
             .build()?)
     }
 


### PR DESCRIPTION
This commit adds a body length limit parameter to the service. This
will allow administrators to limit the size of requests that are accepted
by the service.