### PR TITLE
Add KeyInfo to the KeyIDManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013a6e0a2cbe3d20f9c60b65458f7a7f7a5e636c5d0f45a5a6aee5d4b1f01785"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 
 [[package]]
 name = "arbitrary"
@@ -58,9 +58,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
+checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 dependencies = [
  "cc",
  "libc",
@@ -136,7 +136,7 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
  "regex",
  "rustc-hash",
@@ -253,8 +253,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caedd6a71b6d00bdc458ec8ffbfd12689c1ee7ffa69ad9933310aaf2f08f18d8"
 dependencies = [
- "proc-macro2 1.0.9",
- "syn 1.0.16",
+ "proc-macro2 1.0.10",
+ "syn 1.0.17",
  "synstructure",
 ]
 
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 dependencies = [
  "libc",
 ]
@@ -442,9 +442,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "multimap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97fbd5d00e0e37bfb10f433af8f5aaf631e739368dc9fc28286ca81ca4948dc"
+checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
 name = "nom"
@@ -565,8 +565,8 @@ dependencies = [
 
 [[package]]
 name = "parsec-client-test"
-version = "0.2.0"
-source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.2.0#f8ca691f3a1538de1e0f74237d489710a3d7718f"
+version = "0.2.2"
+source = "git+https://github.com/parallaxsecond/parsec-client-test?tag=0.2.2#0c3373635e950384b506091e19afb1c6f622600d"
 dependencies = [
  "derivative",
  "log",
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "parsec-interface"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9276712f0eaf3ea7126277eb685c2cabe282e6b66a294ffaa53976465db19c3"
+checksum = "1d14be8b6d151c8054e2a1fe3b03c83748d138ebb0145637a57afbb576b211d7"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs11"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20593a99fe08068cbe2b59001527f36021d6ad53ac5f2d8793fcf2fe94015a0"
+checksum = "45712272d3a9d9a26471f6bee1596574d38df0136dd7eb163ed736913dc1f6bf"
 dependencies = [
  "libloading",
  "num-bigint",
@@ -686,26 +686,26 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7959c6467d962050d639361f7703b2051c43036d03493c36f01d440fdd3138a"
+checksum = "8931031034aa65c73f3f1a05c3ec0fa51287fcd06557ecf4e88b2768bdca375e"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
  "version_check 0.9.1",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4002d9f55991d5e019fb940a90e1a95eb80c24e77cb2462dd4dc869604d543a"
+checksum = "2147536f412ee7ae5529364ed50172ca0220fd64591e236296f45f36b38b2f98"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
  "syn-mid",
  "version_check 0.9.1",
 ]
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -764,9 +764,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -800,7 +800,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
 ]
 
 [[package]]
@@ -852,9 +852,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
+checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -921,9 +921,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
+checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 dependencies = [
  "serde_derive",
 ]
@@ -939,13 +939,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
+checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -994,9 +994,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"
+checksum = "ff6da2e8d107dfd7b74df5ef4d205c6aebee0706c647f6bc6a2d5789905c00fb"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1005,15 +1005,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88b8e18c69496aad6f9ddf4630dd7d585bcaf765786cb415b9aec2fe5a0430"
+checksum = "a489c87c08fbaf12e386665109dd13470dcc9c4583ea3e10dd2b4523e5ebd9ac"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1029,11 +1029,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
+checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
@@ -1044,9 +1044,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -1055,9 +1055,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.16",
+ "syn 1.0.17",
  "unicode-xid 0.2.0",
 ]
 
@@ -1240,9 +1240,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
+checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = "0.10.0"
+parsec-interface = "0.12.0"
 rand = "0.7.2"
 base64 = "0.10.1"
 uuid = "0.7.4"
@@ -40,7 +40,7 @@ derivative = "1.0.3"
 version = "3.0.0"
 
 [dev-dependencies]
-parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.2.0" }
+parsec-client-test = { git = "https://github.com/parallaxsecond/parsec-client-test", tag = "0.2.2" }
 num_cpus = "1.10.1"
 
 [build-dependencies]

--- a/src/key_id_managers/mod.rs
+++ b/src/key_id_managers/mod.rs
@@ -12,17 +12,18 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//! Persistent mapping between key triples and key IDs
+//! Persistent mapping between key triples and key information
 //!
 //! This module declares a [`ManageKeyIDs`](https://parallaxsecond.github.io/parsec-book/parsec_service/key_id_managers.html)
 //! trait to help providers to store in a persistent manner the mapping between the name and the
-//! IDs of the keys they manage. Different implementors might store this mapping using different
+//! information of the keys they manage. Different implementors might store this mapping using different
 //! means but it has to be persistent.
 
 use crate::authenticators::ApplicationName;
 use log::error;
+use parsec_interface::operations::psa_key_attributes::KeyAttributes;
 use parsec_interface::requests::{ProviderID, ResponseStatus};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 pub mod on_disk_manager;
@@ -58,6 +59,15 @@ impl fmt::Display for KeyTriple {
     }
 }
 
