### PR TITLE
Improve handling of list_opcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "parsec-interface"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702a234e09ad3735c845136728dd2755b8acf979919ffeecf53f72f62b7ad934"
+checksum = "3af91cbaea6e805729d28101be13161cb75e75b8425a9197008190202019cc84"
 dependencies = [
  "arbitrary",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = "0.14.1"
+parsec-interface = "0.14.2"
 rand = "0.7.2"
 base64 = "0.10.1"
 uuid = "0.7.4"

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -18,7 +18,7 @@ picky-asn1-der = "0.2.2"
 picky-asn1 = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.1"
-parsec-client = { version = "0.2.0", features = ["testing"] }
+parsec-client = { version = "0.3.0", features = ["testing"] }
 log = "0.4.8"
 rand = "0.7.3"
 

--- a/e2e_tests/tests/all_providers/mod.rs
+++ b/e2e_tests/tests/all_providers/mod.rs
@@ -22,9 +22,6 @@ fn list_providers() {
 }
 
 #[test]
-// ListOpcodes is not currently supported only by the Core Provider, see
-// parallaxsecond/parsec-operations#9
-#[ignore]
 fn list_opcodes() {
     let mut client = TestClient::new();
     let mut crypto_providers_opcodes = HashSet::new();

--- a/src/providers/mbed_provider/mod.rs
+++ b/src/providers/mbed_provider/mod.rs
@@ -8,8 +8,8 @@ use derivative::Derivative;
 use log::error;
 use parsec_interface::operations::list_providers::ProviderInfo;
 use parsec_interface::operations::{
-    list_opcodes, psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
-    psa_sign_hash, psa_verify_hash,
+    psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key, psa_sign_hash,
+    psa_verify_hash,
 };
 use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use psa_crypto_binding::psa_key_id_t;
@@ -40,14 +40,13 @@ mod utils;
 
 type LocalIdStore = HashSet<psa_key_id_t>;
 
-const SUPPORTED_OPCODES: [Opcode; 7] = [
+const SUPPORTED_OPCODES: [Opcode; 6] = [
     Opcode::PsaGenerateKey,
     Opcode::PsaDestroyKey,
     Opcode::PsaSignHash,
     Opcode::PsaVerifyHash,
     Opcode::PsaImportKey,
     Opcode::PsaExportPublicKey,
-    Opcode::ListOpcodes,
 ];
 
 #[derive(Derivative)]
@@ -153,14 +152,8 @@ impl MbedProvider {
 }
 
 impl Provide for MbedProvider {
-    fn list_opcodes(&self, _op: list_opcodes::Operation) -> Result<list_opcodes::Result> {
-        Ok(list_opcodes::Result {
-            opcodes: SUPPORTED_OPCODES.iter().copied().collect(),
-        })
-    }
-
-    fn describe(&self) -> Result<ProviderInfo> {
-        Ok(ProviderInfo {
+    fn describe(&self) -> Result<(ProviderInfo, HashSet<Opcode>)> {
+        Ok((ProviderInfo {
             // Assigned UUID for this provider: 1c1139dc-ad7c-47dc-ad6b-db6fdb466552
             uuid: Uuid::parse_str("1c1139dc-ad7c-47dc-ad6b-db6fdb466552").or(Err(ResponseStatus::InvalidEncoding))?,
             description: String::from("User space software provider, based on Mbed Crypto - the reference implementation of the PSA crypto API"),
@@ -169,7 +162,7 @@ impl Provide for MbedProvider {
             version_min: 1,
             version_rev: 0,
             id: ProviderID::MbedCrypto,
-        })
+        }, SUPPORTED_OPCODES.iter().copied().collect()))
     }
 
     fn psa_generate_key(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -6,8 +6,9 @@
 //! are the real implementors of the operations that Parsec claims to support. They map to
 //! functionality in the underlying hardware which allows the PSA Crypto operations to be
 //! backed by a hardware root of trust.
-use parsec_interface::requests::ProviderID;
+use parsec_interface::requests::{Opcode, ProviderID};
 use serde::Deserialize;
+use std::collections::HashSet;
 
 pub mod core_provider;
 
@@ -86,15 +87,19 @@ pub trait Provide {
     /// Return a description of the current provider.
     ///
     /// The descriptions are gathered in the Core Provider and returned for a ListProviders operation.
-    fn describe(&self) -> Result<list_providers::ProviderInfo>;
+    fn describe(&self) -> Result<(list_providers::ProviderInfo, HashSet<Opcode>)> {
+        Err(ResponseStatus::PsaErrorNotSupported)
+    }
 
     /// List the providers running in the service.
     fn list_providers(&self, _op: list_providers::Operation) -> Result<list_providers::Result> {
         Err(ResponseStatus::PsaErrorNotSupported)
     }
 
-    /// List the opcodes supported by the current provider.
-    fn list_opcodes(&self, _op: list_opcodes::Operation) -> Result<list_opcodes::Result>;
+    /// List the opcodes supported by the given provider.
+    fn list_opcodes(&self, _op: list_opcodes::Operation) -> Result<list_opcodes::Result> {
+        Err(ResponseStatus::PsaErrorNotSupported)
+    }
 
     /// Execute a Ping operation to get the wire protocol version major and minor information.
     ///

--- a/src/providers/pkcs11_provider/mod.rs
+++ b/src/providers/pkcs11_provider/mod.rs
@@ -11,8 +11,8 @@ use derivative::Derivative;
 use log::{error, info, warn};
 use parsec_interface::operations::list_providers::ProviderInfo;
 use parsec_interface::operations::{
-    list_opcodes, psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
-    psa_sign_hash, psa_verify_hash,
+    psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key, psa_sign_hash,
+    psa_verify_hash,
 };
 use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use pkcs11::types::{CKF_OS_LOCKING_OK, CK_C_INITIALIZE_ARGS, CK_SLOT_ID};
@@ -29,14 +29,13 @@ mod asym_sign;
 mod key_management;
 mod utils;
 
-const SUPPORTED_OPCODES: [Opcode; 7] = [
+const SUPPORTED_OPCODES: [Opcode; 6] = [
     Opcode::PsaGenerateKey,
     Opcode::PsaDestroyKey,
     Opcode::PsaSignHash,
     Opcode::PsaVerifyHash,
     Opcode::PsaImportKey,
     Opcode::PsaExportPublicKey,
-    Opcode::ListOpcodes,
 ];
 
 /// Provider for Public Key Cryptography Standard #11
@@ -162,24 +161,23 @@ impl Pkcs11Provider {
 }
 
 impl Provide for Pkcs11Provider {
-    fn list_opcodes(&self, _op: list_opcodes::Operation) -> Result<list_opcodes::Result> {
-        Ok(list_opcodes::Result {
-            opcodes: SUPPORTED_OPCODES.iter().copied().collect(),
-        })
-    }
-
-    fn describe(&self) -> Result<ProviderInfo> {
-        Ok(ProviderInfo {
-            // Assigned UUID for this provider: 30e39502-eba6-4d60-a4af-c518b7f5e38f
-            uuid: Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f")
-                .or(Err(ResponseStatus::InvalidEncoding))?,
-            description: String::from("PKCS #11 provider, interfacing with a PKCS #11 library."),
-            vendor: String::from("OASIS Standard."),
-            version_maj: 0,
-            version_min: 1,
-            version_rev: 0,
-            id: ProviderID::Pkcs11,
-        })
+    fn describe(&self) -> Result<(ProviderInfo, HashSet<Opcode>)> {
+        Ok((
+            ProviderInfo {
+                // Assigned UUID for this provider: 30e39502-eba6-4d60-a4af-c518b7f5e38f
+                uuid: Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f")
+                    .or(Err(ResponseStatus::InvalidEncoding))?,
+                description: String::from(
+                    "PKCS #11 provider, interfacing with a PKCS #11 library.",
+                ),
+                vendor: String::from("OASIS Standard."),
+                version_maj: 0,
+                version_min: 1,
+                version_rev: 0,
+                id: ProviderID::Pkcs11,
+            },
+            SUPPORTED_OPCODES.iter().copied().collect(),
+        ))
     }
 
     fn psa_generate_key(

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -148,17 +148,17 @@ fn build_backend_handlers(
 ) -> Result<HashMap<ProviderID, BackEndHandler>> {
     let mut map = HashMap::new();
 
-    let mut core_provider_builder = CoreProviderBuilder::new()
+    let mut core_provider_builder = CoreProviderBuilder::new()?
         .with_wire_protocol_version(WIRE_PROTOCOL_VERSION_MINOR, WIRE_PROTOCOL_VERSION_MAJOR);
 
     for (provider_id, provider) in providers.drain() {
-        core_provider_builder =
-            core_provider_builder.with_provider_info(provider.describe().or_else(|_| {
-                Err(Error::new(
-                    ErrorKind::InvalidData,
-                    "error describing Core provider",
-                ))
-            })?);
+        let (info, opcodes) = provider.describe().or_else(|_| {
+            Err(Error::new(
+                ErrorKind::InvalidData,
+                "error describing provider",
+            ))
+        })?;
+        core_provider_builder = core_provider_builder.with_provider_details(info, opcodes);
 
         let backend_handler = BackEndHandlerBuilder::new()
             .with_provider(provider)


### PR DESCRIPTION
This commit adjusts the handling of `list_opcodes` to match the
documentation. This implies allowing the Core provider to reply with a
set of opcodes on behalf of the other providers.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>