### PR TITLE
Improve TPM provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
+name = "enumflags2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.18",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +374,12 @@ checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "humantime"
@@ -518,6 +544,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.18",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,7 +626,7 @@ dependencies = [
  "bytes 0.4.12",
  "log",
  "num",
- "num-derive",
+ "num-derive 0.2.5",
  "num-traits",
  "prost",
  "prost-build",
@@ -607,6 +644,7 @@ dependencies = [
  "cargo_toml",
  "derivative",
  "env_logger 0.7.1",
+ "hex",
  "lazy_static",
  "log",
  "parsec-interface",
@@ -1143,14 +1181,17 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "2.0.0"
+version = "4.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3b539f6041adee649c4d7a3fd9f7b38add791cf3c22d741434918c47f017d6"
+checksum = "b1603cf9e6bd76eb9f574f51334beb8ac887952902b50a7b6c9422d652bdefff"
 dependencies = [
  "bindgen 0.52.0",
  "bitfield",
+ "enumflags2",
  "log",
  "mbox",
+ "num-derive 0.3.0",
+ "num-traits",
  "pkg-config",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,12 @@ log = { version = "0.4.8", features = ["serde"] }
 pkcs11 = { version = "0.4.0", optional = true }
 picky-asn1-der = { version = "0.2.2", optional = true }
 picky-asn1 = { version = "0.2.1", optional = true }
-tss-esapi = { version = "2.0.0", optional = true }
+tss-esapi = { version = "4.0.0-alpha.1", optional = true }
 bincode = "1.1.4"
 structopt = "0.3.5"
 derivative = "2.1.1"
 version = "3.0.0"
+hex = "0.4.2"
 
 [dev-dependencies]
 ring = "0.16.12"

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ This project uses the following third party crates:
 * lazy_static (MIT and Apache-2.0)
 * version (MIT and Apache-2.0)
 * sha2 (MIT and Apache-2.0)
+* hex (MIT and Apache-2.0)
 
 This project uses the following third party libraries:
 * [**Mbed Crypto**](https://github.com/ARMmbed/mbed-crypto) (Apache-2.0)

--- a/config.toml
+++ b/config.toml
@@ -74,5 +74,8 @@ key_info_manager = "on-disk-manager"
 # - "tabrmd": uses the TPM2 Access Broker & Resource Management Daemon
 #tcti = "mssim"
 # (Required) Authentication value for performing operations on the TPM Owner Hierarchy. The string can
-# be empty, however we strongly suggest that you use a secure password.
+# be empty, however we strongly suggest that you use a secure passcode.
+# To align with TPM tooling, PARSEC allows "owner_hierarchy_auth" to have a prefix indicating a string value,
+# e.g. "str:password", or to represent a string version of a hex value, e.g. "hex:1a2b3c". If no prefix is
+# provided, the value is considered to be a string.
 #owner_hierarchy_auth = "password"

--- a/e2e_tests/provider_cfg/all/Dockerfile
+++ b/e2e_tests/provider_cfg/all/Dockerfile
@@ -16,7 +16,7 @@ RUN cd mbed-crypto-mbedcrypto-2.0.0 \
 
 WORKDIR /tmp
 # Download and install TSS 2.0
-RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.1
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.3
 RUN cd tpm2-tss \
 	&& ./bootstrap \
 	&& ./configure \

--- a/e2e_tests/provider_cfg/tpm/Dockerfile
+++ b/e2e_tests/provider_cfg/tpm/Dockerfile
@@ -3,7 +3,7 @@ FROM tpm2software/tpm2-tss:ubuntu-18.04
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 
 # Download and install TSS 2.0
-RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.1
+RUN git clone https://github.com/tpm2-software/tpm2-tss.git --branch 2.3.3
 RUN cd tpm2-tss \
 	&& ./bootstrap \
 	&& ./configure \

--- a/e2e_tests/provider_cfg/tpm/config.toml
+++ b/e2e_tests/provider_cfg/tpm/config.toml
@@ -16,4 +16,4 @@ manager_type = "OnDisk"
 provider_type = "Tpm"
 key_info_manager = "on-disk-manager"
 tcti = "mssim"
-owner_hierarchy_auth = "tpm_pass"
+owner_hierarchy_auth = "hex:74706d5f70617373" # "tpm_pass" in hex


### PR DESCRIPTION
This commit includes a couple of fixes in the TPM provider.
* the TSS crate used has been updated to the latest one, including a few
functionality updates; this now allows the session hash algorithm and
the cipher used for sessions and primary key
* more control over the format of the authentication value is now
offered to admins; more precisely, they can provide string versions of
hex values, prefixed by "hex:"

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

Fixes #120 
Fixes #121 