+/// Information stored about a key
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct KeyInfo {
+    /// Reference to a key in the Provider
+    pub id: Vec<u8>,
+    /// Attributes of a key
+    pub attributes: KeyAttributes,
+}
+
 impl KeyTriple {
     /// Creates a new instance of KeyTriple.
     pub fn new(app_name: ApplicationName, provider_id: ProviderID, key_name: String) -> KeyTriple {
@@ -84,17 +94,17 @@ pub fn to_response_status(error_string: String) -> ResponseStatus {
     ResponseStatus::KeyIDManagerError
 }
 
-/// Management interface for key name to ID mapping
+/// Management interface for key name to key info mapping
 ///
-/// Interface to be implemented for persistent storage of key name -> key ID mappings.
+/// Interface to be implemented for persistent storage of key name -> key info mappings.
 pub trait ManageKeyIDs {
-    /// Returns a reference to the key ID corresponding to this key triple or `None` if it does not
+    /// Returns a reference to the key info corresponding to this key triple or `None` if it does not
     /// exist.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key ID Manager.
-    fn get(&self, key_triple: &KeyTriple) -> Result<Option<&[u8]>, String>;
+    fn get(&self, key_triple: &KeyTriple) -> Result<Option<&KeyInfo>, String>;
 
     /// Returns a Vec of reference to the key triples corresponding to this provider.
     ///
@@ -103,14 +113,17 @@ pub trait ManageKeyIDs {
     /// Returns an error as a String if there was a problem accessing the Key ID Manager.
     fn get_all(&self, provider_id: ProviderID) -> Result<Vec<&KeyTriple>, String>;
 
-    /// Inserts a new mapping between the key triple and the key ID. If the triple already exists,
-    /// overwrite the existing mapping and returns the old Key ID. Otherwise returns `None`.
+    /// Inserts a new mapping between the key triple and the key info. If the triple already exists,
+    /// overwrite the existing mapping and returns the old `KeyInfo`. Otherwise returns `None`.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key ID Manager.
-    fn insert(&mut self, key_triple: KeyTriple, key_id: Vec<u8>)
-        -> Result<Option<Vec<u8>>, String>;
+    fn insert(
+        &mut self,
+        key_triple: KeyTriple,
+        key_info: KeyInfo,
+    ) -> Result<Option<KeyInfo>, String>;
 
     /// Removes a key triple mapping and returns it. Does nothing and returns `None` if the mapping
     /// does not exist.
@@ -118,7 +131,7 @@ pub trait ManageKeyIDs {
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key ID Manager.
-    fn remove(&mut self, key_triple: &KeyTriple) -> Result<Option<Vec<u8>>, String>;
+    fn remove(&mut self, key_triple: &KeyTriple) -> Result<Option<KeyInfo>, String>;
 
     /// Check if a key triple mapping exists.
     ///

--- a/src/providers/mbed_provider/utils.rs
+++ b/src/providers/mbed_provider/utils.rs
@@ -254,10 +254,6 @@ impl KeyAttributes {
     pub unsafe fn reset(&mut self) {
         psa_crypto_binding::psa_reset_key_attributes(&mut self.0);
     }
-
-    pub fn raw(&self) -> psa_key_attributes_t {
-        self.0
-    }
 }
 
 impl AsRef<psa_key_attributes_t> for KeyAttributes {

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -153,11 +153,15 @@ else
     if [ "$PROVIDER_NAME" = "mbed-crypto" ]; then
         echo "Create a fake mapping file for Mbed Provider"
         mkdir -p mappings/cm9vdA==/1
-        printf '\xe0\x19\xb2\x5c' > mappings/cm9vdA==/1/VGVzdCBLZXk\=
+        printf '\x04\x00\x00\x00\x00\x00\x00\x00\xd6\xcb\xf8\x23\x09\x00\x00\x00' > mappings/cm9vdA==/1/VGVzdCBLZXk\=
+        printf '\x00\x04\x00\x00\x01\x00\x00\x00\x00\x01\x01\x01\x01\x00\x05\x00' >> mappings/cm9vdA==/1/VGVzdCBLZXk\=
+        printf '\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00' >> mappings/cm9vdA==/1/VGVzdCBLZXk\=
     elif [ "$PROVIDER_NAME" = "pkcs11" ]; then
         echo "Create a fake mapping file for PKCS 11 Provider"
         mkdir -p mappings/cm9vdA==/2
-        printf '\xe0\x19\xb2\x5c' > mappings/cm9vdA==/2/VGVzdCBLZXk\=
+        printf '\x04\x00\x00\x00\x00\x00\x00\x00\xd6\xcb\xf8\x23\x09\x00\x00\x00' > mappings/cm9vdA==/2/VGVzdCBLZXk\=
+        printf '\x00\x04\x00\x00\x01\x00\x00\x00\x00\x01\x01\x01\x01\x00\x05\x00' >> mappings/cm9vdA==/2/VGVzdCBLZXk\=
+        printf '\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00' >> mappings/cm9vdA==/2/VGVzdCBLZXk\=
     fi
 
     echo "Trigger a configuration reload to load the new mappings"

--- a/tests/per_provider/normal_tests/key_attributes.rs
+++ b/tests/per_provider/normal_tests/key_attributes.rs
@@ -5,8 +5,9 @@ use parsec_interface::operations::psa_algorithm::{Algorithm, AsymmetricSignature
 use parsec_interface::operations::psa_key_attributes::{
     KeyAttributes, KeyPolicy, KeyType, UsageFlags,
 };
-use parsec_interface::requests::ResponseStatus;
+use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus};
 
+// Ignored as only RSA key types are supported for now.
 #[ignore]
 #[test]
 fn wrong_type() {
@@ -49,7 +50,6 @@ fn wrong_type() {
     assert_eq!(status, ResponseStatus::PsaErrorNotPermitted);
 }
 
-#[ignore]
 #[test]
 fn wrong_usage_flags() {
     let mut client = TestClient::new();
@@ -91,7 +91,6 @@ fn wrong_usage_flags() {
     assert_eq!(status, ResponseStatus::PsaErrorNotPermitted);
 }
 
-#[ignore]
 #[test]
 fn wrong_permitted_algorithm() {
     let mut client = TestClient::new();
@@ -120,9 +119,16 @@ fn wrong_permitted_algorithm() {
         },
     };
 
+    // The Mbed Crypto provider currently does not support other algorithms than the RSA PKCS 1v15
+    // signing algorithm with hash when checking policies only.
+    if client.get_cached_provider(Opcode::PsaSignHash) == ProviderID::MbedCrypto {
+        return;
+    }
+
     client
         .generate_key(key_name.clone(), key_attributes)
         .unwrap();
+
     let status = client
         .sign_with_rsa_sha256(key_name, vec![0xDE, 0xAD, 0xBE, 0xEF])
         .unwrap_err();


### PR DESCRIPTION
The KeyIDManager also needs to store the KeyAttributes of the key. It
will eventually be renamed KeyInfoManager in a later commit.
Uses methods on KeyAttributes to check if an operation is permitted and
compatible with the type of the key.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>