### PR TITLE
Changed local_ids for Atomic counter and removed key_slot_semaphore.

### DIFF
--- a/src/providers/mbed_provider/asym_sign.rs
+++ b/src/providers/mbed_provider/asym_sign.rs
@@ -16,7 +16,6 @@ impl MbedProvider {
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
         info!("Mbed Provider - Asym Sign");
-        let _semaphore_guard = self.key_slot_semaphore.access();
         let key_name = op.key_name;
         let hash = op.hash;
         let alg = op.alg;
@@ -53,7 +52,6 @@ impl MbedProvider {
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
         info!("Mbed Provider - Asym Verify");
-        let _semaphore_guard = self.key_slot_semaphore.access();
         let key_name = op.key_name;
         let hash = op.hash;
         let alg = op.alg;

--- a/src/providers/mbed_provider/key_management.rs
+++ b/src/providers/mbed_provider/key_management.rs
@@ -1,9 +1,10 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use super::{LocalIdStore, MbedProvider};
+use super::MbedProvider;
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers;
 use crate::key_info_managers::{KeyInfo, KeyTriple, ManageKeyInfo};
+use log::error;
 use log::{info, warn};
 use parsec_interface::operations::psa_key_attributes::Attributes;
 use parsec_interface::operations::{
@@ -12,8 +13,7 @@ use parsec_interface::operations::{
 use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
 use psa_crypto::operations::key_management as psa_crypto_key_management;
 use psa_crypto::types::key;
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
 
 /// Gets a PSA Key ID from the Key Info Manager.
 /// Wrapper around the get method of the Key Info Manager to convert the key ID to the psa_key_id_t
@@ -46,16 +46,23 @@ fn create_key_id(
     key_triple: KeyTriple,
     key_attributes: Attributes,
     store_handle: &mut dyn ManageKeyInfo,
-    local_ids_handle: &mut LocalIdStore,
+    max_current_id: &AtomicU32,
 ) -> Result<key::psa_key_id_t> {
-    let mut rng = SmallRng::from_entropy();
-    let mut key_id = rng.gen_range(key::PSA_KEY_ID_USER_MIN, key::PSA_KEY_ID_USER_MAX + 1);
-
-    while local_ids_handle.contains(&key_id) {
-        key_id = rng.gen_range(key::PSA_KEY_ID_USER_MIN, key::PSA_KEY_ID_USER_MAX + 1);
+    // fetch_add adds 1 to the old value and returns the old value, so add 1 to local value for new ID
+    let new_key_id = max_current_id.fetch_add(1, Relaxed) + 1;
+    if new_key_id > key::PSA_KEY_ID_USER_MAX {
+        // If storing key failed and no other keys were created in the mean time, it is safe to
+        // decrement the key counter.
+        let _ = max_current_id.store(key::PSA_KEY_ID_USER_MAX, Relaxed);
+        error!(
+            "PSA max key ID limit of {} reached",
+            key::PSA_KEY_ID_USER_MAX
+        );
+        return Err(ResponseStatus::PsaErrorInsufficientMemory);
     }
+
     let key_info = KeyInfo {
-        id: key_id.to_ne_bytes().to_vec(),
+        id: new_key_id.to_ne_bytes().to_vec(),
         attributes: key_attributes,
     };
     match store_handle.insert(key_triple.clone(), key_info) {
@@ -63,25 +70,16 @@ fn create_key_id(
             if insert_option.is_some() {
                 warn!("Overwriting Key triple mapping ({})", key_triple);
             }
-            let _ = local_ids_handle.insert(key_id);
-
-            Ok(key_id)
+            Ok(new_key_id)
         }
         Err(string) => Err(key_info_managers::to_response_status(string)),
     }
 }
 
-fn remove_key_id(
-    key_triple: &KeyTriple,
-    key_id: key::psa_key_id_t,
-    store_handle: &mut dyn ManageKeyInfo,
-    local_ids_handle: &mut LocalIdStore,
-) -> Result<()> {
+fn remove_key_id(key_triple: &KeyTriple, store_handle: &mut dyn ManageKeyInfo) -> Result<()> {
+    // ID Counter not affected as overhead and extra complication deemed unnecessary
     match store_handle.remove(key_triple) {
-        Ok(_) => {
-            let _ = local_ids_handle.remove(&key_id);
-            Ok(())
-        }
+        Ok(_) => Ok(()),
         Err(string) => Err(key_info_managers::to_response_status(string)),
     }
 }
@@ -99,7 +97,6 @@ impl MbedProvider {
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         info!("Mbed Provider - Create Key");
-        let _semaphore_guard = self.key_slot_semaphore.access();
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
@@ -107,7 +104,6 @@ impl MbedProvider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
         if key_info_exists(&key_triple, &*store_handle)? {
             return Err(ResponseStatus::PsaErrorAlreadyExists);
         }
@@ -115,7 +111,7 @@ impl MbedProvider {
             key_triple.clone(),
             key_attributes,
             &mut *store_handle,
-            &mut local_ids_handle,
+            &self.id_counter,
         )?;
 
         let _guard = self
@@ -126,12 +122,7 @@ impl MbedProvider {
         match psa_crypto_key_management::generate(key_attributes, Some(key_id)) {
             Ok(_) => Ok(psa_generate_key::Result {}),
             Err(error) => {
-                remove_key_id(
-                    &key_triple,
-                    key_id,
-                    &mut *store_handle,
-                    &mut local_ids_handle,
-                )?;
+                remove_key_id(&key_triple, &mut *store_handle)?;
                 let error = ResponseStatus::from(error);
                 format_error!("Generate key status: {}", error);
                 Err(error)
@@ -145,7 +136,6 @@ impl MbedProvider {
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         info!("Mbed Provider - Import Key");
-        let _semaphore_guard = self.key_slot_semaphore.access();
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_data = op.data;
@@ -154,7 +144,6 @@ impl MbedProvider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
         if key_info_exists(&key_triple, &*store_handle)? {
             return Err(ResponseStatus::PsaErrorAlreadyExists);
         }
@@ -162,7 +151,7 @@ impl MbedProvider {
             key_triple.clone(),
             key_attributes,
             &mut *store_handle,
-            &mut local_ids_handle,
+            &self.id_counter,
         )?;
 
         let _guard = self
@@ -173,12 +162,7 @@ impl MbedProvider {
         match psa_crypto_key_management::import(key_attributes, Some(key_id), &key_data[..]) {
             Ok(_) => Ok(psa_import_key::Result {}),
             Err(error) => {
-                remove_key_id(
-                    &key_triple,
-                    key_id,
-                    &mut *store_handle,
-                    &mut local_ids_handle,
-                )?;
+                remove_key_id(&key_triple, &mut *store_handle)?;
                 let error = ResponseStatus::from(error);
                 format_error!("Import key status: {}", error);
                 Err(error)
@@ -192,7 +176,6 @@ impl MbedProvider {
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         info!("Mbed Provider - Export Public Key");
-        let _semaphore_guard = self.key_slot_semaphore.access();
         let key_name = op.key_name;
         let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
         let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
@@ -220,14 +203,12 @@ impl MbedProvider {
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         info!("Mbed Provider - Destroy Key");
-        let _semaphore_guard = self.key_slot_semaphore.access();
         let key_name = op.key_name;
         let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
         let mut store_handle = self
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
         let key_id = get_key_id(&key_triple, &*store_handle)?;
 
         let _guard = self
@@ -247,12 +228,7 @@ impl MbedProvider {
 
         match destroy_key_status {
             Ok(()) => {
-                remove_key_id(
-                    &key_triple,
-                    key_id,
-                    &mut *store_handle,
-                    &mut local_ids_handle,
-                )?;
+                remove_key_id(&key_triple, &mut *store_handle)?;
                 Ok(psa_destroy_key::Result {})
             }
             Err(error) => {


### PR DESCRIPTION
`key_slot_semaphore` removed - #187 1.

`local_ids` changed to an `AtomicU32` that store the current highest key ID including destroyed keys). On load, loops through all stored keys and sets the counter to the max ID. On creating a key ID, adds 1 to the counter. If key store fails and no thread has created another key in the mean time, decrements the counter to the value before the attempt to create a new key ID failed. On key destroy, counter not altered as extra complication deemed unnecessary. #187 2.

Signed-off-by: Samuel Bailey <samuel.bailey@arm.com>