### PR TITLE
Migrated uses of a locally declared RsaPublic key to new create picky-asn1-x509

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,7 +781,7 @@ dependencies = [
 name = "parsec-service"
 version = "0.1.2"
 dependencies = [
- "base64",
+ "base64 0.10.1",
  "bincode",
  "bindgen",
  "cargo_toml",
@@ -788,6 +794,7 @@ dependencies = [
  "picky",
  "picky-asn1",
  "picky-asn1-der",
+ "picky-asn1-x509",
  "pkcs11",
  "psa-crypto",
  "rand",
@@ -827,7 +834,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3880185fff1d095094fde13a56727dd77994d1065a54bd776dcce988858ab80"
 dependencies = [
- "base64",
+ "base64 0.10.1",
  "http",
  "oid",
  "picky-asn1",
@@ -862,6 +869,19 @@ dependencies = [
  "picky-asn1",
  "serde",
  "serde_bytes",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969171630cdf5c269611dfffdc1e6d749365fc4059b86fe3620d8afa3ddce4e6"
+dependencies = [
+ "base64 0.12.3",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ hex = "0.4.2"
 picky = "5.0.0"
 psa-crypto = { version = "0.2.1" , default-features = false, features = ["with-mbed-crypto"], optional = true }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
+picky-asn1-x509 = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 ring = "0.16.12"
@@ -62,8 +63,8 @@ features = ["docs"]
 [features]
 default = []
 mbed-crypto-provider = ["psa-crypto"]
-pkcs11-provider = ["pkcs11", "picky-asn1-der", "picky-asn1"]
-tpm-provider = ["tss-esapi", "picky-asn1-der", "picky-asn1"]
+pkcs11-provider = ["pkcs11", "picky-asn1-der", "picky-asn1", "picky-asn1-x509"]
+tpm-provider = ["tss-esapi", "picky-asn1-der", "picky-asn1", "picky-asn1-x509"]
 all-providers = ["tpm-provider", "pkcs11-provider", "mbed-crypto-provider"]
 # The Mbed provider is not included in the docs because of 2 reasons:
 # 1) it is currently impossible for it to be built inside the docs.rs build system (as it has dependencies

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This project uses the following third party crates:
 * pkcs11 (Apache-2.0)
 * picky-asn1-der (MIT and Apache-2.0)
 * picky-asn1 (MIT and Apache-2.0)
+* picky-asn1-x509 (MIT and Apache-2.0)
 * bincode (MIT)
 * structopt (MIT and Apache-2.0)
 * derivative (MIT and Apache-2.0)

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -25,3 +25,4 @@ rand = "0.7.3"
 [dev-dependencies]
 env_logger = "0.7.1"
 uuid = "0.7.4"
+picky-asn1-x509 = "0.1.0"

--- a/e2e_tests/tests/per_provider/normal_tests/create_destroy_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/create_destroy_key.rs
@@ -3,19 +3,7 @@
 use e2e_tests::TestClient;
 use parsec_client::core::interface::requests::ResponseStatus;
 use parsec_client::core::interface::requests::Result;
-use picky_asn1::wrapper::IntegerAsn1;
-use serde::{Deserialize, Serialize};
-
-// The RSA Public Key data are DER encoded with the following representation:
-// RSAPublicKey ::= SEQUENCE {
-//     modulus            INTEGER,  -- n
-//     publicExponent     INTEGER   -- e
-// }
-#[derive(Serialize, Deserialize, Debug)]
-struct RsaPublicKey {
-    modulus: IntegerAsn1,
-    public_exponent: IntegerAsn1,
-}
+use picky_asn1_x509::RSAPublicKey;
 
 #[test]
 fn create_and_destroy() -> Result<()> {
@@ -92,7 +80,7 @@ fn generate_public_rsa_check_modulus() -> Result<()> {
     client.generate_rsa_sign_key(key_name.clone())?;
     let public_key = client.export_public_key(key_name)?;
 
-    let public_key: RsaPublicKey = picky_asn1_der::from_bytes(&public_key).unwrap();
+    let public_key: RSAPublicKey = picky_asn1_der::from_bytes(&public_key).unwrap();
     assert_eq!(
         public_key.public_exponent.as_unsigned_bytes_be(),
         [0x01, 0x00, 0x01]

--- a/e2e_tests/tests/per_provider/normal_tests/export_public_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/export_public_key.rs
@@ -5,19 +5,7 @@ use parsec_client::core::interface::operations::psa_algorithm::*;
 use parsec_client::core::interface::operations::psa_key_attributes::*;
 use parsec_client::core::interface::requests::ResponseStatus;
 use parsec_client::core::interface::requests::Result;
-use picky_asn1::wrapper::IntegerAsn1;
-use serde::{Deserialize, Serialize};
-
-// The RSA Public Key data are DER encoded with the following representation:
-// RSAPublicKey ::= SEQUENCE {
-//     modulus            INTEGER,  -- n
-//     publicExponent     INTEGER   -- e
-// }
-#[derive(Serialize, Deserialize, Debug)]
-struct RsaPublicKey {
-    modulus: IntegerAsn1,
-    public_exponent: IntegerAsn1,
-}
+use picky_asn1_x509::RSAPublicKey;
 
 #[test]
 fn export_public_key() -> Result<()> {
@@ -70,7 +58,7 @@ fn check_public_rsa_export_format() -> Result<()> {
     let public_key = client.export_public_key(key_name)?;
 
     // That should not fail if the bytes are in the expected format.
-    let _public_key: RsaPublicKey = picky_asn1_der::from_bytes(&public_key).unwrap();
+    let _public_key: RSAPublicKey = picky_asn1_der::from_bytes(&public_key).unwrap();
     Ok(())
 }
 

--- a/e2e_tests/tests/per_provider/normal_tests/import_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/import_key.rs
@@ -6,18 +6,7 @@ use parsec_client::core::interface::operations::psa_key_attributes::*;
 use parsec_client::core::interface::requests::ResponseStatus;
 use parsec_client::core::interface::requests::Result;
 use picky_asn1::wrapper::IntegerAsn1;
-use serde::{Deserialize, Serialize};
-
-// The RSA Public Key data are DER encoded with the following representation:
-// RSAPublicKey ::= SEQUENCE {
-//     modulus            INTEGER,  -- n
-//     publicExponent     INTEGER   -- e
-// }
-#[derive(Serialize, Deserialize, Debug)]
-struct RsaPublicKey {
-    modulus: IntegerAsn1,
-    public_exponent: IntegerAsn1,
-}
+use picky_asn1_x509::RSAPublicKey;
 
 const KEY_DATA: [u8; 140] = [
     48, 129, 137, 2, 129, 129, 0, 153, 165, 220, 135, 89, 101, 254, 229, 28, 33, 138, 247, 20, 102,
@@ -83,7 +72,7 @@ fn check_format_import1() -> Result<()> {
     let mut client = TestClient::new();
     let key_name = String::from("check_format_import");
 
-    let public_key = RsaPublicKey {
+    let public_key = RSAPublicKey {
         modulus: IntegerAsn1::from_unsigned_bytes_be(example_modulus_1024()),
         public_exponent: IntegerAsn1::from_unsigned_bytes_be(vec![0x01, 0x00, 0x01]),
     };
@@ -100,7 +89,7 @@ fn check_format_import2() -> Result<()> {
     let mut client = TestClient::new();
     let key_name = String::from("check_format_import2");
 
-    let public_key = RsaPublicKey {
+    let public_key = RSAPublicKey {
         modulus: IntegerAsn1::from_unsigned_bytes_be(example_modulus_1024()),
         public_exponent: IntegerAsn1::from_unsigned_bytes_be(vec![0x01, 0x00, 0x01]),
     };
@@ -146,7 +135,7 @@ fn check_format_import3() -> Result<()> {
     let mut client = TestClient::new();
     let key_name = String::from("check_format_import3");
 
-    let public_key = RsaPublicKey {
+    let public_key = RSAPublicKey {
         modulus: IntegerAsn1::from_unsigned_bytes_be(vec![0xDE; 1024]),
         public_exponent: IntegerAsn1::from_unsigned_bytes_be(vec![0x01, 0x00, 0x01]),
     };
@@ -194,7 +183,7 @@ fn failed_imported_key_should_be_removed() -> Result<()> {
     let mut client = TestClient::new();
     let key_name = String::from("failed_imported_key_should_be_removed");
 
-    let public_key = RsaPublicKey {
+    let public_key = RSAPublicKey {
         modulus: IntegerAsn1::from_unsigned_bytes_be(example_modulus_1024()),
         public_exponent: IntegerAsn1::from_unsigned_bytes_be(vec![0x01, 0x00, 0x01]),
     };

--- a/src/providers/pkcs11_provider/key_management.rs
+++ b/src/providers/pkcs11_provider/key_management.rs
@@ -1,9 +1,6 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use super::{
-    utils, KeyInfo, KeyPairType, LocalIdStore, Pkcs11Provider, ReadWriteSession, RsaPublicKey,
-    Session,
-};
+use super::{utils, KeyInfo, KeyPairType, LocalIdStore, Pkcs11Provider, ReadWriteSession, Session};
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::KeyTriple;
 use crate::key_info_managers::{self, ManageKeyInfo};
@@ -15,6 +12,7 @@ use parsec_interface::operations::{
 use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
 use picky_asn1::wrapper::IntegerAsn1;
+use picky_asn1_x509::RSAPublicKey;
 use pkcs11::types::{CKR_OK, CK_ATTRIBUTE, CK_MECHANISM, CK_OBJECT_HANDLE, CK_SESSION_HANDLE};
 use std::mem;
 
@@ -277,7 +275,7 @@ impl Pkcs11Provider {
 
         let mut template: Vec<CK_ATTRIBUTE> = Vec::new();
 
-        let public_key: RsaPublicKey = picky_asn1_der::from_bytes(op.data.expose_secret())
+        let public_key: RSAPublicKey = picky_asn1_der::from_bytes(op.data.expose_secret())
             .or_else(|e| {
                 format_error!("Failed to parse RsaPublicKey data", e);
                 remove_key_id(
@@ -467,7 +465,7 @@ impl Pkcs11Provider {
                     let modulus = IntegerAsn1::from_unsigned_bytes_be(modulus);
                     let public_exponent = IntegerAsn1::from_unsigned_bytes_be(public_exponent);
 
-                    let key = RsaPublicKey {
+                    let key = RSAPublicKey {
                         modulus,
                         public_exponent,
                     };

--- a/src/providers/pkcs11_provider/mod.rs
+++ b/src/providers/pkcs11_provider/mod.rs
@@ -20,7 +20,7 @@ use pkcs11::Ctx;
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
 use std::sync::{Arc, Mutex, RwLock};
-use utils::{KeyPairType, ReadWriteSession, RsaPublicKey, Session};
+use utils::{KeyPairType, ReadWriteSession, Session};
 use uuid::Uuid;
 
 type LocalIdStore = HashSet<[u8; 4]>;

--- a/src/providers/pkcs11_provider/utils.rs
+++ b/src/providers/pkcs11_provider/utils.rs
@@ -6,11 +6,9 @@ use log::error;
 use log::{info, trace, warn};
 use parsec_interface::requests::ResponseStatus;
 use parsec_interface::requests::Result;
-use picky_asn1::wrapper::IntegerAsn1;
 use pkcs11::errors::Error;
 use pkcs11::types::*;
 use pkcs11::types::{CKF_RW_SESSION, CKF_SERIAL_SESSION, CKU_USER};
-use serde::{Deserialize, Serialize};
 
 /// Convert the PKCS 11 library specific error values to ResponseStatus values that are returned on
 /// the wire protocol
@@ -58,17 +56,6 @@ pub fn rv_to_response_status(rv: CK_RV) -> ResponseStatus {
             ResponseStatus::PsaErrorCommunicationFailure
         }
     }
-}
-
-// The RSA Public Key data are DER encoded with the following representation:
-// RSAPublicKey ::= SEQUENCE {
-//     modulus            INTEGER,  -- n
-//     publicExponent     INTEGER   -- e
-// }
-#[derive(Serialize, Deserialize, Debug)]
-pub struct RsaPublicKey {
-    pub modulus: IntegerAsn1,
-    pub public_exponent: IntegerAsn1,
 }
 
 // For PKCS 11, a key pair consists of two independant public and private keys. Both will share the

--- a/src/providers/tpm_provider/key_management.rs
+++ b/src/providers/tpm_provider/key_management.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::utils;
-use super::utils::{PasswordContext, RsaPublicKey};
+use super::utils::PasswordContext;
 use super::TpmProvider;
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers;
@@ -14,6 +14,7 @@ use parsec_interface::operations::{
 };
 use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
+use picky_asn1_x509::RSAPublicKey;
 
 // Public exponent value for all RSA keys.
 const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
@@ -130,7 +131,7 @@ impl TpmProvider {
             .lock()
             .expect("ESAPI Context lock poisoned");
 
-        let public_key: RsaPublicKey = picky_asn1_der::from_bytes(key_data.expose_secret())
+        let public_key: RSAPublicKey = picky_asn1_der::from_bytes(key_data.expose_secret())
             .or_else(|err| {
                 format_error!("Could not deserialise key elements", err);
                 Err(ResponseStatus::PsaErrorInvalidArgument)

--- a/src/providers/tpm_provider/utils.rs
+++ b/src/providers/tpm_provider/utils.rs
@@ -6,6 +6,7 @@ use parsec_interface::operations::psa_algorithm::*;
 use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::requests::{ResponseStatus, Result};
 use picky_asn1::wrapper::IntegerAsn1;
+use picky_asn1_x509::RSAPublicKey;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::convert::TryInto;
@@ -85,17 +86,6 @@ pub fn to_response_status(error: Error) -> ResponseStatus {
     }
 }
 
-// The RSA Public Key data are DER encoded with the following representation:
-// RSAPublicKey ::= SEQUENCE {
-//     modulus            INTEGER,  -- n
-//     publicExponent     INTEGER   -- e
-// }
-#[derive(Serialize, Deserialize, Debug)]
-pub struct RsaPublicKey {
-    pub modulus: IntegerAsn1,
-    pub public_exponent: IntegerAsn1,
-}
-
 // The PasswordContext is what is stored by the Key Info Manager.
 #[derive(Serialize, Deserialize)]
 pub struct PasswordContext {
@@ -171,7 +161,7 @@ fn convert_curve_to_tpm(key_attributes: Attributes) -> Result<EllipticCurve> {
 
 pub fn pub_key_to_bytes(pub_key: PublicKey, key_attributes: Attributes) -> Result<Vec<u8>> {
     match pub_key {
-        PublicKey::Rsa(key) => picky_asn1_der::to_vec(&RsaPublicKey {
+        PublicKey::Rsa(key) => picky_asn1_der::to_vec(&RSAPublicKey {
             modulus: IntegerAsn1::from_unsigned_bytes_be(key),
             public_exponent: IntegerAsn1::from_signed_bytes_be(PUBLIC_EXPONENT.to_vec()),
         })


### PR DESCRIPTION
The folks over at Devolutions have [put together a create with some useful types in it](https://github.com/Devolutions/picky-rs/issues/12#issuecomment-654877827). We use `RsaPublicKey` at various places in Parsec so I've moved them over from local declarations of an `RsaPublicKey` to `picky-asn1-x509::RSAPublicKey`.

Signed-off-by: Samuel Bailey <samuel.bailey@arm.com>