### PR TITLE
Add tests checking if key attributes are respected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,8 +565,8 @@ dependencies = [
 
 [[package]]
 name = "parsec-client-test"
-version = "0.1.18"
-source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.1.18#fb15945d9bfde90a0978e6fef19901459626bdfc"
+version = "0.2.0"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.2.0#f8ca691f3a1538de1e0f74237d489710a3d7718f"
 dependencies = [
  "derivative",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ derivative = "1.0.3"
 version = "3.0.0"
 
 [dev-dependencies]
-parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.1.18" }
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.2.0" }
 num_cpus = "1.10.1"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ use parsec_client_test::TestClient;
 
 let mut client = TestClient::new();
 let key_name = String::from("🔑 What shall I sign? 🔑");
-client.create_rsa_sign_key(key_name.clone()).unwrap();
+client.generate_rsa_sign_key(key_name.clone()).unwrap();
 let signature = client.sign(key_name,
                             String::from("Platform AbstRaction for SECurity").into_bytes())
                       .unwrap();

--- a/tests/all_providers/mod.rs
+++ b/tests/all_providers/mod.rs
@@ -57,5 +57,5 @@ fn mangled_list_providers() {
 fn sign_verify_with_provider_discovery() -> Result<()> {
     let mut client = TestClient::new();
     let key_name = String::from("sign_verify_with_provider_discovery");
-    client.create_rsa_sign_key(key_name)
+    client.generate_rsa_sign_key(key_name)
 }

--- a/tests/per_provider/normal_tests/asym_sign_verify.rs
+++ b/tests/per_provider/normal_tests/asym_sign_verify.rs
@@ -48,7 +48,7 @@ fn asym_sign_and_verify_rsa_pkcs() -> Result<()> {
     let key_name = String::from("asym_sign_and_verify_rsa_pkcs");
     let mut client = TestClient::new();
 
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
 
     let signature = client.sign_with_rsa_sha256(key_name.clone(), HASH.to_vec())?;
 
@@ -61,7 +61,7 @@ fn asym_verify_fail() -> Result<()> {
     let signature = vec![0xff; 128];
     let mut client = TestClient::new();
 
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
 
     let status = client
         .verify_with_rsa_sha256(key_name, HASH.to_vec(), signature)

--- a/tests/per_provider/normal_tests/auth.rs
+++ b/tests/per_provider/normal_tests/auth.rs
@@ -23,10 +23,10 @@ fn two_auths_same_key_name() -> Result<()> {
     let auth2 = String::from("second_client").into_bytes();
 
     client.set_auth(auth1);
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
 
     client.set_auth(auth2);
-    client.create_rsa_sign_key(key_name)
+    client.generate_rsa_sign_key(key_name)
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn delete_wrong_key() -> Result<()> {
     let auth2 = String::from("second_client").into_bytes();
 
     client.set_auth(auth1);
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
 
     client.set_auth(auth2);
     let status = client

--- a/tests/per_provider/normal_tests/create_destroy_key.rs
+++ b/tests/per_provider/normal_tests/create_destroy_key.rs
@@ -21,7 +21,7 @@ fn create_and_destroy() -> Result<()> {
     client.do_not_destroy_keys();
     let key_name = String::from("create_and_destroy");
 
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
     client.destroy_key(key_name)
 }
 
@@ -30,9 +30,9 @@ fn create_twice() -> Result<()> {
     let mut client = TestClient::new();
     let key_name = String::from("create_twice");
 
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
     let status = client
-        .create_rsa_sign_key(key_name)
+        .generate_rsa_sign_key(key_name)
         .expect_err("A key with the same name can not be created twice.");
     assert_eq!(status, ResponseStatus::PsaErrorAlreadyExists);
 
@@ -56,7 +56,7 @@ fn create_destroy_and_operation() -> Result<()> {
     let hash = vec![0xDE, 0xAD, 0xBE, 0xEF];
     let key_name = String::from("create_destroy_and_operation");
 
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
 
     client.destroy_key(key_name.clone())?;
 
@@ -74,8 +74,8 @@ fn create_destroy_twice() -> Result<()> {
     let key_name = String::from("create_destroy_twice_1");
     let key_name_2 = String::from("create_destroy_twice_2");
 
-    client.create_rsa_sign_key(key_name.clone())?;
-    client.create_rsa_sign_key(key_name_2.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name_2.clone())?;
 
     client.destroy_key(key_name)?;
     client.destroy_key(key_name_2)

--- a/tests/per_provider/normal_tests/export_public_key.rs
+++ b/tests/per_provider/normal_tests/export_public_key.rs
@@ -22,7 +22,7 @@ fn export_public_key() -> Result<()> {
     let mut client = TestClient::new();
     let key_name = String::from("export_public_key");
 
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
 
     let _ = client.export_public_key(key_name)?;
 

--- a/tests/per_provider/normal_tests/import_key.rs
+++ b/tests/per_provider/normal_tests/import_key.rs
@@ -47,7 +47,7 @@ fn create_and_import_key() -> Result<()> {
     let mut client = TestClient::new();
     let key_name = String::from("create_and_import_key");
 
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
 
     let status = client
         .import_key(

--- a/tests/per_provider/normal_tests/key_attributes.rs
+++ b/tests/per_provider/normal_tests/key_attributes.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2020, Arm Limited, All Rights Reserved
+// SPDX-License-Identifier: Apache-2.0
+use parsec_client_test::TestClient;
+use parsec_interface::operations::psa_algorithm::{Algorithm, AsymmetricSignature, Cipher, Hash};
+use parsec_interface::operations::psa_key_attributes::{
+    KeyAttributes, KeyPolicy, KeyType, UsageFlags,
+};
+use parsec_interface::requests::ResponseStatus;
+
+#[ignore]
+#[test]
+fn wrong_type() {
+    let mut client = TestClient::new();
+    let key_name = String::from("wrong_type");
+
+    // Wrong key type
+    let key_type = KeyType::Derive;
+    let permitted_algorithm =
+        Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
+            hash_alg: Hash::Sha256,
+        });
+    let key_attributes = KeyAttributes {
+        key_type,
+        key_bits: 1024,
+        key_policy: KeyPolicy {
+            key_usage_flags: UsageFlags {
+                sign_hash: true,
+                verify_hash: false,
+                sign_message: false,
+                verify_message: false,
+                export: false,
+                encrypt: false,
+                decrypt: false,
+                cache: false,
+                copy: false,
+                derive: false,
+            },
+            key_algorithm: permitted_algorithm,
+        },
+    };
+
+    client
+        .generate_key(key_name.clone(), key_attributes)
+        .unwrap();
+    let status = client
+        .sign_with_rsa_sha256(key_name, vec![0xDE, 0xAD, 0xBE, 0xEF])
+        .unwrap_err();
+
+    assert_eq!(status, ResponseStatus::PsaErrorNotPermitted);
+}
+
+#[ignore]
+#[test]
+fn wrong_usage_flags() {
+    let mut client = TestClient::new();
+    let key_name = String::from("wrong_usage_flags");
+
+    let key_type = KeyType::RsaKeyPair;
+    let permitted_algorithm =
+        Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
+            hash_alg: Hash::Sha256,
+        });
+    let key_attributes = KeyAttributes {
+        key_type,
+        key_bits: 1024,
+        key_policy: KeyPolicy {
+            key_usage_flags: UsageFlags {
+                // Forbid signing
+                sign_hash: false,
+                verify_hash: false,
+                sign_message: false,
+                verify_message: false,
+                export: false,
+                encrypt: false,
+                decrypt: false,
+                cache: false,
+                copy: false,
+                derive: false,
+            },
+            key_algorithm: permitted_algorithm,
+        },
+    };
+
+    client
+        .generate_key(key_name.clone(), key_attributes)
+        .unwrap();
+    let status = client
+        .sign_with_rsa_sha256(key_name, vec![0xDE, 0xAD, 0xBE, 0xEF])
+        .unwrap_err();
+
+    assert_eq!(status, ResponseStatus::PsaErrorNotPermitted);
+}
+
+#[ignore]
+#[test]
+fn wrong_permitted_algorithm() {
+    let mut client = TestClient::new();
+    let key_name = String::from("wrong_permitted_algorithm");
+
+    let key_type = KeyType::RsaKeyPair;
+    // Do not permit RSA PKCS 1v15 signing algorithm with SHA-256.
+    let permitted_algorithm = Algorithm::Cipher(Cipher::Ctr);
+    let key_attributes = KeyAttributes {
+        key_type,
+        key_bits: 1024,
+        key_policy: KeyPolicy {
+            key_usage_flags: UsageFlags {
+                sign_hash: true,
+                verify_hash: false,
+                sign_message: false,
+                verify_message: false,
+                export: false,
+                encrypt: false,
+                decrypt: false,
+                cache: false,
+                copy: false,
+                derive: false,
+            },
+            key_algorithm: permitted_algorithm,
+        },
+    };
+
+    client
+        .generate_key(key_name.clone(), key_attributes)
+        .unwrap();
+    let status = client
+        .sign_with_rsa_sha256(key_name, vec![0xDE, 0xAD, 0xBE, 0xEF])
+        .unwrap_err();
+
+    assert_eq!(status, ResponseStatus::PsaErrorNotPermitted);
+}

--- a/tests/per_provider/normal_tests/mod.rs
+++ b/tests/per_provider/normal_tests/mod.rs
@@ -18,4 +18,5 @@ mod basic;
 mod create_destroy_key;
 mod export_public_key;
 mod import_key;
+mod key_attributes;
 mod ping;

--- a/tests/per_provider/persistent_before.rs
+++ b/tests/per_provider/persistent_before.rs
@@ -29,7 +29,7 @@ fn create_and_verify() -> Result<()> {
     client.do_not_destroy_keys();
 
     let key_name = String::from("🤡 Clown's Master Key 🤡");
-    client.create_rsa_sign_key(key_name.clone())?;
+    client.generate_rsa_sign_key(key_name.clone())?;
     let signature = client.sign_with_rsa_sha256(key_name.clone(), HASH.to_vec())?;
 
     client.verify_with_rsa_sha256(key_name, HASH.to_vec(), signature)


### PR DESCRIPTION
These tests check:
* asymmetric signature operations can only be done if they is of correct
type
* the specific algorithm used for those operations needs to be permitted
* the usage flags of the key need to allow the operation

The tests are disabled for now until the checking feature is implemented.