### PR TITLE
Allow TPM provider to use TestParms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tss-esapi 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tss-esapi 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "version 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "2.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1232,7 +1232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-"checksum tss-esapi 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3b539f6041adee649c4d7a3fd9f7b38add791cf3c22d741434918c47f017d6"
+"checksum tss-esapi 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "839a772b9f565e3792eeb3514c23f6e1bb0da4994def9c965fc1c96deeb5877a"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ log = { version = "0.4.8", features = ["serde"] }
 pkcs11 = { version = "0.4.0", optional = true }
 picky-asn1-der = { version = "0.2.2", optional = true }
 picky-asn1 = { version = "0.2.1", optional = true }
-tss-esapi = { version = "2.0.0", optional = true }
+tss-esapi = { version = "3.0.1", optional = true }
 bincode = "1.1.4"
 structopt = "0.3.5"
 derivative = "1.0.3"

--- a/fuzz/docker/Dockerfile
+++ b/fuzz/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN cd mbed-crypto-mbedcrypto-2.0.0 \
 
 WORKDIR /tmp
 # Download and install TSS 2.0
-RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.1
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.3
 RUN cd tpm2-tss \
 	&& ./bootstrap \
 	&& ./configure \

--- a/tests/all_providers/Dockerfile
+++ b/tests/all_providers/Dockerfile
@@ -16,7 +16,7 @@ RUN cd mbed-crypto-mbedcrypto-2.0.0 \
 
 WORKDIR /tmp
 # Download and install TSS 2.0
-RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.1
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.3
 RUN cd tpm2-tss \
 	&& ./bootstrap \
 	&& ./configure \

--- a/tests/per_provider/provider_cfg/tpm/Dockerfile
+++ b/tests/per_provider/provider_cfg/tpm/Dockerfile
@@ -3,7 +3,7 @@ FROM tpm2software/tpm2-tss:ubuntu-18.04
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
 # Download and install TSS 2.0
-RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.1
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.3
 RUN cd tpm2-tss \
 	&& ./bootstrap \
 	&& ./configure \


### PR DESCRIPTION
This commit improves the usage of the TSS crate by the TPM provider. The
provider can now go through a limited list of predefined ciphers that it
can use for securing sessions. It also uses the new transient context
builder.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

Closes #121

# ON HOLD

Test on RPi failed because only part of the usage of hardcoded ciphers was removed. Removing all of it would imply a bigger refactor in the TSS crate, which I'll do after the interface updates get done