### PR TITLE
Split provider code into separate modules

### DIFF
--- a/src/providers/mbed_provider/asym_sign.rs
+++ b/src/providers/mbed_provider/asym_sign.rs
@@ -1,0 +1,125 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::constants::PSA_SUCCESS;
+use super::utils::{self, KeyHandle};
+use super::{key_management, psa_crypto_binding, MbedProvider};
+use crate::authenticators::ApplicationName;
+use crate::key_info_managers::KeyTriple;
+use log::{error, info};
+use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
+use parsec_interface::requests::{ProviderID, Result};
+
+impl MbedProvider {
+    pub(super) fn psa_sign_hash_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_sign_hash::Operation,
+    ) -> Result<psa_sign_hash::Result> {
+        info!("Mbed Provider - Asym Sign");
+        let _semaphore_guard = self.key_slot_semaphore.access();
+        let key_name = op.key_name;
+        let hash = op.hash;
+        let alg = op.alg;
+        let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let key_id = key_management::get_key_id(&key_triple, &*store_handle)?;
+
+        let _guard = self
+            .key_handle_mutex
+            .lock()
+            .expect("Grabbing key handle mutex failed");
+
+        let mut key_handle;
+        let mut key_attrs;
+        // Safety:
+        //   * at this point the provider has been instantiated so Mbed Crypto has been initialized
+        //   * self.key_handle_mutex prevents concurrent accesses
+        //   * self.key_slot_semaphore prevents overflowing key slots
+        unsafe {
+            key_handle = KeyHandle::open(key_id)?;
+            key_attrs = key_handle.attributes()?;
+        }
+
+        let buffer_size = utils::psa_asymmetric_sign_output_size(key_attrs.as_ref())?;
+        let mut signature = vec![0u8; buffer_size];
+        let mut signature_size: usize = 0;
+
+        let sign_status;
+        // Safety: same conditions than above.
+        unsafe {
+            sign_status = psa_crypto_binding::psa_asymmetric_sign(
+                key_handle.raw(),
+                utils::convert_algorithm(&alg.into())?,
+                hash.as_ptr(),
+                hash.len(),
+                signature.as_mut_ptr(),
+                buffer_size,
+                &mut signature_size,
+            );
+            key_attrs.reset();
+            key_handle.close()?;
+        };
+
+        if sign_status == PSA_SUCCESS {
+            let mut res = psa_sign_hash::Result {
+                signature: Vec::new(),
+            };
+            res.signature.resize(signature_size, 0);
+            res.signature.copy_from_slice(&signature[0..signature_size]);
+
+            Ok(res)
+        } else {
+            error!("Sign status: {}", sign_status);
+            Err(utils::convert_status(sign_status))
+        }
+    }
+
+    pub(super) fn psa_verify_hash_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_verify_hash::Operation,
+    ) -> Result<psa_verify_hash::Result> {
+        info!("Mbed Provider - Asym Verify");
+        let _semaphore_guard = self.key_slot_semaphore.access();
+        let key_name = op.key_name;
+        let hash = op.hash;
+        let alg = op.alg;
+        let signature = op.signature;
+        let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let key_id = key_management::get_key_id(&key_triple, &*store_handle)?;
+
+        let _guard = self
+            .key_handle_mutex
+            .lock()
+            .expect("Grabbing key handle mutex failed");
+
+        let mut key_handle;
+        let mut key_attrs;
+        let verify_status;
+        // Safety:
+        //   * at this point the provider has been instantiated so Mbed Crypto has been initialized
+        //   * self.key_handle_mutex prevents concurrent accesses
+        //   * self.key_slot_semaphore prevents overflowing key slots
+        unsafe {
+            key_handle = KeyHandle::open(key_id)?;
+            key_attrs = key_handle.attributes()?;
+            verify_status = psa_crypto_binding::psa_asymmetric_verify(
+                key_handle.raw(),
+                utils::convert_algorithm(&alg.into())?,
+                hash.as_ptr(),
+                hash.len(),
+                signature.as_ptr(),
+                signature.len(),
+            );
+            key_attrs.reset();
+            key_handle.close()?;
+        }
+
+        if verify_status == PSA_SUCCESS {
+            Ok(psa_verify_hash::Result {})
+        } else {
+            Err(utils::convert_status(verify_status))
+        }
+    }
+}

--- a/src/providers/mbed_provider/key_management.rs
+++ b/src/providers/mbed_provider/key_management.rs
@@ -1,0 +1,323 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::constants::{PSA_MAX_PERSISTENT_KEY_IDENTIFIER, PSA_SUCCESS};
+use super::psa_crypto_binding::{self, psa_key_id_t};
+use super::utils::{self, KeyHandle};
+use super::{LocalIdStore, MbedProvider};
+use crate::authenticators::ApplicationName;
+use crate::key_info_managers;
+use crate::key_info_managers::{KeyInfo, KeyTriple, ManageKeyInfo};
+use log::{error, info, warn};
+use parsec_interface::operations::psa_key_attributes::KeyAttributes;
+use parsec_interface::operations::{
+    psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
+};
+use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
+
+/// Gets a PSA Key ID from the Key Info Manager.
+/// Wrapper around the get method of the Key Info Manager to convert the key ID to the psa_key_id_t
+/// type.
+pub fn get_key_id(
+    key_triple: &KeyTriple,
+    store_handle: &dyn ManageKeyInfo,
+) -> Result<psa_key_id_t> {
+    match store_handle.get(key_triple) {
+        Ok(Some(key_info)) => {
+            if key_info.id.len() == 4 {
+                let mut dst = [0; 4];
+                dst.copy_from_slice(&key_info.id);
+                Ok(u32::from_ne_bytes(dst))
+            } else {
+                error!("Stored Key ID is not valid.");
+                Err(ResponseStatus::KeyInfoManagerError)
+            }
+        }
+        Ok(None) => Err(ResponseStatus::PsaErrorDoesNotExist),
+        Err(string) => Err(key_info_managers::to_response_status(string)),
+    }
+}
+
+/// Creates a new PSA Key ID and stores it in the Key Info Manager.
+fn create_key_id(
+    key_triple: KeyTriple,
+    key_attributes: KeyAttributes,
+    store_handle: &mut dyn ManageKeyInfo,
+    local_ids_handle: &mut LocalIdStore,
+) -> Result<psa_key_id_t> {
+    let mut key_id = rand::random::<psa_key_id_t>();
+    while local_ids_handle.contains(&key_id)
+        || key_id == 0
+        || key_id > PSA_MAX_PERSISTENT_KEY_IDENTIFIER
+    {
+        key_id = rand::random::<psa_key_id_t>();
+    }
+    let key_info = KeyInfo {
+        id: key_id.to_ne_bytes().to_vec(),
+        attributes: key_attributes,
+    };
+    match store_handle.insert(key_triple.clone(), key_info) {
+        Ok(insert_option) => {
+            if insert_option.is_some() {
+                warn!("Overwriting Key triple mapping ({})", key_triple);
+            }
+            let _ = local_ids_handle.insert(key_id);
+
+            Ok(key_id)
+        }
+        Err(string) => Err(key_info_managers::to_response_status(string)),
+    }
+}
+
+fn remove_key_id(
+    key_triple: &KeyTriple,
+    key_id: psa_key_id_t,
+    store_handle: &mut dyn ManageKeyInfo,
+    local_ids_handle: &mut LocalIdStore,
+) -> Result<()> {
+    match store_handle.remove(key_triple) {
+        Ok(_) => {
+            let _ = local_ids_handle.remove(&key_id);
+            Ok(())
+        }
+        Err(string) => Err(key_info_managers::to_response_status(string)),
+    }
+}
+
+pub fn key_info_exists(key_triple: &KeyTriple, store_handle: &dyn ManageKeyInfo) -> Result<bool> {
+    store_handle
+        .exists(key_triple)
+        .or_else(|e| Err(key_info_managers::to_response_status(e)))
+}
+
+impl MbedProvider {
+    pub(super) fn psa_generate_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_generate_key::Operation,
+    ) -> Result<psa_generate_key::Result> {
+        info!("Mbed Provider - Create Key");
+        let _semaphore_guard = self.key_slot_semaphore.access();
+        let key_name = op.key_name;
+        let key_attributes = op.attributes;
+        let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        if key_info_exists(&key_triple, &*store_handle)? {
+            return Err(ResponseStatus::PsaErrorAlreadyExists);
+        }
+        let key_id = create_key_id(
+            key_triple.clone(),
+            key_attributes,
+            &mut *store_handle,
+            &mut local_ids_handle,
+        )?;
+
+        let key_attrs = utils::convert_key_attributes(&key_attributes, key_id).or_else(|e| {
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            error!("Failed converting key attributes.");
+            Err(e)
+        })?;
+
+        let _guard = self
+            .key_handle_mutex
+            .lock()
+            .expect("Grabbing key handle mutex failed");
+
+        // Safety:
+        //   * at this point the provider has been instantiated so Mbed Crypto has been initialized
+        //   * self.key_handle_mutex prevents concurrent accesses
+        //   * self.key_slot_semaphore prevents overflowing key slots
+        let mut key_handle = unsafe { KeyHandle::generate(&key_attrs) }.or_else(|e| {
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            error!("Generate key status: {}", e);
+            Err(e)
+        })?;
+
+        // Safety: same conditions than above.
+        unsafe {
+            key_handle.close()?;
+        }
+
+        Ok(psa_generate_key::Result {})
+    }
+
+    pub(super) fn psa_import_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_import_key::Operation,
+    ) -> Result<psa_import_key::Result> {
+        info!("Mbed Provider - Import Key");
+        let _semaphore_guard = self.key_slot_semaphore.access();
+        let key_name = op.key_name;
+        let key_attributes = op.attributes;
+        let key_data = op.data;
+        let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        if key_info_exists(&key_triple, &*store_handle)? {
+            return Err(ResponseStatus::PsaErrorAlreadyExists);
+        }
+        let key_id = create_key_id(
+            key_triple.clone(),
+            key_attributes,
+            &mut *store_handle,
+            &mut local_ids_handle,
+        )?;
+
+        let key_attrs = utils::convert_key_attributes(&key_attributes, key_id).or_else(|e| {
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            error!("Failed converting key attributes.");
+            Err(e)
+        })?;
+
+        let _guard = self
+            .key_handle_mutex
+            .lock()
+            .expect("Grabbing key handle mutex failed");
+
+        // Safety:
+        //   * at this point the provider has been instantiated so Mbed Crypto has been initialized
+        //   * self.key_handle_mutex prevents concurrent accesses
+        //   * self.key_slot_semaphore prevents overflowing key slots
+        let mut key_handle = unsafe { KeyHandle::import(&key_attrs, key_data) }.or_else(|e| {
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            error!("Import key status: {}", e);
+            Err(e)
+        })?;
+
+        // Safety: same conditions than above.
+        unsafe {
+            key_handle.close()?;
+        }
+
+        Ok(psa_import_key::Result {})
+    }
+
+    pub(super) fn psa_export_public_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_export_public_key::Operation,
+    ) -> Result<psa_export_public_key::Result> {
+        info!("Mbed Provider - Export Public Key");
+        let _semaphore_guard = self.key_slot_semaphore.access();
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let key_id = get_key_id(&key_triple, &*store_handle)?;
+
+        let _guard = self
+            .key_handle_mutex
+            .lock()
+            .expect("Grabbing key handle mutex failed");
+
+        let mut key_handle;
+        let mut key_attrs;
+        // Safety:
+        //   * at this point the provider has been instantiated so Mbed Crypto has been initialized
+        //   * self.key_handle_mutex prevents concurrent accesses
+        //   * self.key_slot_semaphore prevents overflowing key slots
+        unsafe {
+            key_handle = KeyHandle::open(key_id)?;
+            key_attrs = key_handle.attributes()?;
+        }
+
+        let buffer_size = utils::psa_export_public_key_size(key_attrs.as_ref())?;
+        let mut buffer = vec![0u8; buffer_size];
+        let mut actual_size = 0;
+
+        let export_status;
+        // Safety: same conditions than above.
+        unsafe {
+            export_status = psa_crypto_binding::psa_export_public_key(
+                key_handle.raw(),
+                buffer.as_mut_ptr(),
+                buffer_size,
+                &mut actual_size,
+            );
+            key_attrs.reset();
+            key_handle.close()?;
+        };
+
+        if export_status != PSA_SUCCESS {
+            error!("Export status: {}", export_status);
+            // Safety: same conditions than above.
+            return Err(utils::convert_status(export_status));
+        }
+
+        buffer.resize(actual_size, 0);
+        Ok(psa_export_public_key::Result { data: buffer })
+    }
+
+    pub(super) fn psa_destroy_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_destroy_key::Operation,
+    ) -> Result<psa_destroy_key::Result> {
+        info!("Mbed Provider - Destroy Key");
+        let _semaphore_guard = self.key_slot_semaphore.access();
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        let key_id = get_key_id(&key_triple, &*store_handle)?;
+
+        let _guard = self
+            .key_handle_mutex
+            .lock()
+            .expect("Grabbing key handle mutex failed");
+
+        let key_handle;
+        let destroy_key_status;
+
+        // Safety:
+        //   * at this point the provider has been instantiated so Mbed Crypto has been initialized
+        //   * self.key_handle_mutex prevents concurrent accesses
+        //   * self.key_slot_semaphore prevents overflowing key slots
+        unsafe {
+            key_handle = KeyHandle::open(key_id)?;
+            destroy_key_status = psa_crypto_binding::psa_destroy_key(key_handle.raw());
+        }
+
+        if destroy_key_status == PSA_SUCCESS {
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            Ok(psa_destroy_key::Result {})
+        } else {
+            error!("Destroy key status: {}", destroy_key_status);
+            Err(utils::convert_status(destroy_key_status))
+        }
+    }
+}

