### PR TITLE
Rename key ID to key info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,9 +622,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "parsec-client"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3832239b87248521954be6117ea958212bfc93f9cbe9abac66696928699e08cc"
+checksum = "4b8437134e1f22cd1dd0267a3052dd8c17df582fbbf1363c91e80e415786953c"
 dependencies = [
  "derivative",
  "log",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "parsec-interface"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e87877b00d360536d09d4e8a12a637b6458fec56f5d4fe6c375b43fc4e25245"
+checksum = "fd624e1236194a6ee915f7b54f03c6e94a7d4b8a63062db65397c3af25b323eb"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = "0.13.0"
+parsec-interface = "0.14.0"
 rand = "0.7.2"
 base64 = "0.10.1"
 uuid = "0.7.4"
@@ -45,8 +45,8 @@ picky-asn1-der = "0.2.2"
 picky-asn1 = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.1"
-parsec-client = "0.1.0"
-parsec-interface = { version = "0.13.0", features = ["testing"] }
+parsec-client = "0.2.0"
+parsec-interface = { version = "0.14.0", features = ["testing"] }
 
 [build-dependencies]
 bindgen = "0.50.0"

--- a/config.toml
+++ b/config.toml
@@ -30,13 +30,13 @@ listener_type = "DomainSocket"
 # timeout expires, the connection is dropped.
 timeout = 200 # in milliseconds
 
-# (Required) Configuration for the components managing key IDs for providers.
+# (Required) Configuration for the components managing key info for providers.
 # Defined as an array of tables: https://github.com/toml-lang/toml#user-content-array-of-tables
 [[key_manager]]
-# (Required) Name of the key ID manager. Used to tie providers to the manager supporting them.
+# (Required) Name of the key info manager. Used to tie providers to the manager supporting them.
 name = "on-disk-manager"
 
-# (Required) Type of key ID manager to be used.
+# (Required) Type of key info manager to be used.
 manager_type = "OnDisk"
 
 # Path to the location where the mapping will be persisted (in this case, the filesystem path)
@@ -48,13 +48,13 @@ manager_type = "OnDisk"
 # (Required) Type of provider.
 provider_type = "MbedCrypto"
 
-# (Required) Name of key ID manager that will support this provider.
-key_id_manager = "on-disk-manager"
+# (Required) Name of key info manager that will support this provider.
+key_info_manager = "on-disk-manager"
 
 # Example of a PKCS 11 provider configuration
 #[[provider]]
 #provider_type = "Pkcs11"
-#key_id_manager = "on-disk-manager"
+#key_info_manager = "on-disk-manager"
 # (Required for this provider) Path to the location of the dynamic library loaded by this provider.
 # For the PKCS 11 provider, this library implements the PKCS 11 API on the target platform.
 #library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
@@ -67,7 +67,7 @@ key_id_manager = "on-disk-manager"
 # Example of a TPM provider configuration
 #[[provider]]
 #provider_type = "Tpm"
-#key_id_manager = "on-disk-manager"
+#key_info_manager = "on-disk-manager"
 # (Required) TPM TCTI device to use with this provider. Options are:
 # - "device": uses the TPM device on /dev/tpm0
 # - "mssim": uses the simulation TPM with the socket

--- a/fuzz/config.toml
+++ b/fuzz/config.toml
@@ -10,16 +10,16 @@ manager_type = "OnDisk"
 
 [[provider]]
 provider_type = "MbedProvider"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"
 
 [[provider]]
 provider_type = "TpmProvider"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"
 tcti = "mssim"
 
 [[provider]]
 provider_type = "Pkcs11Provider"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to be added by the find_slot_number.sh script

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Persistent mapping between key triples and key information
 //!
-//! This module declares a [`ManageKeyIDs`](https://parallaxsecond.github.io/parsec-book/parsec_service/key_id_managers.html)
+//! This module declares a [`ManageKeyInfo`](https://parallaxsecond.github.io/parsec-book/parsec_service/key_info_managers.html)
 //! trait to help providers to store in a persistent manner the mapping between the name and the
 //! information of the keys they manage. Different implementors might store this mapping using different
 //! means but it has to be persistent.
@@ -17,14 +17,14 @@ use std::fmt;
 pub mod on_disk_manager;
 
 #[derive(Copy, Clone, Deserialize, Debug)]
-pub enum KeyIdManagerType {
+pub enum KeyInfoManagerType {
     OnDisk,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct KeyIdManagerConfig {
+pub struct KeyInfoManagerConfig {
     pub name: String,
-    pub manager_type: KeyIdManagerType,
+    pub manager_type: KeyInfoManagerType,
     pub store_path: Option<String>,
 }
 
@@ -72,33 +72,33 @@ impl KeyTriple {
     }
 }
 
-/// Converts the error string returned by the ManageKeyIDs methods to
-/// ResponseStatus::KeyIDManagerError.
+/// Converts the error string returned by the ManageKeyInfo methods to
+/// ResponseStatus::KeyInfoManagerError.
 pub fn to_response_status(error_string: String) -> ResponseStatus {
     error!(
-        "Converting error string \"{}\" to ResponseStatus:KeyIDManagerError.",
+        "Converting error string \"{}\" to ResponseStatus:KeyInfoManagerError.",
         error_string
     );
-    ResponseStatus::KeyIDManagerError
+    ResponseStatus::KeyInfoManagerError
 }
 
 /// Management interface for key name to key info mapping
 ///
 /// Interface to be implemented for persistent storage of key name -> key info mappings.
-pub trait ManageKeyIDs {
+pub trait ManageKeyInfo {
     /// Returns a reference to the key info corresponding to this key triple or `None` if it does not
     /// exist.
     ///
     /// # Errors
     ///
-    /// Returns an error as a String if there was a problem accessing the Key ID Manager.
+    /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn get(&self, key_triple: &KeyTriple) -> Result<Option<&KeyInfo>, String>;
 
     /// Returns a Vec of reference to the key triples corresponding to this provider.
     ///
     /// # Errors
     ///
-    /// Returns an error as a String if there was a problem accessing the Key ID Manager.
+    /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn get_all(&self, provider_id: ProviderID) -> Result<Vec<&KeyTriple>, String>;
 
     /// Inserts a new mapping between the key triple and the key info. If the triple already exists,
@@ -106,7 +106,7 @@ pub trait ManageKeyIDs {
     ///
     /// # Errors
     ///
-    /// Returns an error as a String if there was a problem accessing the Key ID Manager.
+    /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn insert(
         &mut self,
         key_triple: KeyTriple,
@@ -118,13 +118,13 @@ pub trait ManageKeyIDs {
     ///
     /// # Errors
     ///
-    /// Returns an error as a String if there was a problem accessing the Key ID Manager.
+    /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn remove(&mut self, key_triple: &KeyTriple) -> Result<Option<KeyInfo>, String>;
 
     /// Check if a key triple mapping exists.
     ///
     /// # Errors
     ///
-    /// Returns an error as a String if there was a problem accessing the Key ID Manager.
+    /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn exists(&self, key_triple: &KeyTriple) -> Result<bool, String>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,6 @@
 pub mod authenticators;
 pub mod back;
 pub mod front;
-pub mod key_id_managers;
+pub mod key_info_managers;
 pub mod providers;
 pub mod utils;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -28,16 +28,16 @@ pub mod tpm_provider;
 #[serde(tag = "provider_type")]
 pub enum ProviderConfig {
     MbedCrypto {
-        key_id_manager: String,
+        key_info_manager: String,
     },
     Pkcs11 {
-        key_id_manager: String,
+        key_info_manager: String,
         library_path: String,
         slot_number: usize,
         user_pin: Option<String>,
     },
     Tpm {
-        key_id_manager: String,
+        key_info_manager: String,
         tcti: String,
         owner_hierarchy_auth: String,
     },
@@ -46,17 +46,20 @@ pub enum ProviderConfig {
 use self::ProviderConfig::{MbedCrypto, Pkcs11, Tpm};
 
 impl ProviderConfig {
-    pub fn key_id_manager(&self) -> &String {
+    pub fn key_info_manager(&self) -> &String {
         match *self {
             MbedCrypto {
-                ref key_id_manager, ..
-            } => key_id_manager,
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
             Pkcs11 {
-                ref key_id_manager, ..
-            } => key_id_manager,
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
             Tpm {
-                ref key_id_manager, ..
-            } => key_id_manager,
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
         }
     }
     pub fn provider_id(&self) -> ProviderID {

--- a/tests/all_providers/config.toml
+++ b/tests/all_providers/config.toml
@@ -12,17 +12,17 @@ manager_type = "OnDisk"
 
 [[provider]]
 provider_type = "MbedCrypto"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"
 
 [[provider]]
 provider_type = "Tpm"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "tpm_pass"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to be added by the find_slot_number.sh script

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -137,7 +137,7 @@ else
     RUST_BACKTRACE=1 cargo test $FEATURES persistent_before
 
     # Create a fake mapping file for the root application, the provider and a
-    # key name of "Test Key". It contains a valid PSA Key ID.
+    # key name of "Test Key". It contains a valid KeyInfo structure.
     # It is tested in test "should_have_been_deleted".
     # This test does not make sense for the TPM provider.
     if [ "$PROVIDER_NAME" = "mbed-crypto" ]; then

--- a/tests/per_provider/normal_tests/basic.rs
+++ b/tests/per_provider/normal_tests/basic.rs
@@ -10,7 +10,7 @@ fn invalid_provider() {
     let mut req_hdr = RawHeader::new();
 
     req_hdr.provider = 0xff;
-    req_hdr.opcode = Opcode::Ping as u16;
+    req_hdr.opcode = Opcode::Ping as u32;
 
     let resp = client
         .send_raw_request(req_hdr, Vec::new())
@@ -25,7 +25,7 @@ fn invalid_content_type() {
     let mut req_hdr = RawHeader::new();
 
     req_hdr.provider = ProviderID::Core as u8;
-    req_hdr.opcode = Opcode::Ping as u16;
+    req_hdr.opcode = Opcode::Ping as u32;
     req_hdr.content_type = 0xff;
 
     let resp = client
@@ -41,7 +41,7 @@ fn invalid_accept_type() {
     let mut req_hdr = RawHeader::new();
 
     req_hdr.provider = ProviderID::Core as u8;
-    req_hdr.opcode = Opcode::Ping as u16;
+    req_hdr.opcode = Opcode::Ping as u32;
 
     req_hdr.accept_type = 0xff;
 
@@ -58,7 +58,7 @@ fn invalid_body_len() {
     let mut req_hdr = RawHeader::new();
 
     req_hdr.provider = ProviderID::Core as u8;
-    req_hdr.opcode = Opcode::Ping as u16;
+    req_hdr.opcode = Opcode::Ping as u32;
 
     req_hdr.body_len = 0xff_ff;
 
@@ -74,7 +74,7 @@ fn invalid_auth_len() {
     let mut req_hdr = RawHeader::new();
 
     req_hdr.provider = ProviderID::Core as u8;
-    req_hdr.opcode = Opcode::Ping as u16;
+    req_hdr.opcode = Opcode::Ping as u32;
 
     req_hdr.auth_len = 0xff_ff;
 

--- a/tests/per_provider/provider_cfg/mbed-crypto/config.toml
+++ b/tests/per_provider/provider_cfg/mbed-crypto/config.toml
@@ -14,4 +14,4 @@ manager_type = "OnDisk"
 
 [[provider]]
 provider_type = "MbedCrypto"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"

--- a/tests/per_provider/provider_cfg/pkcs11/config.toml
+++ b/tests/per_provider/provider_cfg/pkcs11/config.toml
@@ -14,7 +14,7 @@ manager_type = "OnDisk"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to be added by the find_slot_number.sh script

--- a/tests/per_provider/provider_cfg/tpm/config.toml
+++ b/tests/per_provider/provider_cfg/tpm/config.toml
@@ -14,6 +14,6 @@ manager_type = "OnDisk"
 
 [[provider]]
 provider_type = "Tpm"
-key_id_manager = "on-disk-manager"
+key_info_manager = "on-disk-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "tpm_pass"


### PR DESCRIPTION
Does the following renaming, when it makes sense:
* key ID -> key info
* KeyID -> KeyInfo
* key_id -> key_info

See #147

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>