### PR TITLE
Add ECDSA support for TPM provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "parsec-interface"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd624e1236194a6ee915f7b54f03c6e94a7d4b8a63062db65397c3af25b323eb"
+checksum = "702a234e09ad3735c845136728dd2755b8acf979919ffeecf53f72f62b7ad934"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "4.0.0-alpha.1"
+version = "4.0.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1603cf9e6bd76eb9f574f51334beb8ac887952902b50a7b6c9422d652bdefff"
+checksum = "71ade800b2821a2d093a71c91998e2c2829c317e13d3772c7c83551ceb02801c"
 dependencies = [
  "bindgen 0.52.0",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = "0.14.0"
+parsec-interface = "0.14.1"
 rand = "0.7.2"
 base64 = "0.10.1"
 uuid = "0.7.4"
@@ -33,7 +33,7 @@ log = { version = "0.4.8", features = ["serde"] }
 pkcs11 = { version = "0.4.0", optional = true }
 picky-asn1-der = { version = "0.2.2", optional = true }
 picky-asn1 = { version = "0.2.1", optional = true }
-tss-esapi = { version = "4.0.0-alpha.1", optional = true }
+tss-esapi = { version = "4.0.2-alpha.1", optional = true }
 bincode = "1.1.4"
 structopt = "0.3.5"
 derivative = "2.1.1"

--- a/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use e2e_tests::TestClient;
 use parsec_client::core::interface::operations::psa_algorithm::{
-    Algorithm, AsymmetricSignature, Cipher, Hash,
+    Algorithm, AsymmetricSignature, Hash,
 };
 use parsec_client::core::interface::operations::psa_key_attributes::{
     KeyAttributes, KeyPolicy, KeyType, UsageFlags,
@@ -100,7 +100,10 @@ fn wrong_permitted_algorithm() {
 
     let key_type = KeyType::RsaKeyPair;
     // Do not permit RSA PKCS 1v15 signing algorithm with SHA-256.
-    let permitted_algorithm = Algorithm::Cipher(Cipher::Ctr);
+    let permitted_algorithm =
+        Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
+            hash_alg: Hash::Sha512,
+        });
     let key_attributes = KeyAttributes {
         key_type,
         key_bits: 1024,

--- a/tests/providers/tpm.rs
+++ b/tests/providers/tpm.rs
@@ -3,7 +3,10 @@
 use lazy_static::lazy_static;
 use parsec_interface::operations::psa_algorithm::*;
 use parsec_interface::operations::psa_key_attributes::*;
-use parsec_interface::operations::{psa_export_public_key, psa_generate_key, psa_sign_hash};
+use parsec_interface::operations::{
+    psa_export_public_key, psa_generate_key, psa_sign_hash, psa_verify_hash,
+};
+use parsec_interface::requests::ResponseStatus;
 use parsec_service::authenticators::ApplicationName;
 use parsec_service::key_info_managers::on_disk_manager::OnDiskKeyInfoManagerBuilder;
 use parsec_service::providers::tpm_provider::{TpmProvider, TpmProviderBuilder};
@@ -66,6 +69,35 @@ fn gen_rsa_sign_key_op(key_name: String) -> psa_generate_key::Operation {
     }
 }
 
+fn gen_ecc_sign_key_op(key_name: String) -> psa_generate_key::Operation {
+    psa_generate_key::Operation {
+        key_name,
+        attributes: KeyAttributes {
+            key_type: KeyType::EccKeyPair {
+                curve_family: EccFamily::SecpR1,
+            },
+            key_bits: 256,
+            key_policy: KeyPolicy {
+                key_usage_flags: UsageFlags {
+                    export: true,
+                    copy: false,
+                    cache: false,
+                    encrypt: false,
+                    decrypt: false,
+                    sign_message: true,
+                    sign_hash: true,
+                    verify_message: true,
+                    verify_hash: true,
+                    derive: false,
+                },
+                key_algorithm: Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                }),
+            },
+        },
+    }
+}
+
 #[test]
 fn verify_with_ring() {
     let key_name = String::from("key_name");
@@ -92,4 +124,83 @@ fn verify_with_ring() {
         .unwrap();
     let pk = UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, data);
     pk.verify(&MESSAGE, &sign).unwrap();
+}
+
+#[test]
+fn verify_ecc_with_ring() {
+    let key_name = String::from("key_name");
+    let app_name = ApplicationName::new(String::from("verify_ecc_with_ring"));
+    let _ = TPM_PROVIDER
+        .psa_generate_key(app_name.clone(), gen_ecc_sign_key_op(key_name.clone()))
+        .unwrap();
+
+    let psa_sign_hash::Result { signature: sign } = TPM_PROVIDER
+        .psa_sign_hash(
+            app_name.clone(),
+            psa_sign_hash::Operation {
+                key_name: key_name.clone(),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                },
+                hash: HASH.clone(),
+            },
+        )
+        .unwrap();
+
+    let psa_export_public_key::Result { data } = TPM_PROVIDER
+        .psa_export_public_key(app_name, psa_export_public_key::Operation { key_name })
+        .unwrap();
+    let pk = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_FIXED, data);
+    pk.verify(&MESSAGE, &sign).unwrap();
+}
+
+#[test]
+fn sign_verify_ecc() {
+    let key_name = String::from("key_name");
+    let app_name = ApplicationName::new(String::from("sign_verify_ecc"));
+    let _ = TPM_PROVIDER
+        .psa_generate_key(app_name.clone(), gen_ecc_sign_key_op(key_name.clone()))
+        .unwrap();
+
+    let psa_sign_hash::Result { signature: sign } = TPM_PROVIDER
+        .psa_sign_hash(
+            app_name.clone(),
+            psa_sign_hash::Operation {
+                key_name: key_name.clone(),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                },
+                hash: HASH.clone(),
+            },
+        )
+        .unwrap();
+
+    let _ = TPM_PROVIDER
+        .psa_verify_hash(
+            app_name,
+            psa_verify_hash::Operation {
+                key_name,
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                },
+                hash: HASH.clone(),
+                signature: sign,
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn wildcard_hash_not_supported() {
+    let key_name = String::from("key_name");
+    let app_name = ApplicationName::new(String::from("wildcard_hash_not_supported"));
+    let mut op = gen_ecc_sign_key_op(key_name);
+    op.attributes.key_policy.key_algorithm =
+        Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa {
+            hash_alg: Hash::Any,
+        });
+    assert_eq!(
+        TPM_PROVIDER.psa_generate_key(app_name, op).unwrap_err(),
+        ResponseStatus::PsaErrorNotSupported
+    );
 }


### PR DESCRIPTION
This commit expands the supported algorithms for the TPM provider to
include ECDSA key creation, as well as signing, verification and public
key export for them.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>