--- a/src/providers/pkcs11_provider/asym_sign.rs
+++ b/src/providers/pkcs11_provider/asym_sign.rs
@@ -1,0 +1,192 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::Pkcs11Provider;
+use super::{key_management::get_key_info, utils, KeyPairType, ReadWriteSession, Session};
+use crate::authenticators::ApplicationName;
+use crate::key_info_managers::KeyTriple;
+use log::{error, info};
+use parsec_interface::operations::psa_algorithm::*;
+use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
+use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
+use pkcs11::types::CK_MECHANISM;
+
+impl Pkcs11Provider {
+    pub(super) fn psa_sign_hash_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_sign_hash::Operation,
+    ) -> Result<psa_sign_hash::Result> {
+        info!("Pkcs11 Provider - Asym Sign");
+
+        let key_name = op.key_name;
+        let mut hash = op.hash;
+        let alg = op.alg;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+
+        key_attributes.can_sign_hash()?;
+        key_attributes.permits_alg(alg.into())?;
+        key_attributes.compatible_with_alg(alg.into())?;
+
+        match alg {
+            AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            } => (),
+            _ => {
+                error!(
+                    "The PKCS 11 provider currently only supports \"RSA PKCS#1 v1.5 signature with hashing\" algorithm with SHA-256 as hashing algorithm for the PsaSignHash operation.");
+                return Err(ResponseStatus::PsaErrorNotSupported);
+            }
+        }
+
+        if alg
+            != (AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            })
+        {
+            error!(
+                "The PKCS 11 provider currently only supports signature algorithm to be RSA PKCS#1 v1.5 and the text hashed with SHA-256.");
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        if hash.len() != 32 {
+            error!("The SHA-256 hash must be 32 bytes long.");
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        let mech = CK_MECHANISM {
+            mechanism: pkcs11::types::CKM_RSA_PKCS,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
+        info!("Asymmetric sign in session {}", session.session_handle());
+
+        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PrivateKey)?;
+        info!("Located signing key.");
+
+        match self.backend.sign_init(session.session_handle(), &mech, key) {
+            Ok(_) => {
+                info!("Signing operation initialized.");
+
+                // Build a valid ASN.1 DigestInfo DER-encoded structure by appending the hash to a
+                // DigestAlgorithmIdentifier value representing the SHA256 OID with no parameters.
+                // The OID used is: "2.16.840.1.101.3.4.2.1".
+                // It would be better to use the DigestInfo structure defined in this file but the
+                // AlgorithmIdentifier structure does not currently support the simple SHA256 OID.
+                // See Devolutions/picky-rs#19
+                let mut digest_info = vec![
+                    0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04,
+                    0x02, 0x01, 0x05, 0x00, 0x04, 0x20,
+                ];
+                digest_info.append(&mut hash);
+
+                match self.backend.sign(session.session_handle(), &digest_info) {
+                    Ok(signature) => Ok(psa_sign_hash::Result { signature }),
+                    Err(e) => {
+                        error!("Failed to execute signing operation. Error: {}", e);
+                        Err(utils::to_response_status(e))
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to initialize signing operation. Error: {}", e);
+                Err(utils::to_response_status(e))
+            }
+        }
+    }
+
+    pub(super) fn psa_verify_hash_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_verify_hash::Operation,
+    ) -> Result<psa_verify_hash::Result> {
+        info!("Pkcs11 Provider - Asym Verify");
+
+        let key_name = op.key_name;
+        let mut hash = op.hash;
+        let signature = op.signature;
+        let alg = op.alg;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+
+        key_attributes.can_verify_hash()?;
+        key_attributes.permits_alg(alg.into())?;
+        key_attributes.compatible_with_alg(alg.into())?;
+
+        match alg {
+            AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            } => (),
+            _ => {
+                error!(
+                    "The PKCS 11 provider currently only supports \"RSA PKCS#1 v1.5 signature with hashing\" algorithm with SHA-256 as hashing algorithm for the PsaVerifyHash operation.");
+                return Err(ResponseStatus::PsaErrorNotSupported);
+            }
+        }
+
+        if alg
+            != (AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            })
+        {
+            error!(
+                "The PKCS 11 provider currently only supports signature algorithm to be RSA PKCS#1 v1.5 and the text hashed with SHA-256.");
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        if hash.len() != 32 {
+            error!("The SHA-256 hash must be 32 bytes long.");
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        let mech = CK_MECHANISM {
+            // Verify without hashing.
+            mechanism: pkcs11::types::CKM_RSA_PKCS,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
+        info!("Asymmetric verify in session {}", session.session_handle());
+
+        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PublicKey)?;
+        info!("Located public key.");
+
+        match self
+            .backend
+            .verify_init(session.session_handle(), &mech, key)
+        {
+            Ok(_) => {
+                info!("Verify operation initialized.");
+
+                // Build a valid ASN.1 DigestInfo DER-encoded structure by appending the hash to a
+                // DigestAlgorithmIdentifier value representing the SHA256 OID with no parameters.
+                // The OID used is: "2.16.840.1.101.3.4.2.1".
+                // It would be better to use the DigestInfo structure defined in this file but the
+                // AlgorithmIdentifier structure does not currently support the simple SHA256 OID.
+                // See Devolutions/picky-rs#19
+                let mut digest_info = vec![
+                    0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04,
+                    0x02, 0x01, 0x05, 0x00, 0x04, 0x20,
+                ];
+                digest_info.append(&mut hash);
+
+                match self
+                    .backend
+                    .verify(session.session_handle(), &digest_info, &signature)
+                {
+                    Ok(_) => Ok(psa_verify_hash::Result {}),
+                    Err(e) => Err(utils::to_response_status(e)),
+                }
+            }
+            Err(e) => {
+                error!("Failed to initialize verifying operation. Error: {}", e);
+                Err(utils::to_response_status(e))
+            }
+        }
+    }
+}

--- a/src/providers/pkcs11_provider/key_management.rs
+++ b/src/providers/pkcs11_provider/key_management.rs
@@ -1,0 +1,515 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::{
+    utils, KeyInfo, KeyPairType, LocalIdStore, Pkcs11Provider, ReadWriteSession, RsaPublicKey,
+    Session,
+};
+use crate::authenticators::ApplicationName;
+use crate::key_info_managers::KeyTriple;
+use crate::key_info_managers::{self, ManageKeyInfo};
+use log::{error, info, warn};
+use parsec_interface::operations::psa_key_attributes::*;
+use parsec_interface::operations::{
+    psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
+};
+use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
+use picky_asn1::wrapper::IntegerAsn1;
+use pkcs11::types::{CKR_OK, CK_ATTRIBUTE, CK_MECHANISM, CK_OBJECT_HANDLE, CK_SESSION_HANDLE};
+use std::mem;
+
+// Public exponent value for all RSA keys.
+const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
+
+/// Gets a key identifier and key attributes from the Key Info Manager.
+pub fn get_key_info(
+    key_triple: &KeyTriple,
+    store_handle: &dyn ManageKeyInfo,
+) -> Result<([u8; 4], KeyAttributes)> {
+    match store_handle.get(key_triple) {
+        Ok(Some(key_info)) => {
+            if key_info.id.len() == 4 {
+                let mut dst = [0; 4];
+                dst.copy_from_slice(&key_info.id);
+                Ok((dst, key_info.attributes))
+            } else {
+                error!("Stored Key ID is not valid.");
+                Err(ResponseStatus::KeyInfoManagerError)
+            }
+        }
+        Ok(None) => Err(ResponseStatus::PsaErrorDoesNotExist),
+        Err(string) => Err(key_info_managers::to_response_status(string)),
+    }
+}
+
+pub fn create_key_id(
+    key_triple: KeyTriple,
+    key_attributes: KeyAttributes,
+    store_handle: &mut dyn ManageKeyInfo,
+    local_ids_handle: &mut LocalIdStore,
+) -> Result<[u8; 4]> {
+    let mut key_id = rand::random::<[u8; 4]>();
+    while local_ids_handle.contains(&key_id) {
+        key_id = rand::random::<[u8; 4]>();
+    }
+    let key_info = KeyInfo {
+        id: key_id.to_vec(),
+        attributes: key_attributes,
+    };
+    match store_handle.insert(key_triple.clone(), key_info) {
+        Ok(insert_option) => {
+            if insert_option.is_some() {
+                warn!("Overwriting Key triple mapping ({})", key_triple);
+            }
+            let _ = local_ids_handle.insert(key_id);
+
+            Ok(key_id)
+        }
+        Err(string) => Err(key_info_managers::to_response_status(string)),
+    }
+}
+
+pub fn remove_key_id(
+    key_triple: &KeyTriple,
+    key_id: [u8; 4],
+    store_handle: &mut dyn ManageKeyInfo,
+    local_ids_handle: &mut LocalIdStore,
+) -> Result<()> {
+    match store_handle.remove(key_triple) {
+        Ok(_) => {
+            let _ = local_ids_handle.remove(&key_id);
+            Ok(())
+        }
+        Err(string) => Err(key_info_managers::to_response_status(string)),
+    }
+}
+
+pub fn key_info_exists(key_triple: &KeyTriple, store_handle: &dyn ManageKeyInfo) -> Result<bool> {
+    match store_handle.exists(key_triple) {
+        Ok(val) => Ok(val),
+        Err(string) => Err(key_info_managers::to_response_status(string)),
+    }
+}
+
+impl Pkcs11Provider {
+    /// Find the PKCS 11 object handle corresponding to the key ID and the key type (public or
+    /// private key) given as parameters for the current session.
+    pub(super) fn find_key(
+        &self,
+        session: CK_SESSION_HANDLE,
+        key_id: [u8; 4],
+        key_type: KeyPairType,
+    ) -> Result<CK_OBJECT_HANDLE> {
+        let mut template = vec![CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id)];
+        match key_type {
+            KeyPairType::PublicKey => template.push(
+                CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
+                    .with_ck_ulong(&pkcs11::types::CKO_PUBLIC_KEY),
+            ),
+            KeyPairType::PrivateKey => template.push(
+                CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
+                    .with_ck_ulong(&pkcs11::types::CKO_PRIVATE_KEY),
+            ),
+            KeyPairType::Any => (),
+        }
+
+        if let Err(e) = self.backend.find_objects_init(session, &template) {
+            error!("Object enumeration init failed with {}", e);
+            Err(utils::to_response_status(e))
+        } else {
+            match self.backend.find_objects(session, 1) {
+                Ok(objects) => {
+                    if let Err(e) = self.backend.find_objects_final(session) {
+                        error!("Object enumeration final failed with {}", e);
+                        Err(utils::to_response_status(e))
+                    } else if objects.is_empty() {
+                        Err(ResponseStatus::PsaErrorDoesNotExist)
+                    } else {
+                        Ok(objects[0])
+                    }
+                }
+                Err(e) => {
+                    error!("Finding objects failed with {}", e);
+                    Err(utils::to_response_status(e))
+                }
+            }
+        }
+    }
+    pub(super) fn psa_generate_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_generate_key::Operation,
+    ) -> Result<psa_generate_key::Result> {
+        info!("Pkcs11 Provider - Create Key");
+
+        if op.attributes.key_type != KeyType::RsaKeyPair {
+            error!("The PKCS11 provider currently only supports creating RSA key pairs.");
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        let key_name = op.key_name;
+        let key_attributes = op.attributes;
+        // This should never panic on 32 bits or more machines.
+        let key_size = std::convert::TryFrom::try_from(op.attributes.key_bits).unwrap();
+
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        if key_info_exists(&key_triple, &*store_handle)? {
+            return Err(ResponseStatus::PsaErrorAlreadyExists);
+        }
+        let key_id = create_key_id(
+            key_triple.clone(),
+            key_attributes,
+            &mut *store_handle,
+            &mut local_ids_handle,
+        )?;
+
+        let mech = CK_MECHANISM {
+            mechanism: pkcs11::types::CKM_RSA_PKCS_KEY_PAIR_GEN,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+
+        let mut priv_template: Vec<CK_ATTRIBUTE> = Vec::new();
+        let mut pub_template: Vec<CK_ATTRIBUTE> = Vec::new();
+
+        priv_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_SIGN).with_bool(&pkcs11::types::CK_TRUE));
+        priv_template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
+        priv_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
+
+        pub_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_VERIFY).with_bool(&pkcs11::types::CK_TRUE));
+        pub_template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
+        pub_template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT).with_bytes(&PUBLIC_EXPONENT),
+        );
+        pub_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS_BITS).with_ck_ulong(&key_size));
+        pub_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
+        pub_template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PRIVATE).with_bool(&pkcs11::types::CK_FALSE),
+        );
+        pub_template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ENCRYPT).with_bool(&pkcs11::types::CK_TRUE));
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite).or_else(|err| {
+            error!("Error creating a new session: {}.", err);
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            Err(err)
+        })?;
+
+        info!(
+            "Generating RSA key pair in session {}",
+            session.session_handle()
+        );
+
+        match self.backend.generate_key_pair(
+            session.session_handle(),
+            &mech,
+            &pub_template,
+            &priv_template,
+        ) {
+            Ok(_key) => Ok(psa_generate_key::Result {}),
+            Err(e) => {
+                error!("Generate Key Pair operation failed with {}", e);
+                remove_key_id(
+                    &key_triple,
+                    key_id,
+                    &mut *store_handle,
+                    &mut local_ids_handle,
+                )?;
+                Err(utils::to_response_status(e))
+            }
+        }
+    }
+
+    pub(super) fn psa_import_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_import_key::Operation,
+    ) -> Result<psa_import_key::Result> {
+        info!("Pkcs11 Provider - Import Key");
+
+        if op.attributes.key_type != KeyType::RsaPublicKey {
+            error!("The PKCS 11 provider currently only supports importing RSA public key.");
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        let key_name = op.key_name;
+        let key_attributes = op.attributes;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        if key_info_exists(&key_triple, &*store_handle)? {
+            return Err(ResponseStatus::PsaErrorAlreadyExists);
+        }
+        let key_id = create_key_id(
+            key_triple.clone(),
+            key_attributes,
+            &mut *store_handle,
+            &mut local_ids_handle,
+        )?;
+
+        let mut template: Vec<CK_ATTRIBUTE> = Vec::new();
+
+        let public_key: RsaPublicKey = picky_asn1_der::from_bytes(&op.data).or_else(|e| {
+            error!("Failed to parse RsaPublicKey data ({}).", e);
+            Err(ResponseStatus::PsaErrorInvalidArgument)
+        })?;
+
+        if public_key.modulus.is_negative() || public_key.public_exponent.is_negative() {
+            error!("Only positive modulus and public exponent are supported.");
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        let modulus_object = &public_key.modulus.as_unsigned_bytes_be();
+        let exponent_object = &public_key.public_exponent.as_unsigned_bytes_be();
+        let key_bits = key_attributes.key_bits;
+        if key_bits != 0 && modulus_object.len() * 8 != key_bits as usize {
+            error!("If the key_bits field is non-zero (value is {}) it must be equal to the size of the key in data.", key_attributes.key_bits);
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
+                .with_ck_ulong(&pkcs11::types::CKO_PUBLIC_KEY),
+        );
+        template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_KEY_TYPE).with_ck_ulong(&pkcs11::types::CKK_RSA),
+        );
+        template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
+        template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS).with_bytes(modulus_object));
+        template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT).with_bytes(exponent_object),
+        );
+        template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_VERIFY).with_bool(&pkcs11::types::CK_TRUE));
+        template
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ENCRYPT).with_bool(&pkcs11::types::CK_TRUE));
+        template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
+        template.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PRIVATE).with_bool(&pkcs11::types::CK_FALSE),
+        );
+
+        // Restrict to RSA.
+        let allowed_mechanisms = [pkcs11::types::CKM_RSA_PKCS];
+        // The attribute contains a pointer to the allowed_mechanism array and its size as
+        // ulValueLen.
+        let mut allowed_mechanisms_attribute =
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_ALLOWED_MECHANISMS);
+        allowed_mechanisms_attribute.ulValueLen = mem::size_of_val(&allowed_mechanisms);
+        allowed_mechanisms_attribute.pValue = &allowed_mechanisms
+            as *const pkcs11::types::CK_MECHANISM_TYPE
+            as pkcs11::types::CK_VOID_PTR;
+        template.push(allowed_mechanisms_attribute);
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite).or_else(|err| {
+            error!("Error creating a new session: {}.", err);
+            remove_key_id(
+                &key_triple,
+                key_id,
+                &mut *store_handle,
+                &mut local_ids_handle,
+            )?;
+            Err(err)
+        })?;
+
+        info!(
+            "Importing RSA public key in session {}",
+            session.session_handle()
+        );
+
+        match self
+            .backend
+            .create_object(session.session_handle(), &template)
+        {
+            Ok(_key) => Ok(psa_import_key::Result {}),
+            Err(e) => {
+                error!("Import operation failed with {}", e);
+                remove_key_id(
+                    &key_triple,
+                    key_id,
+                    &mut *store_handle,
+                    &mut local_ids_handle,
+                )?;
+                Err(utils::to_response_status(e))
+            }
+        }
+    }
+
+    pub(super) fn psa_export_public_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_export_public_key::Operation,
+    ) -> Result<psa_export_public_key::Result> {
+        info!("Pkcs11 Provider - Export Public Key");
+
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let (key_id, _key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+
+        let session = Session::new(self, ReadWriteSession::ReadOnly)?;
+        info!(
+            "Export RSA public key in session {}",
+            session.session_handle()
+        );
+
+        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PublicKey)?;
+        info!("Located key for export.");
+
+        let mut size_attrs: Vec<CK_ATTRIBUTE> = Vec::new();
+        size_attrs.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS));
+        size_attrs.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT));
+
+        // Get the length of the attributes to retrieve.
+        let (modulus_len, public_exponent_len) =
+            match self
+                .backend
+                .get_attribute_value(session.session_handle(), key, &mut size_attrs)
+            {
+                Ok((rv, attrs)) => {
+                    if rv != CKR_OK {
+                        error!("Error when extracting attribute: {}.", rv);
+                        Err(utils::rv_to_response_status(rv))
+                    } else {
+                        Ok((attrs[0].ulValueLen, attrs[1].ulValueLen))
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to read attributes from public key. Error: {}", e);
+                    Err(utils::to_response_status(e))
+                }
+            }?;
+
+        let mut modulus: Vec<pkcs11::types::CK_BYTE> = Vec::new();
+        let mut public_exponent: Vec<pkcs11::types::CK_BYTE> = Vec::new();
+        modulus.resize(modulus_len, 0);
+        public_exponent.resize(public_exponent_len, 0);
+
+        let mut extract_attrs: Vec<CK_ATTRIBUTE> = Vec::new();
+        extract_attrs
+            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS).with_bytes(modulus.as_mut_slice()));
+        extract_attrs.push(
+            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT)
+                .with_bytes(public_exponent.as_mut_slice()),
+        );
+
+        match self
+            .backend
+            .get_attribute_value(session.session_handle(), key, &mut extract_attrs)
+        {
+            Ok(res) => {
+                let (rv, attrs) = res;
+                if rv != CKR_OK {
+                    error!("Error when extracting attribute: {}.", rv);
+                    Err(utils::rv_to_response_status(rv))
+                } else {
+                    let modulus = attrs[0].get_bytes();
+                    let public_exponent = attrs[1].get_bytes();
+
+                    // To produce a valid ASN.1 RSAPublicKey structure, 0x00 is put in front of the positive
+                    // integer if highest significant bit is one, to differentiate it from a negative number.
+                    let modulus = IntegerAsn1::from_unsigned_bytes_be(modulus);
+                    let public_exponent = IntegerAsn1::from_unsigned_bytes_be(public_exponent);
+
+                    let key = RsaPublicKey {
+                        modulus,
+                        public_exponent,
+                    };
+                    let data = picky_asn1_der::to_vec(&key).or_else(|err| {
+                        error!("Could not serialise key elements: {}.", err);
+                        Err(ResponseStatus::PsaErrorCommunicationFailure)
+                    })?;
+                    Ok(psa_export_public_key::Result { data })
+                }
+            }
+            Err(e) => {
+                error!("Failed to read attributes from public key. Error: {}", e);
+                Err(utils::to_response_status(e))
+            }
+        }
+    }
+
+    pub(super) fn psa_destroy_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_destroy_key::Operation,
+    ) -> Result<psa_destroy_key::Result> {
+        info!("Pkcs11 Provider - Destroy Key");
+
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        let (key_id, _) = get_key_info(&key_triple, &*store_handle)?;
+
+        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
+        info!(
+            "Deleting RSA keypair in session {}",
+            session.session_handle()
+        );
+
+        match self.find_key(session.session_handle(), key_id, KeyPairType::Any) {
+            Ok(key) => {
+                match self.backend.destroy_object(session.session_handle(), key) {
+                    Ok(_) => info!("Private part of the key destroyed successfully."),
+                    Err(e) => {
+                        error!("Failed to destroy private part of the key. Error: {}", e);
+                        return Err(utils::to_response_status(e));
+                    }
+                };
+            }
+            Err(e) => {
+                error!("Error destroying key: {}", e);
+                return Err(e);
+            }
+        };
+
+        // Second key is optional.
+        match self.find_key(session.session_handle(), key_id, KeyPairType::Any) {
+            Ok(key) => {
+                match self.backend.destroy_object(session.session_handle(), key) {
+                    Ok(_) => info!("Private part of the key destroyed successfully."),
+                    Err(e) => {
+                        error!("Failed to destroy private part of the key. Error: {}", e);
+                        return Err(utils::to_response_status(e));
+                    }
+                };
+            }
+            // A second key is optional.
+            Err(ResponseStatus::PsaErrorDoesNotExist) => (),
+            Err(e) => {
+                error!("Error destroying key: {}", e);
+                return Err(e);
+            }
+        };
+
+        remove_key_id(
+            &key_triple,
+            key_id,
+            &mut *store_handle,
+            &mut local_ids_handle,
+        )?;
+
+        Ok(psa_destroy_key::Result {})
+    }
+}

