### PR TITLE
Add TCTI configuration functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "hostname-validator"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b8bcb948d9f63a35f0527cde7ca4f4794e817451eaebd47a3c92ef6905c129"
+
+[[package]]
 name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,18 +1471,20 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "4.0.3-alpha.1"
+version = "4.0.5-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b8770c1c7414f8a4390627337ddf01091b3955a175692442dffb280ecb8e6c"
+checksum = "f6c7d8fe1664e642607e5aeea9407e27b2e293424418c9a1d972ac8dea8e0320"
 dependencies = [
  "bindgen",
  "bitfield",
  "enumflags2",
+ "hostname-validator",
  "log",
  "mbox",
  "num-derive",
  "num-traits",
  "pkg-config",
+ "regex",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ log = { version = "0.4.8", features = ["serde"] }
 pkcs11 = { version = "0.4.0", optional = true }
 picky-asn1-der = { version = "0.2.2", optional = true }
 picky-asn1 = { version = "0.2.1", optional = true }
-tss-esapi = { version = "4.0.3-alpha.1", optional = true }
+tss-esapi = { version = "4.0.5-alpha.1", optional = true }
 bincode = "1.1.4"
 structopt = "0.3.5"
 derivative = "2.1.1"

--- a/config.toml
+++ b/config.toml
@@ -73,10 +73,16 @@ key_info_manager = "on-disk-manager"
 #[[provider]]
 #provider_type = "Tpm"
 #key_info_manager = "on-disk-manager"
-# (Required) TPM TCTI device to use with this provider. Options are:
-# - "device": uses the TPM device on /dev/tpm0
-# - "mssim": uses the simulation TPM with the socket
-# - "tabrmd": uses the TPM2 Access Broker & Resource Management Daemon
+# (Required) TPM TCTI device to use with this provider. The string can include configuration values - if no
+# configuration value is given, the defaults are used. Options are:
+# - "device": uses a TPM device available as a file node; path can be given as a configuration string,
+# e.g "device:/path/to/tpm"; the default path is /dev/tpm0
+# - "mssim": uses the TPM simulator server with the socket; server path and/or port can be given as configuration values,
+# e.g. "mssim:host=168.0.1.1,port=1234"; "host" can be set to IPv4, IPv6 or a hostname; default values are 
+# "localhost" for "host" and 2321 for "port"
+# - "tabrmd": uses the TPM2 Access Broker & Resource Management Daemon; dbus name and type ("session" or 
+# "system") can be given as parameters: e.g. "tabrmd:bus_name=some.bus.Name,bus_type=session"; default
+# values are "com.intel.tss2.Tabrmd" for "bus_name" and "system" for "bus_type"
 #tcti = "mssim"
 # (Required) Authentication value for performing operations on the TPM Owner Hierarchy. The string can
 # be empty, however we strongly suggest that you use a secure passcode.

--- a/e2e_tests/provider_cfg/tpm/config.toml
+++ b/e2e_tests/provider_cfg/tpm/config.toml
@@ -16,5 +16,5 @@ manager_type = "OnDisk"
 [[provider]]
 provider_type = "Tpm"
 key_info_manager = "on-disk-manager"
-tcti = "mssim"
+tcti = "mssim:host=127.0.0.1,port=2321"
 owner_hierarchy_auth = "hex:74706d5f70617373" # "tpm_pass" in hex


### PR DESCRIPTION
This commit adds functionality that allows admins to pass in a
configuration string for the TCTI connection to the TPM.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>