--- a/src/providers/pkcs11_provider/mod.rs
+++ b/src/providers/pkcs11_provider/mod.rs
@@ -6,33 +6,27 @@
 //! through the Parsec interface.
 use super::Provide;
 use crate::authenticators::ApplicationName;
-use crate::key_info_managers;
 use crate::key_info_managers::{KeyInfo, KeyTriple, ManageKeyInfo};
 use derivative::Derivative;
 use log::{error, info, warn};
 use parsec_interface::operations::list_providers::ProviderInfo;
-use parsec_interface::operations::psa_algorithm::*;
-use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::operations::{
     list_opcodes, psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
     psa_sign_hash, psa_verify_hash,
 };
 use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
-use picky_asn1::wrapper::IntegerAsn1;
-use pkcs11::types::{
-    CKF_OS_LOCKING_OK, CKF_RW_SESSION, CKF_SERIAL_SESSION, CKR_OK, CKU_USER, CK_ATTRIBUTE,
-    CK_C_INITIALIZE_ARGS, CK_MECHANISM, CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_SLOT_ID,
-};
+use pkcs11::types::{CKF_OS_LOCKING_OK, CK_C_INITIALIZE_ARGS, CK_SLOT_ID};
 use pkcs11::Ctx;
-use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
-use std::mem;
 use std::sync::{Arc, Mutex, RwLock};
+use utils::{KeyPairType, ReadWriteSession, RsaPublicKey, Session};
 use uuid::Uuid;
 
 type LocalIdStore = HashSet<[u8; 4]>;
 
+mod asym_sign;
+mod key_management;
 mod utils;
 
 const SUPPORTED_OPCODES: [Opcode; 7] = [
@@ -44,9 +38,6 @@ const SUPPORTED_OPCODES: [Opcode; 7] = [
     Opcode::PsaExportPublicKey,
     Opcode::ListOpcodes,
 ];
-
-// Public exponent value for all RSA keys.
-const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
 
 /// Provider for Public Key Cryptography Standard #11
 ///
@@ -74,256 +65,6 @@ pub struct Pkcs11Provider {
     slot_number: CK_SLOT_ID,
     // Some PKCS 11 devices do not need a pin, the None variant means that.
     user_pin: Option<String>,
-}
-
-// The RSA Public Key data are DER encoded with the following representation:
-// RSAPublicKey ::= SEQUENCE {
-//     modulus            INTEGER,  -- n
-//     publicExponent     INTEGER   -- e
-// }
-#[derive(Serialize, Deserialize, Debug)]
-struct RsaPublicKey {
-    modulus: IntegerAsn1,
-    public_exponent: IntegerAsn1,
-}
-
-// For PKCS 11, a key pair consists of two independant public and private keys. Both will share the
-// same key ID.
-enum KeyPairType {
-    PublicKey,
-    PrivateKey,
-    Any,
-}
-
-// Representation of a PKCS 11 session.
-struct Session<'a> {
-    provider: &'a Pkcs11Provider,
-    session_handle: CK_SESSION_HANDLE,
-    // This information is necessary to log out when dropped.
-    is_logged_in: bool,
-}
-
-#[derive(PartialEq)]
-enum ReadWriteSession {
-    ReadOnly,
-    ReadWrite,
-}
-
-impl Session<'_> {
-    fn new(provider: &Pkcs11Provider, read_write: ReadWriteSession) -> Result<Session> {
-        info!("Opening session on slot {}", provider.slot_number);
-
-        let mut session_flags = CKF_SERIAL_SESSION;
-        if read_write == ReadWriteSession::ReadWrite {
-            session_flags |= CKF_RW_SESSION;
-        }
-
-        match provider
-            .backend
-            .open_session(provider.slot_number, session_flags, None, None)
-        {
-            Ok(session_handle) => {
-                let mut session = Session {
-                    provider,
-                    session_handle,
-                    is_logged_in: false,
-                };
-
-                // The stress tests revealed bugs when sessions were concurrently running and some
-                // of them where logging in and out during their execution. These bugs seemed to
-                // disappear when *all* sessions are logged in by default.
-                // See https://github.com/opendnssec/SoftHSMv2/issues/509 for reference.
-                // This has security implications and should be disclosed.
-                session.login()?;
-
-                Ok(session)
-            }
-            Err(e) => {
-                error!(
-                    "Error opening session for slot {}: {}.",
-                    provider.slot_number, e
-                );
-                Err(utils::to_response_status(e))
-            }
-        }
-    }
-
-    fn session_handle(&self) -> CK_SESSION_HANDLE {
-        self.session_handle
-    }
-
-    fn login(&mut self) -> Result<()> {
-        #[allow(clippy::mutex_atomic)]
-        let mut logged_sessions_counter = self
-            .provider
-            .logged_sessions_counter
-            .lock()
-            .expect("Error while locking mutex.");
-
-        if self.is_logged_in {
-            info!(
-                "This session ({}) has already requested authentication.",
-                self.session_handle
-            );
-            Ok(())
-        } else if *logged_sessions_counter > 0 {
-            info!(
-                "Logging in ignored as {} sessions are already requiring authentication.",
-                *logged_sessions_counter
-            );
-            *logged_sessions_counter += 1;
-            self.is_logged_in = true;
-            Ok(())
-        } else if let Some(user_pin) = self.provider.user_pin.as_ref() {
-            match self
-                .provider
-                .backend
-                .login(self.session_handle, CKU_USER, Some(user_pin))
-            {
-                Ok(_) => {
-                    info!("Logging in session {}.", self.session_handle);
-                    *logged_sessions_counter += 1;
-                    self.is_logged_in = true;
-                    Ok(())
-                }
-                Err(e) => {
-                    error!("Login operation failed with {}", e);
-                    Err(utils::to_response_status(e))
-                }
-            }
-        } else {
-            warn!("Authentication requested but the provider has no user pin set!");
-            Ok(())
-        }
-    }
-
-    fn logout(&mut self) -> Result<()> {
-        #[allow(clippy::mutex_atomic)]
-        let mut logged_sessions_counter = self
-            .provider
-            .logged_sessions_counter
-            .lock()
-            .expect("Error while locking mutex.");
-
-        if !self.is_logged_in {
-            info!("Session {} has already logged out.", self.session_handle);
-            Ok(())
-        } else if *logged_sessions_counter == 0 {
-            info!("The user is already logged out, ignoring.");
-            Ok(())
-        } else if *logged_sessions_counter == 1 {
-            // Only this session requires authentication.
-            match self.provider.backend.logout(self.session_handle) {
-                Ok(_) => {
-                    info!("Logged out in session {}.", self.session_handle);
-                    *logged_sessions_counter -= 1;
-                    self.is_logged_in = false;
-                    Ok(())
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to log out from session {} due to error {}. Continuing...",
-                        self.session_handle, e
-                    );
-                    Err(utils::to_response_status(e))
-                }
-            }
-        } else {
-            info!(
-                "{} sessions are still requiring authentication, not logging out.",
-                *logged_sessions_counter
-            );
-            *logged_sessions_counter -= 1;
-            self.is_logged_in = false;
-            Ok(())
-        }
-    }
-}
-
-impl Drop for Session<'_> {
-    fn drop(&mut self) {
-        if self.logout().is_err() {
-            error!("Error while logging out. Continuing...");
-        }
-        match self.provider.backend.close_session(self.session_handle) {
-            Ok(_) => info!("Session {} closed.", self.session_handle),
-            // Treat this as best effort.
-            Err(e) => error!(
-                "Failed to close session {} due to error {}. Continuing...",
-                self.session_handle, e
-            ),
-        }
-    }
-}
-
-/// Gets a key identifier and key attributes from the Key Info Manager.
-fn get_key_info(
-    key_triple: &KeyTriple,
-    store_handle: &dyn ManageKeyInfo,
-) -> Result<([u8; 4], KeyAttributes)> {
-    match store_handle.get(key_triple) {
-        Ok(Some(key_info)) => {
-            if key_info.id.len() == 4 {
-                let mut dst = [0; 4];
-                dst.copy_from_slice(&key_info.id);
-                Ok((dst, key_info.attributes))
-            } else {
-                error!("Stored Key ID is not valid.");
-                Err(ResponseStatus::KeyInfoManagerError)
-            }
-        }
-        Ok(None) => Err(ResponseStatus::PsaErrorDoesNotExist),
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
-}
-
-fn create_key_id(
-    key_triple: KeyTriple,
-    key_attributes: KeyAttributes,
-    store_handle: &mut dyn ManageKeyInfo,
-    local_ids_handle: &mut LocalIdStore,
-) -> Result<[u8; 4]> {
-    let mut key_id = rand::random::<[u8; 4]>();
-    while local_ids_handle.contains(&key_id) {
-        key_id = rand::random::<[u8; 4]>();
-    }
-    let key_info = KeyInfo {
-        id: key_id.to_vec(),
-        attributes: key_attributes,
-    };
-    match store_handle.insert(key_triple.clone(), key_info) {
-        Ok(insert_option) => {
-            if insert_option.is_some() {
-                warn!("Overwriting Key triple mapping ({})", key_triple);
-            }
-            let _ = local_ids_handle.insert(key_id);
-
-            Ok(key_id)
-        }
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
-}
-
-fn remove_key_id(
-    key_triple: &KeyTriple,
-    key_id: [u8; 4],
-    store_handle: &mut dyn ManageKeyInfo,
-    local_ids_handle: &mut LocalIdStore,
-) -> Result<()> {
-    match store_handle.remove(key_triple) {
-        Ok(_) => {
-            let _ = local_ids_handle.remove(&key_id);
-            Ok(())
-        }
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
-}
-
-fn key_info_exists(key_triple: &KeyTriple, store_handle: &dyn ManageKeyInfo) -> Result<bool> {
-    match store_handle.exists(key_triple) {
-        Ok(val) => Ok(val),
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
 }
 
 impl Pkcs11Provider {
@@ -367,7 +108,10 @@ impl Pkcs11Provider {
                         Session::new(&pkcs11_provider, ReadWriteSession::ReadOnly).ok()?;
 
                     for key_triple in key_triples.iter().cloned() {
-                        let (key_id, _) = match get_key_info(key_triple, &*store_handle) {
+                        let (key_id, _) = match key_management::get_key_info(
+                            key_triple,
+                            &*store_handle,
+                        ) {
                             Ok(key_id) => key_id,
                             Err(response_status) => {
                                 error!("Error getting the KeyInfo for triple:\n{}\n(error: {}), continuing...", key_triple, response_status);
@@ -415,50 +159,6 @@ impl Pkcs11Provider {
 
         Some(pkcs11_provider)
     }
-
-    /// Find the PKCS 11 object handle corresponding to the key ID and the key type (public or
-    /// private key) given as parameters for the current session.
-    fn find_key(
-        &self,
-        session: CK_SESSION_HANDLE,
-        key_id: [u8; 4],
-        key_type: KeyPairType,
-    ) -> Result<CK_OBJECT_HANDLE> {
-        let mut template = vec![CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id)];
-        match key_type {
-            KeyPairType::PublicKey => template.push(
-                CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
-                    .with_ck_ulong(&pkcs11::types::CKO_PUBLIC_KEY),
-            ),
-            KeyPairType::PrivateKey => template.push(
-                CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
-                    .with_ck_ulong(&pkcs11::types::CKO_PRIVATE_KEY),
-            ),
-            KeyPairType::Any => (),
-        }
-
-        if let Err(e) = self.backend.find_objects_init(session, &template) {
-            error!("Object enumeration init failed with {}", e);
-            Err(utils::to_response_status(e))
-        } else {
-            match self.backend.find_objects(session, 1) {
-                Ok(objects) => {
-                    if let Err(e) = self.backend.find_objects_final(session) {
-                        error!("Object enumeration final failed with {}", e);
-                        Err(utils::to_response_status(e))
-                    } else if objects.is_empty() {
-                        Err(ResponseStatus::PsaErrorDoesNotExist)
-                    } else {
-                        Ok(objects[0])
-                    }
-                }
-                Err(e) => {
-                    error!("Finding objects failed with {}", e);
-                    Err(utils::to_response_status(e))
-                }
-            }
-        }
-    }
 }
 
 impl Provide for Pkcs11Provider {
@@ -487,99 +187,7 @@ impl Provide for Pkcs11Provider {
         app_name: ApplicationName,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
-        info!("Pkcs11 Provider - Create Key");
-
-        if op.attributes.key_type != KeyType::RsaKeyPair {
-            error!("The PKCS11 provider currently only supports creating RSA key pairs.");
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        let key_name = op.key_name;
-        let key_attributes = op.attributes;
-        // This should never panic on 32 bits or more machines.
-        let key_size = std::convert::TryFrom::try_from(op.attributes.key_bits).unwrap();
-
-        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
-        if key_info_exists(&key_triple, &*store_handle)? {
-            return Err(ResponseStatus::PsaErrorAlreadyExists);
-        }
-        let key_id = create_key_id(
-            key_triple.clone(),
-            key_attributes,
-            &mut *store_handle,
-            &mut local_ids_handle,
-        )?;
-
-        let mech = CK_MECHANISM {
-            mechanism: pkcs11::types::CKM_RSA_PKCS_KEY_PAIR_GEN,
-            pParameter: std::ptr::null_mut(),
-            ulParameterLen: 0,
-        };
-
-        let mut priv_template: Vec<CK_ATTRIBUTE> = Vec::new();
-        let mut pub_template: Vec<CK_ATTRIBUTE> = Vec::new();
-
-        priv_template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_SIGN).with_bool(&pkcs11::types::CK_TRUE));
-        priv_template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
-        priv_template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
-
-        pub_template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_VERIFY).with_bool(&pkcs11::types::CK_TRUE));
-        pub_template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
-        pub_template.push(
-            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT).with_bytes(&PUBLIC_EXPONENT),
-        );
-        pub_template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS_BITS).with_ck_ulong(&key_size));
-        pub_template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
-        pub_template.push(
-            CK_ATTRIBUTE::new(pkcs11::types::CKA_PRIVATE).with_bool(&pkcs11::types::CK_FALSE),
-        );
-        pub_template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ENCRYPT).with_bool(&pkcs11::types::CK_TRUE));
-
-        let session = Session::new(self, ReadWriteSession::ReadWrite).or_else(|err| {
-            error!("Error creating a new session: {}.", err);
-            remove_key_id(
-                &key_triple,
-                key_id,
-                &mut *store_handle,
-                &mut local_ids_handle,
-            )?;
-            Err(err)
-        })?;
-
-        info!(
-            "Generating RSA key pair in session {}",
-            session.session_handle()
-        );
-
-        match self.backend.generate_key_pair(
-            session.session_handle(),
-            &mech,
-            &pub_template,
-            &priv_template,
-        ) {
-            Ok(_key) => Ok(psa_generate_key::Result {}),
-            Err(e) => {
-                error!("Generate Key Pair operation failed with {}", e);
-                remove_key_id(
-                    &key_triple,
-                    key_id,
-                    &mut *store_handle,
-                    &mut local_ids_handle,
-                )?;
-                Err(utils::to_response_status(e))
-            }
-        }
+        self.psa_generate_key_internal(app_name, op)
     }
 
     fn psa_import_key(
@@ -587,117 +195,7 @@ impl Provide for Pkcs11Provider {
         app_name: ApplicationName,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
-        info!("Pkcs11 Provider - Import Key");
-
-        if op.attributes.key_type != KeyType::RsaPublicKey {
-            error!("The PKCS 11 provider currently only supports importing RSA public key.");
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        let key_name = op.key_name;
-        let key_attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
-        if key_info_exists(&key_triple, &*store_handle)? {
-            return Err(ResponseStatus::PsaErrorAlreadyExists);
-        }
-        let key_id = create_key_id(
-            key_triple.clone(),
-            key_attributes,
-            &mut *store_handle,
-            &mut local_ids_handle,
-        )?;
-
-        let mut template: Vec<CK_ATTRIBUTE> = Vec::new();
-
-        let public_key: RsaPublicKey = picky_asn1_der::from_bytes(&op.data).or_else(|e| {
-            error!("Failed to parse RsaPublicKey data ({}).", e);
-            Err(ResponseStatus::PsaErrorInvalidArgument)
-        })?;
-
-        if public_key.modulus.is_negative() || public_key.public_exponent.is_negative() {
-            error!("Only positive modulus and public exponent are supported.");
-            return Err(ResponseStatus::PsaErrorInvalidArgument);
-        }
-
-        let modulus_object = &public_key.modulus.as_unsigned_bytes_be();
-        let exponent_object = &public_key.public_exponent.as_unsigned_bytes_be();
-        let key_bits = key_attributes.key_bits;
-        if key_bits != 0 && modulus_object.len() * 8 != key_bits as usize {
-            error!("If the key_bits field is non-zero (value is {}) it must be equal to the size of the key in data.", key_attributes.key_bits);
-            return Err(ResponseStatus::PsaErrorInvalidArgument);
-        }
-
-        template.push(
-            CK_ATTRIBUTE::new(pkcs11::types::CKA_CLASS)
-                .with_ck_ulong(&pkcs11::types::CKO_PUBLIC_KEY),
-        );
-        template.push(
-            CK_ATTRIBUTE::new(pkcs11::types::CKA_KEY_TYPE).with_ck_ulong(&pkcs11::types::CKK_RSA),
-        );
-        template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_TOKEN).with_bool(&pkcs11::types::CK_TRUE));
-        template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS).with_bytes(modulus_object));
-        template.push(
-            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT).with_bytes(exponent_object),
-        );
-        template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_VERIFY).with_bool(&pkcs11::types::CK_TRUE));
-        template
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ENCRYPT).with_bool(&pkcs11::types::CK_TRUE));
-        template.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_ID).with_bytes(&key_id));
-        template.push(
-            CK_ATTRIBUTE::new(pkcs11::types::CKA_PRIVATE).with_bool(&pkcs11::types::CK_FALSE),
-        );
-
-        // Restrict to RSA.
-        let allowed_mechanisms = [pkcs11::types::CKM_RSA_PKCS];
-        // The attribute contains a pointer to the allowed_mechanism array and its size as
-        // ulValueLen.
-        let mut allowed_mechanisms_attribute =
-            CK_ATTRIBUTE::new(pkcs11::types::CKA_ALLOWED_MECHANISMS);
-        allowed_mechanisms_attribute.ulValueLen = mem::size_of_val(&allowed_mechanisms);
-        allowed_mechanisms_attribute.pValue = &allowed_mechanisms
-            as *const pkcs11::types::CK_MECHANISM_TYPE
-            as pkcs11::types::CK_VOID_PTR;
-        template.push(allowed_mechanisms_attribute);
-
-        let session = Session::new(self, ReadWriteSession::ReadWrite).or_else(|err| {
-            error!("Error creating a new session: {}.", err);
-            remove_key_id(
-                &key_triple,
-                key_id,
-                &mut *store_handle,
-                &mut local_ids_handle,
-            )?;
-            Err(err)
-        })?;
-
-        info!(
-            "Importing RSA public key in session {}",
-            session.session_handle()
-        );
-
-        match self
-            .backend
-            .create_object(session.session_handle(), &template)
-        {
-            Ok(_key) => Ok(psa_import_key::Result {}),
-            Err(e) => {
-                error!("Import operation failed with {}", e);
-                remove_key_id(
-                    &key_triple,
-                    key_id,
-                    &mut *store_handle,
-                    &mut local_ids_handle,
-                )?;
-                Err(utils::to_response_status(e))
-            }
-        }
+        self.psa_import_key_internal(app_name, op)
     }
 
     fn psa_export_public_key(
@@ -705,93 +203,7 @@ impl Provide for Pkcs11Provider {
         app_name: ApplicationName,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
-        info!("Pkcs11 Provider - Export Public Key");
-
-        let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, _key_attributes) = get_key_info(&key_triple, &*store_handle)?;
-
-        let session = Session::new(self, ReadWriteSession::ReadOnly)?;
-        info!(
-            "Export RSA public key in session {}",
-            session.session_handle()
-        );
-
-        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PublicKey)?;
-        info!("Located key for export.");
-
-        let mut size_attrs: Vec<CK_ATTRIBUTE> = Vec::new();
-        size_attrs.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS));
-        size_attrs.push(CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT));
-
-        // Get the length of the attributes to retrieve.
-        let (modulus_len, public_exponent_len) =
-            match self
-                .backend
-                .get_attribute_value(session.session_handle(), key, &mut size_attrs)
-            {
-                Ok((rv, attrs)) => {
-                    if rv != CKR_OK {
-                        error!("Error when extracting attribute: {}.", rv);
-                        Err(utils::rv_to_response_status(rv))
-                    } else {
-                        Ok((attrs[0].ulValueLen, attrs[1].ulValueLen))
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to read attributes from public key. Error: {}", e);
-                    Err(utils::to_response_status(e))
-                }
-            }?;
-
-        let mut modulus: Vec<pkcs11::types::CK_BYTE> = Vec::new();
-        let mut public_exponent: Vec<pkcs11::types::CK_BYTE> = Vec::new();
-        modulus.resize(modulus_len, 0);
-        public_exponent.resize(public_exponent_len, 0);
-
-        let mut extract_attrs: Vec<CK_ATTRIBUTE> = Vec::new();
-        extract_attrs
-            .push(CK_ATTRIBUTE::new(pkcs11::types::CKA_MODULUS).with_bytes(modulus.as_mut_slice()));
-        extract_attrs.push(
-            CK_ATTRIBUTE::new(pkcs11::types::CKA_PUBLIC_EXPONENT)
-                .with_bytes(public_exponent.as_mut_slice()),
-        );
-
-        match self
-            .backend
-            .get_attribute_value(session.session_handle(), key, &mut extract_attrs)
-        {
-            Ok(res) => {
-                let (rv, attrs) = res;
-                if rv != CKR_OK {
-                    error!("Error when extracting attribute: {}.", rv);
-                    Err(utils::rv_to_response_status(rv))
-                } else {
-                    let modulus = attrs[0].get_bytes();
-                    let public_exponent = attrs[1].get_bytes();
-
-                    // To produce a valid ASN.1 RSAPublicKey structure, 0x00 is put in front of the positive
-                    // integer if highest significant bit is one, to differentiate it from a negative number.
-                    let modulus = IntegerAsn1::from_unsigned_bytes_be(modulus);
-                    let public_exponent = IntegerAsn1::from_unsigned_bytes_be(public_exponent);
-
-                    let key = RsaPublicKey {
-                        modulus,
-                        public_exponent,
-                    };
-                    let data = picky_asn1_der::to_vec(&key).or_else(|err| {
-                        error!("Could not serialise key elements: {}.", err);
-                        Err(ResponseStatus::PsaErrorCommunicationFailure)
-                    })?;
-                    Ok(psa_export_public_key::Result { data })
-                }
-            }
-            Err(e) => {
-                error!("Failed to read attributes from public key. Error: {}", e);
-                Err(utils::to_response_status(e))
-            }
-        }
+        self.psa_export_public_key_internal(app_name, op)
     }
 
     fn psa_destroy_key(
@@ -799,66 +211,7 @@ impl Provide for Pkcs11Provider {
         app_name: ApplicationName,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
-        info!("Pkcs11 Provider - Destroy Key");
-
-        let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
-        let (key_id, _) = get_key_info(&key_triple, &*store_handle)?;
-
-        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
-        info!(
-            "Deleting RSA keypair in session {}",
-            session.session_handle()
-        );
-
-        match self.find_key(session.session_handle(), key_id, KeyPairType::Any) {
-            Ok(key) => {
-                match self.backend.destroy_object(session.session_handle(), key) {
-                    Ok(_) => info!("Private part of the key destroyed successfully."),
-                    Err(e) => {
-                        error!("Failed to destroy private part of the key. Error: {}", e);
-                        return Err(utils::to_response_status(e));
-                    }
-                };
-            }
-            Err(e) => {
-                error!("Error destroying key: {}", e);
-                return Err(e);
-            }
-        };
-
-        // Second key is optional.
-        match self.find_key(session.session_handle(), key_id, KeyPairType::Any) {
-            Ok(key) => {
-                match self.backend.destroy_object(session.session_handle(), key) {
-                    Ok(_) => info!("Private part of the key destroyed successfully."),
-                    Err(e) => {
-                        error!("Failed to destroy private part of the key. Error: {}", e);
-                        return Err(utils::to_response_status(e));
-                    }
-                };
-            }
-            // A second key is optional.
-            Err(ResponseStatus::PsaErrorDoesNotExist) => (),
-            Err(e) => {
-                error!("Error destroying key: {}", e);
-                return Err(e);
-            }
-        };
-
-        remove_key_id(
-            &key_triple,
-            key_id,
-            &mut *store_handle,
-            &mut local_ids_handle,
-        )?;
-
-        Ok(psa_destroy_key::Result {})
+        self.psa_destroy_key_internal(app_name, op)
     }
 
     fn psa_sign_hash(
@@ -866,86 +219,7 @@ impl Provide for Pkcs11Provider {
         app_name: ApplicationName,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        info!("Pkcs11 Provider - Asym Sign");
-
-        let key_name = op.key_name;
-        let mut hash = op.hash;
-        let alg = op.alg;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
-
-        key_attributes.can_sign_hash()?;
-        key_attributes.permits_alg(alg.into())?;
-        key_attributes.compatible_with_alg(alg.into())?;
-
-        match alg {
-            AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: Hash::Sha256,
-            } => (),
-            _ => {
-                error!(
-                    "The PKCS 11 provider currently only supports \"RSA PKCS#1 v1.5 signature with hashing\" algorithm with SHA-256 as hashing algorithm for the PsaSignHash operation.");
-                return Err(ResponseStatus::PsaErrorNotSupported);
-            }
-        }
-
-        if alg
-            != (AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: Hash::Sha256,
-            })
-        {
-            error!(
-                "The PKCS 11 provider currently only supports signature algorithm to be RSA PKCS#1 v1.5 and the text hashed with SHA-256.");
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        if hash.len() != 32 {
-            error!("The SHA-256 hash must be 32 bytes long.");
-            return Err(ResponseStatus::PsaErrorInvalidArgument);
-        }
-
-        let mech = CK_MECHANISM {
-            mechanism: pkcs11::types::CKM_RSA_PKCS,
-            pParameter: std::ptr::null_mut(),
-            ulParameterLen: 0,
-        };
-
-        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
-        info!("Asymmetric sign in session {}", session.session_handle());
-
-        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PrivateKey)?;
-        info!("Located signing key.");
-
-        match self.backend.sign_init(session.session_handle(), &mech, key) {
-            Ok(_) => {
-                info!("Signing operation initialized.");
-
-                // Build a valid ASN.1 DigestInfo DER-encoded structure by appending the hash to a
-                // DigestAlgorithmIdentifier value representing the SHA256 OID with no parameters.
-                // The OID used is: "2.16.840.1.101.3.4.2.1".
-                // It would be better to use the DigestInfo structure defined in this file but the
-                // AlgorithmIdentifier structure does not currently support the simple SHA256 OID.
-                // See Devolutions/picky-rs#19
-                let mut digest_info = vec![
-                    0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04,
-                    0x02, 0x01, 0x05, 0x00, 0x04, 0x20,
-                ];
-                digest_info.append(&mut hash);
-
-                match self.backend.sign(session.session_handle(), &digest_info) {
-                    Ok(signature) => Ok(psa_sign_hash::Result { signature }),
-                    Err(e) => {
-                        error!("Failed to execute signing operation. Error: {}", e);
-                        Err(utils::to_response_status(e))
-                    }
-                }
-            }
-            Err(e) => {
-                error!("Failed to initialize signing operation. Error: {}", e);
-                Err(utils::to_response_status(e))
-            }
-        }
+        self.psa_sign_hash_internal(app_name, op)
     }
 
     fn psa_verify_hash(
@@ -953,91 +227,7 @@ impl Provide for Pkcs11Provider {
         app_name: ApplicationName,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        info!("Pkcs11 Provider - Asym Verify");
-
-        let key_name = op.key_name;
-        let mut hash = op.hash;
-        let signature = op.signature;
-        let alg = op.alg;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
-
-        key_attributes.can_verify_hash()?;
-        key_attributes.permits_alg(alg.into())?;
-        key_attributes.compatible_with_alg(alg.into())?;
-
-        match alg {
-            AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: Hash::Sha256,
-            } => (),
-            _ => {
-                error!(
-                    "The PKCS 11 provider currently only supports \"RSA PKCS#1 v1.5 signature with hashing\" algorithm with SHA-256 as hashing algorithm for the PsaVerifyHash operation.");
-                return Err(ResponseStatus::PsaErrorNotSupported);
-            }
-        }
-
-        if alg
-            != (AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: Hash::Sha256,
-            })
-        {
-            error!(
-                "The PKCS 11 provider currently only supports signature algorithm to be RSA PKCS#1 v1.5 and the text hashed with SHA-256.");
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        if hash.len() != 32 {
-            error!("The SHA-256 hash must be 32 bytes long.");
-            return Err(ResponseStatus::PsaErrorInvalidArgument);
-        }
-
-        let mech = CK_MECHANISM {
-            // Verify without hashing.
-            mechanism: pkcs11::types::CKM_RSA_PKCS,
-            pParameter: std::ptr::null_mut(),
-            ulParameterLen: 0,
-        };
-
-        let session = Session::new(self, ReadWriteSession::ReadWrite)?;
-        info!("Asymmetric verify in session {}", session.session_handle());
-
-        let key = self.find_key(session.session_handle(), key_id, KeyPairType::PublicKey)?;
-        info!("Located public key.");
-
-        match self
-            .backend
-            .verify_init(session.session_handle(), &mech, key)
-        {
-            Ok(_) => {
-                info!("Verify operation initialized.");
-
-                // Build a valid ASN.1 DigestInfo DER-encoded structure by appending the hash to a
-                // DigestAlgorithmIdentifier value representing the SHA256 OID with no parameters.
-                // The OID used is: "2.16.840.1.101.3.4.2.1".
-                // It would be better to use the DigestInfo structure defined in this file but the
-                // AlgorithmIdentifier structure does not currently support the simple SHA256 OID.
-                // See Devolutions/picky-rs#19
-                let mut digest_info = vec![
-                    0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04,
-                    0x02, 0x01, 0x05, 0x00, 0x04, 0x20,
-                ];
-                digest_info.append(&mut hash);
-
-                match self
-                    .backend
-                    .verify(session.session_handle(), &digest_info, &signature)
-                {
-                    Ok(_) => Ok(psa_verify_hash::Result {}),
-                    Err(e) => Err(utils::to_response_status(e)),
-                }
-            }
-            Err(e) => {
-                error!("Failed to initialize verifying operation. Error: {}", e);
-                Err(utils::to_response_status(e))
-            }
-        }
+        self.psa_verify_hash_internal(app_name, op)
     }
 }
 

--- a/src/providers/pkcs11_provider/utils.rs
+++ b/src/providers/pkcs11_provider/utils.rs
@@ -1,10 +1,16 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::Pkcs11Provider;
 use log::error;
+use log::{info, warn};
 use parsec_interface::requests::ResponseStatus;
+use parsec_interface::requests::Result;
+use picky_asn1::wrapper::IntegerAsn1;
 use pkcs11::errors::Error;
 use pkcs11::types::*;
+use pkcs11::types::{CKF_RW_SESSION, CKF_SERIAL_SESSION, CKU_USER};
+use serde::{Deserialize, Serialize};
 
 /// Convert the PKCS 11 library specific error values to ResponseStatus values that are returned on
 /// the wire protocol
@@ -48,6 +54,186 @@ pub fn rv_to_response_status(rv: CK_RV) -> ResponseStatus {
         e => {
             error!("Error \"{}\" converted to PsaErrorCommunicationFailure.", e);
             ResponseStatus::PsaErrorCommunicationFailure
+        }
+    }
+}
+
+// The RSA Public Key data are DER encoded with the following representation:
+// RSAPublicKey ::= SEQUENCE {
+//     modulus            INTEGER,  -- n
+//     publicExponent     INTEGER   -- e
+// }
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RsaPublicKey {
+    pub modulus: IntegerAsn1,
+    pub public_exponent: IntegerAsn1,
+}
+
+// For PKCS 11, a key pair consists of two independant public and private keys. Both will share the
+// same key ID.
+pub enum KeyPairType {
+    PublicKey,
+    PrivateKey,
+    Any,
+}
+
+// Representation of a PKCS 11 session.
+pub struct Session<'a> {
+    provider: &'a Pkcs11Provider,
+    session_handle: CK_SESSION_HANDLE,
+    // This information is necessary to log out when dropped.
+    is_logged_in: bool,
+}
+
+#[derive(PartialEq)]
+pub enum ReadWriteSession {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl Session<'_> {
+    pub fn new(provider: &Pkcs11Provider, read_write: ReadWriteSession) -> Result<Session> {
+        info!("Opening session on slot {}", provider.slot_number);
+
+        let mut session_flags = CKF_SERIAL_SESSION;
+        if read_write == ReadWriteSession::ReadWrite {
+            session_flags |= CKF_RW_SESSION;
+        }
+
+        match provider
+            .backend
+            .open_session(provider.slot_number, session_flags, None, None)
+        {
+            Ok(session_handle) => {
+                let mut session = Session {
+                    provider,
+                    session_handle,
+                    is_logged_in: false,
+                };
+
+                // The stress tests revealed bugs when sessions were concurrently running and some
+                // of them where logging in and out during their execution. These bugs seemed to
+                // disappear when *all* sessions are logged in by default.
+                // See https://github.com/opendnssec/SoftHSMv2/issues/509 for reference.
+                // This has security implications and should be disclosed.
+                session.login()?;
+
+                Ok(session)
+            }
+            Err(e) => {
+                error!(
+                    "Error opening session for slot {}: {}.",
+                    provider.slot_number, e
+                );
+                Err(to_response_status(e))
+            }
+        }
+    }
+
+    pub fn session_handle(&self) -> CK_SESSION_HANDLE {
+        self.session_handle
+    }
+
+    fn login(&mut self) -> Result<()> {
+        #[allow(clippy::mutex_atomic)]
+        let mut logged_sessions_counter = self
+            .provider
+            .logged_sessions_counter
+            .lock()
+            .expect("Error while locking mutex.");
+
+        if self.is_logged_in {
+            info!(
+                "This session ({}) has already requested authentication.",
+                self.session_handle
+            );
+            Ok(())
+        } else if *logged_sessions_counter > 0 {
+            info!(
+                "Logging in ignored as {} sessions are already requiring authentication.",
+                *logged_sessions_counter
+            );
+            *logged_sessions_counter += 1;
+            self.is_logged_in = true;
+            Ok(())
+        } else if let Some(user_pin) = self.provider.user_pin.as_ref() {
+            match self
+                .provider
+                .backend
+                .login(self.session_handle, CKU_USER, Some(user_pin))
+            {
+                Ok(_) => {
+                    info!("Logging in session {}.", self.session_handle);
+                    *logged_sessions_counter += 1;
+                    self.is_logged_in = true;
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("Login operation failed with {}", e);
+                    Err(to_response_status(e))
+                }
+            }
+        } else {
+            warn!("Authentication requested but the provider has no user pin set!");
+            Ok(())
+        }
+    }
+
+    fn logout(&mut self) -> Result<()> {
+        #[allow(clippy::mutex_atomic)]
+        let mut logged_sessions_counter = self
+            .provider
+            .logged_sessions_counter
+            .lock()
+            .expect("Error while locking mutex.");
+
+        if !self.is_logged_in {
+            info!("Session {} has already logged out.", self.session_handle);
+            Ok(())
+        } else if *logged_sessions_counter == 0 {
+            info!("The user is already logged out, ignoring.");
+            Ok(())
+        } else if *logged_sessions_counter == 1 {
+            // Only this session requires authentication.
+            match self.provider.backend.logout(self.session_handle) {
+                Ok(_) => {
+                    info!("Logged out in session {}.", self.session_handle);
+                    *logged_sessions_counter -= 1;
+                    self.is_logged_in = false;
+                    Ok(())
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to log out from session {} due to error {}. Continuing...",
+                        self.session_handle, e
+                    );
+                    Err(to_response_status(e))
+                }
+            }
+        } else {
+            info!(
+                "{} sessions are still requiring authentication, not logging out.",
+                *logged_sessions_counter
+            );
+            *logged_sessions_counter -= 1;
+            self.is_logged_in = false;
+            Ok(())
+        }
+    }
+}
+
+impl Drop for Session<'_> {
+    fn drop(&mut self) {
+        if self.logout().is_err() {
+            error!("Error while logging out. Continuing...");
+        }
+        match self.provider.backend.close_session(self.session_handle) {
+            Ok(_) => info!("Session {} closed.", self.session_handle),
+            // Treat this as best effort.
+            Err(e) => error!(
+                "Failed to close session {} due to error {}. Continuing...",
+                self.session_handle, e
+            ),
         }
     }
 }

--- a/src/providers/tpm_provider/asym_sign.rs
+++ b/src/providers/tpm_provider/asym_sign.rs
@@ -1,0 +1,139 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::{key_management, utils, TpmProvider};
+use crate::authenticators::ApplicationName;
+use crate::key_info_managers::KeyTriple;
+use log::error;
+use parsec_interface::operations::psa_algorithm::*;
+use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
+use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
+use tss_esapi::{constants::TPM2_ALG_SHA256, utils::AsymSchemeUnion, utils::Signature};
+
+impl TpmProvider {
+    pub(super) fn psa_sign_hash_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_sign_hash::Operation,
+    ) -> Result<psa_sign_hash::Result> {
+        let key_name = op.key_name;
+        let hash = op.hash;
+        let alg = op.alg;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
+
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        if alg
+            != (AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            })
+        {
+            error!(
+                "The TPM provider currently only supports signature algorithm to be RSA PKCS#1 v1.5 and the text hashed with SHA-256.");
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        if hash.len() != 32 {
+            error!("The SHA-256 hash must be 32 bytes long.");
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        let (password_context, key_attributes) =
+            key_management::get_password_context(&*store_handle, key_triple)?;
+
+        key_attributes.can_sign_hash()?;
+        key_attributes.permits_alg(alg.into())?;
+        key_attributes.compatible_with_alg(alg.into())?;
+
+        match alg {
+            AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            } => (),
+            _ => {
+                error!(
+                    "The TPM provider currently only supports \"RSA PKCS#1 v1.5 signature with hashing\" algorithm with SHA-256 as hashing algorithm for the PsaSignHash operation.");
+                return Err(ResponseStatus::PsaErrorNotSupported);
+            }
+        }
+
+        let signature = esapi_context
+            .sign(
+                password_context.context,
+                &password_context.auth_value,
+                &hash,
+            )
+            .or_else(|e| {
+                error!("Error signing: {}.", e);
+                Err(utils::to_response_status(e))
+            })?;
+
+        Ok(psa_sign_hash::Result {
+            signature: signature.signature,
+        })
+    }
+
+    pub(super) fn psa_verify_hash_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_verify_hash::Operation,
+    ) -> Result<psa_verify_hash::Result> {
+        let key_name = op.key_name;
+        let hash = op.hash;
+        let alg = op.alg;
+        let signature = op.signature;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
+
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        if alg
+            != (AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            })
+        {
+            error!(
+                "The TPM provider currently only supports signature algorithm to be RSA PKCS#1 v1.5 and the text hashed with SHA-256.");
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        if hash.len() != 32 {
+            error!("The SHA-256 hash must be 32 bytes long.");
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        let signature = Signature {
+            scheme: AsymSchemeUnion::RSASSA(TPM2_ALG_SHA256),
+            signature,
+        };
+
+        let (password_context, key_attributes) =
+            key_management::get_password_context(&*store_handle, key_triple)?;
+
+        key_attributes.can_verify_hash()?;
+        key_attributes.permits_alg(alg.into())?;
+        key_attributes.compatible_with_alg(alg.into())?;
+
+        match alg {
+            AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha256,
+            } => (),
+            _ => {
+                error!(
+                    "The TPM provider currently only supports \"RSA PKCS#1 v1.5 signature with hashing\" algorithm with SHA-256 as hashing algorithm for the PsaVerifyHash operation.");
+                return Err(ResponseStatus::PsaErrorNotSupported);
+            }
+        }
+
+        let _ = esapi_context
+            .verify_signature(password_context.context, &hash, signature)
+            .or_else(|e| Err(utils::to_response_status(e)))?;
+
+        Ok(psa_verify_hash::Result {})
+    }
+}

--- a/src/providers/tpm_provider/key_management.rs
+++ b/src/providers/tpm_provider/key_management.rs
@@ -1,0 +1,252 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::utils;
+use super::utils::{PasswordContext, RsaPublicKey};
+use super::TpmProvider;
+use crate::authenticators::ApplicationName;
+use crate::key_info_managers;
+use crate::key_info_managers::KeyTriple;
+use crate::key_info_managers::{KeyInfo, ManageKeyInfo};
+use log::error;
+use parsec_interface::operations::psa_key_attributes::*;
+use parsec_interface::operations::{
+    psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
+};
+use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
+use picky_asn1::wrapper::IntegerAsn1;
+
+// Public exponent value for all RSA keys.
+const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
+const AUTH_VAL_LEN: usize = 32;
+
+// Inserts a new mapping in the Key Info manager that stores the PasswordContext.
+fn insert_password_context(
+    store_handle: &mut dyn ManageKeyInfo,
+    key_triple: KeyTriple,
+    password_context: PasswordContext,
+    key_attributes: KeyAttributes,
+) -> Result<()> {
+    let error_storing = |e| Err(key_info_managers::to_response_status(e));
+
+    let key_info = KeyInfo {
+        id: bincode::serialize(&password_context)?,
+        attributes: key_attributes,
+    };
+
+    if store_handle
+        .insert(key_triple, key_info)
+        .or_else(error_storing)?
+        .is_some()
+    {
+        error!("Inserting a mapping in the Key Info Manager that would overwrite an existing one.");
+        Err(ResponseStatus::PsaErrorAlreadyExists)
+    } else {
+        Ok(())
+    }
+}
+
+// Gets a PasswordContext mapping to the KeyTriple given.
+pub fn get_password_context(
+    store_handle: &dyn ManageKeyInfo,
+    key_triple: KeyTriple,
+) -> Result<(PasswordContext, KeyAttributes)> {
+    let key_info = store_handle
+        .get(&key_triple)
+        .or_else(|e| Err(key_info_managers::to_response_status(e)))?
+        .ok_or_else(|| {
+            error!(
+                "Key triple \"{}\" does not exist in the Key Info Manager.",
+                key_triple
+            );
+            ResponseStatus::PsaErrorDoesNotExist
+        })?;
+    Ok((bincode::deserialize(&key_info.id)?, key_info.attributes))
+}
+
+impl TpmProvider {
+    pub(super) fn psa_generate_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_generate_key::Operation,
+    ) -> Result<psa_generate_key::Result> {
+        if op.attributes.key_type != KeyType::RsaKeyPair {
+            error!("The TPM provider currently only supports creating RSA key pairs.");
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        let key_name = op.key_name;
+        let attributes = op.attributes;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
+        // This should never panic on 32 bits or more machines.
+        let key_size = std::convert::TryFrom::try_from(op.attributes.key_bits)
+            .expect("Conversion to usize failed.");
+
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let (key_context, auth_value) = esapi_context
+            .create_rsa_signing_key(key_size, AUTH_VAL_LEN)
+            .or_else(|e| {
+                error!("Error creating a RSA signing key: {}.", e);
+                Err(utils::to_response_status(e))
+            })?;
+
+        insert_password_context(
+            &mut *store_handle,
+            key_triple,
+            PasswordContext {
+                context: key_context,
+                auth_value,
+            },
+            attributes,
+        )?;
+
+        Ok(psa_generate_key::Result {})
+    }
+
+    pub(super) fn psa_import_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_import_key::Operation,
+    ) -> Result<psa_import_key::Result> {
+        if op.attributes.key_type != KeyType::RsaPublicKey {
+            error!("The TPM provider currently only supports importing RSA public key.");
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        let key_name = op.key_name;
+        let attributes = op.attributes;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
+        let key_data = op.data;
+
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let public_key: RsaPublicKey = picky_asn1_der::from_bytes(&key_data).or_else(|err| {
+            error!("Could not deserialise key elements: {}.", err);
+            Err(ResponseStatus::PsaErrorInvalidArgument)
+        })?;
+
+        if public_key.modulus.is_negative() || public_key.public_exponent.is_negative() {
+            error!("Only positive modulus and public exponent are supported.");
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        if public_key.public_exponent.as_unsigned_bytes_be() != PUBLIC_EXPONENT {
+            error!("The TPM Provider only supports 0x101 as public exponent for RSA public keys, {:?} given.", public_key.public_exponent.as_unsigned_bytes_be());
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+        let key_data = public_key.modulus.as_unsigned_bytes_be();
+        let len = key_data.len();
+
+        let key_bits = attributes.key_bits;
+        if key_bits != 0 && len * 8 != key_bits as usize {
+            error!("If the key_bits field is non-zero (value is {}) it must be equal to the size of the key in data.", attributes.key_bits);
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        if len != 128 && len != 256 {
+            error!(
+                "The TPM provider only supports 1024 and 2048 bits RSA public keys ({} bits given).",
+                len * 8
+            );
+            return Err(ResponseStatus::PsaErrorNotSupported);
+        }
+
+        let pub_key_context = esapi_context
+            .load_external_rsa_public_key(&key_data)
+            .or_else(|e| {
+                error!("Error creating a RSA signing key: {}.", e);
+                Err(utils::to_response_status(e))
+            })?;
+
+        insert_password_context(
+            &mut *store_handle,
+            key_triple,
+            PasswordContext {
+                context: pub_key_context,
+                auth_value: Vec::new(),
+            },
+            attributes,
+        )?;
+
+        Ok(psa_import_key::Result {})
+    }
+
+    pub(super) fn psa_export_public_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_export_public_key::Operation,
+    ) -> Result<psa_export_public_key::Result> {
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
+
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let (password_context, _key_attributes) = get_password_context(&*store_handle, key_triple)?;
+
+        let pub_key_data = esapi_context
+            .read_public_key(password_context.context)
+            .or_else(|e| {
+                error!("Error reading a public key: {}.", e);
+                Err(utils::to_response_status(e))
+            })?;
+
+        let key = RsaPublicKey {
+            // To produce a valid ASN.1 RSAPublicKey structure, 0x00 is put in front of the positive
+            // modulus if highest significant bit is one, to differentiate it from a negative number.
+            modulus: IntegerAsn1::from_unsigned_bytes_be(pub_key_data),
+            public_exponent: IntegerAsn1::from_signed_bytes_be(PUBLIC_EXPONENT.to_vec()),
+        };
+        let key_data = picky_asn1_der::to_vec(&key).or_else(|err| {
+            error!("Could not serialise key elements: {}.", err);
+            Err(ResponseStatus::PsaErrorCommunicationFailure)
+        })?;
+
+        Ok(psa_export_public_key::Result { data: key_data })
+    }
+
+    pub(super) fn psa_destroy_key_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_destroy_key::Operation,
+    ) -> Result<psa_destroy_key::Result> {
+        let key_name = op.key_name;
+        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+
+        let error_closure = |e| Err(key_info_managers::to_response_status(e));
+        if store_handle
+            .remove(&key_triple)
+            .or_else(error_closure)?
+            .is_none()
+        {
+            error!(
+                "Key triple \"{}\" does not exist in the Key Info Manager.",
+                key_triple
+            );
+            Err(ResponseStatus::PsaErrorDoesNotExist)
+        } else {
+            Ok(psa_destroy_key::Result {})
+        }
+    }
+}

--- a/src/providers/tpm_provider/mod.rs
+++ b/src/providers/tpm_provider/mod.rs
@@ -6,27 +6,22 @@
 //! for their Parsec operations.
 use super::Provide;
 use crate::authenticators::ApplicationName;
-use crate::key_info_managers;
-use crate::key_info_managers::{KeyInfo, KeyTriple, ManageKeyInfo};
+use crate::key_info_managers::ManageKeyInfo;
 use derivative::Derivative;
 use log::{error, info};
 use parsec_interface::operations::list_providers::ProviderInfo;
-use parsec_interface::operations::psa_algorithm::*;
-use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::operations::{
     list_opcodes, psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
     psa_sign_hash, psa_verify_hash,
 };
 use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
-use picky_asn1::wrapper::IntegerAsn1;
-use serde::{Deserialize, Serialize};
 use std::io::ErrorKind;
 use std::sync::{Arc, Mutex, RwLock};
-use tss_esapi::{
-    constants::TPM2_ALG_SHA256, utils::AsymSchemeUnion, utils::Signature, utils::TpmsContext, Tcti,
-};
+use tss_esapi::Tcti;
 use uuid::Uuid;
 
+mod asym_sign;
+mod key_management;
 mod utils;
 
 const SUPPORTED_OPCODES: [Opcode; 7] = [
@@ -59,72 +54,6 @@ pub struct TpmProvider {
     // structure).
     #[derivative(Debug = "ignore")]
     key_info_store: Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>,
-}
-
-// Public exponent value for all RSA keys.
-const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
-const AUTH_VAL_LEN: usize = 32;
-
-// The RSA Public Key data are DER encoded with the following representation:
-// RSAPublicKey ::= SEQUENCE {
-//     modulus            INTEGER,  -- n
-//     publicExponent     INTEGER   -- e
-// }
-#[derive(Serialize, Deserialize, Debug)]
-struct RsaPublicKey {
-    modulus: IntegerAsn1,
-    public_exponent: IntegerAsn1,
-}
-
-// The PasswordContext is what is stored by the Key Info Manager.
-#[derive(Serialize, Deserialize)]
-struct PasswordContext {
-    context: TpmsContext,
-    auth_value: Vec<u8>,
-}
-
-// Inserts a new mapping in the Key Info manager that stores the PasswordContext.
-fn insert_password_context(
-    store_handle: &mut dyn ManageKeyInfo,
-    key_triple: KeyTriple,
-    password_context: PasswordContext,
-    key_attributes: KeyAttributes,
-) -> Result<()> {
-    let error_storing = |e| Err(key_info_managers::to_response_status(e));
-
-    let key_info = KeyInfo {
-        id: bincode::serialize(&password_context)?,
-        attributes: key_attributes,
-    };
-
-    if store_handle
-        .insert(key_triple, key_info)
-        .or_else(error_storing)?
-        .is_some()
-    {
-        error!("Inserting a mapping in the Key Info Manager that would overwrite an existing one.");
-        Err(ResponseStatus::PsaErrorAlreadyExists)
-    } else {
-        Ok(())
-    }
-}
-
-// Gets a PasswordContext mapping to the KeyTriple given.
-fn get_password_context(
-    store_handle: &dyn ManageKeyInfo,
-    key_triple: KeyTriple,
-) -> Result<(PasswordContext, KeyAttributes)> {
-    let key_info = store_handle
-        .get(&key_triple)
-        .or_else(|e| Err(key_info_managers::to_response_status(e)))?
-        .ok_or_else(|| {
-            error!(
-                "Key triple \"{}\" does not exist in the Key Info Manager.",
-                key_triple
-            );
-            ResponseStatus::PsaErrorDoesNotExist
-        })?;
-    Ok((bincode::deserialize(&key_info.id)?, key_info.attributes))
 }
 
 impl TpmProvider {
@@ -165,45 +94,7 @@ impl Provide for TpmProvider {
         app_name: ApplicationName,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
-        if op.attributes.key_type != KeyType::RsaKeyPair {
-            error!("The TPM provider currently only supports creating RSA key pairs.");
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        let key_name = op.key_name;
-        let attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
-        // This should never panic on 32 bits or more machines.
-        let key_size = std::convert::TryFrom::try_from(op.attributes.key_bits)
-            .expect("Conversion to usize failed.");
-
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-        let mut esapi_context = self
-            .esapi_context
-            .lock()
-            .expect("ESAPI Context lock poisoned");
-
-        let (key_context, auth_value) = esapi_context
-            .create_rsa_signing_key(key_size, AUTH_VAL_LEN)
-            .or_else(|e| {
-                error!("Error creating a RSA signing key: {}.", e);
-                Err(utils::to_response_status(e))
-            })?;
-
-        insert_password_context(
-            &mut *store_handle,
-            key_triple,
-            PasswordContext {
-                context: key_context,
-                auth_value,
-            },
-            attributes,
-        )?;
-
-        Ok(psa_generate_key::Result {})
+        self.psa_generate_key_internal(app_name, op)
     }
 
     fn psa_import_key(
@@ -211,74 +102,7 @@ impl Provide for TpmProvider {
         app_name: ApplicationName,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
-        if op.attributes.key_type != KeyType::RsaPublicKey {
-            error!("The TPM provider currently only supports importing RSA public key.");
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        let key_name = op.key_name;
-        let attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
-        let key_data = op.data;
-
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-        let mut esapi_context = self
-            .esapi_context
-            .lock()
-            .expect("ESAPI Context lock poisoned");
-
-        let public_key: RsaPublicKey = picky_asn1_der::from_bytes(&key_data).or_else(|err| {
-            error!("Could not deserialise key elements: {}.", err);
-            Err(ResponseStatus::PsaErrorInvalidArgument)
-        })?;
-
-        if public_key.modulus.is_negative() || public_key.public_exponent.is_negative() {
-            error!("Only positive modulus and public exponent are supported.");
-            return Err(ResponseStatus::PsaErrorInvalidArgument);
-        }
-
-        if public_key.public_exponent.as_unsigned_bytes_be() != PUBLIC_EXPONENT {
-            error!("The TPM Provider only supports 0x101 as public exponent for RSA public keys, {:?} given.", public_key.public_exponent.as_unsigned_bytes_be());
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-        let key_data = public_key.modulus.as_unsigned_bytes_be();
-        let len = key_data.len();
-
-        let key_bits = attributes.key_bits;
-        if key_bits != 0 && len * 8 != key_bits as usize {
-            error!("If the key_bits field is non-zero (value is {}) it must be equal to the size of the key in data.", attributes.key_bits);
-            return Err(ResponseStatus::PsaErrorInvalidArgument);
-        }
-
-        if len != 128 && len != 256 {
-            error!(
-                "The TPM provider only supports 1024 and 2048 bits RSA public keys ({} bits given).",
-                len * 8
-            );
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        let pub_key_context = esapi_context
-            .load_external_rsa_public_key(&key_data)
-            .or_else(|e| {
-                error!("Error creating a RSA signing key: {}.", e);
-                Err(utils::to_response_status(e))
-            })?;
-
-        insert_password_context(
-            &mut *store_handle,
-            key_triple,
-            PasswordContext {
-                context: pub_key_context,
-                auth_value: Vec::new(),
-            },
-            attributes,
-        )?;
-
-        Ok(psa_import_key::Result {})
+        self.psa_import_key_internal(app_name, op)
     }
 
     fn psa_export_public_key(
@@ -286,36 +110,7 @@ impl Provide for TpmProvider {
         app_name: ApplicationName,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
-        let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
-
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let mut esapi_context = self
-            .esapi_context
-            .lock()
-            .expect("ESAPI Context lock poisoned");
-
-        let (password_context, _key_attributes) = get_password_context(&*store_handle, key_triple)?;
-
-        let pub_key_data = esapi_context
-            .read_public_key(password_context.context)
-            .or_else(|e| {
-                error!("Error reading a public key: {}.", e);
-                Err(utils::to_response_status(e))
-            })?;
-
-        let key = RsaPublicKey {
-            // To produce a valid ASN.1 RSAPublicKey structure, 0x00 is put in front of the positive
-            // modulus if highest significant bit is one, to differentiate it from a negative number.
-            modulus: IntegerAsn1::from_unsigned_bytes_be(pub_key_data),
-            public_exponent: IntegerAsn1::from_signed_bytes_be(PUBLIC_EXPONENT.to_vec()),
-        };
-        let key_data = picky_asn1_der::to_vec(&key).or_else(|err| {
-            error!("Could not serialise key elements: {}.", err);
-            Err(ResponseStatus::PsaErrorCommunicationFailure)
-        })?;
-
-        Ok(psa_export_public_key::Result { data: key_data })
+        self.psa_export_public_key_internal(app_name, op)
     }
 
     fn psa_destroy_key(
@@ -323,27 +118,7 @@ impl Provide for TpmProvider {
         app_name: ApplicationName,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
-        let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-
-        let error_closure = |e| Err(key_info_managers::to_response_status(e));
-        if store_handle
-            .remove(&key_triple)
-            .or_else(error_closure)?
-            .is_none()
-        {
-            error!(
-                "Key triple \"{}\" does not exist in the Key Info Manager.",
-                key_triple
-            );
-            Err(ResponseStatus::PsaErrorDoesNotExist)
-        } else {
-            Ok(psa_destroy_key::Result {})
-        }
+        self.psa_destroy_key_internal(app_name, op)
     }
 
     fn psa_sign_hash(
@@ -351,63 +126,7 @@ impl Provide for TpmProvider {
         app_name: ApplicationName,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_name = op.key_name;
-        let hash = op.hash;
-        let alg = op.alg;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
-
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let mut esapi_context = self
-            .esapi_context
-            .lock()
-            .expect("ESAPI Context lock poisoned");
-
-        if alg
-            != (AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: Hash::Sha256,
-            })
-        {
-            error!(
-                "The TPM provider currently only supports signature algorithm to be RSA PKCS#1 v1.5 and the text hashed with SHA-256.");
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        if hash.len() != 32 {
-            error!("The SHA-256 hash must be 32 bytes long.");
-            return Err(ResponseStatus::PsaErrorInvalidArgument);
-        }
-
-        let (password_context, key_attributes) = get_password_context(&*store_handle, key_triple)?;
-
-        key_attributes.can_sign_hash()?;
-        key_attributes.permits_alg(alg.into())?;
-        key_attributes.compatible_with_alg(alg.into())?;
-
-        match alg {
-            AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: Hash::Sha256,
-            } => (),
-            _ => {
-                error!(
-                    "The TPM provider currently only supports \"RSA PKCS#1 v1.5 signature with hashing\" algorithm with SHA-256 as hashing algorithm for the PsaSignHash operation.");
-                return Err(ResponseStatus::PsaErrorNotSupported);
-            }
-        }
-
-        let signature = esapi_context
-            .sign(
-                password_context.context,
-                &password_context.auth_value,
-                &hash,
-            )
-            .or_else(|e| {
-                error!("Error signing: {}.", e);
-                Err(utils::to_response_status(e))
-            })?;
-
-        Ok(psa_sign_hash::Result {
-            signature: signature.signature,
-        })
+        self.psa_sign_hash_internal(app_name, op)
     }
 
     fn psa_verify_hash(
@@ -415,60 +134,7 @@ impl Provide for TpmProvider {
         app_name: ApplicationName,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_name = op.key_name;
-        let hash = op.hash;
-        let alg = op.alg;
-        let signature = op.signature;
-        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, key_name);
-
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let mut esapi_context = self
-            .esapi_context
-            .lock()
-            .expect("ESAPI Context lock poisoned");
-
-        if alg
-            != (AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: Hash::Sha256,
-            })
-        {
-            error!(
-                "The TPM provider currently only supports signature algorithm to be RSA PKCS#1 v1.5 and the text hashed with SHA-256.");
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-
-        if hash.len() != 32 {
-            error!("The SHA-256 hash must be 32 bytes long.");
-            return Err(ResponseStatus::PsaErrorInvalidArgument);
-        }
-
-        let signature = Signature {
-            scheme: AsymSchemeUnion::RSASSA(TPM2_ALG_SHA256),
-            signature,
-        };
-
-        let (password_context, key_attributes) = get_password_context(&*store_handle, key_triple)?;
-
-        key_attributes.can_verify_hash()?;
-        key_attributes.permits_alg(alg.into())?;
-        key_attributes.compatible_with_alg(alg.into())?;
-
-        match alg {
-            AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: Hash::Sha256,
-            } => (),
-            _ => {
-                error!(
-                    "The TPM provider currently only supports \"RSA PKCS#1 v1.5 signature with hashing\" algorithm with SHA-256 as hashing algorithm for the PsaVerifyHash operation.");
-                return Err(ResponseStatus::PsaErrorNotSupported);
-            }
-        }
-
-        let _ = esapi_context
-            .verify_signature(password_context.context, &hash, signature)
-            .or_else(|e| Err(utils::to_response_status(e)))?;
-
-        Ok(psa_verify_hash::Result {})
+        self.psa_verify_hash_internal(app_name, op)
     }
 }
 

--- a/src/providers/tpm_provider/utils.rs
+++ b/src/providers/tpm_provider/utils.rs
@@ -3,7 +3,10 @@
 
 use log::error;
 use parsec_interface::requests::ResponseStatus;
+use picky_asn1::wrapper::IntegerAsn1;
+use serde::{Deserialize, Serialize};
 use tss_esapi::response_code::{Error, Tss2ResponseCodeKind};
+use tss_esapi::utils::TpmsContext;
 
 /// Convert the TSS library specific error values to ResponseStatus values that are returned on
 /// the wire protocol
@@ -62,4 +65,22 @@ pub fn to_response_status(error: Error) -> ResponseStatus {
             }
         }
     }
+}
+
+// The RSA Public Key data are DER encoded with the following representation:
+// RSAPublicKey ::= SEQUENCE {
+//     modulus            INTEGER,  -- n
+//     publicExponent     INTEGER   -- e
+// }
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RsaPublicKey {
+    pub modulus: IntegerAsn1,
+    pub public_exponent: IntegerAsn1,
+}
+
+// The PasswordContext is what is stored by the Key Info Manager.
+#[derive(Serialize, Deserialize)]
+pub struct PasswordContext {
+    pub context: TpmsContext,
+    pub auth_value: Vec<u8>,
 }


### PR DESCRIPTION
This commit splits the code for the 3 existing providers into separate
modules: one for key management (containing the code for key
destruction, creation, import and export) and one for asymetric signing
(currently containing code for signing and verifying hashes).

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

Fixes #133 