### PR TITLE
Added user and group checks. Auto create socket dir.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,6 @@ dependencies = [
  "picky-asn1-der",
  "picky-asn1-x509",
  "pkcs11",
- "psa-crypto",
  "rand",
  "ring",
  "sd-notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ dependencies = [
  "env_logger",
  "hex",
  "lazy_static",
+ "libc",
  "log",
  "parsec-interface",
  "picky",
@@ -773,6 +774,7 @@ dependencies = [
  "picky-asn1-der",
  "picky-asn1-x509",
  "pkcs11",
+ "psa-crypto",
  "rand",
  "ring",
  "sd-notify",
@@ -783,6 +785,7 @@ dependencies = [
  "threadpool",
  "toml 0.4.10",
  "tss-esapi",
+ "users",
  "uuid",
  "version",
  "zeroize",
@@ -1509,6 +1512,16 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "users"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ picky = "5.0.0"
 psa-crypto = { version = "0.3.0" , default-features = false, features = ["operations"], optional = true }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 picky-asn1-x509 = { version = "0.1.0", optional = true }
+users = "0.10.0"
+libc = "0.2.72"
 
 [dev-dependencies]
 ring = "0.16.12"
@@ -62,6 +64,7 @@ features = ["docs"]
 
 [features]
 default = []
+no-parsec-user-and-clients-group = []
 mbed-crypto-provider = ["psa-crypto"]
 pkcs11-provider = ["pkcs11", "picky-asn1-der", "picky-asn1", "picky-asn1-x509"]
 tpm-provider = ["tss-esapi", "picky-asn1-der", "picky-asn1", "picky-asn1-x509"]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ This project uses the following third party crates:
 * sha2 (MIT and Apache-2.0)
 * hex (MIT and Apache-2.0)
 * picky (MIT and Apache-2.0)
+* users (MIT)
+* libc (MIT and Apache-2.0)
 
 This project uses the following third party libraries:
 * [**Mbed Crypto**](https://github.com/ARMmbed/mbed-crypto) (Apache-2.0)

--- a/ci.sh
+++ b/ci.sh
@@ -67,9 +67,9 @@ while [ "$#" -gt 0 ]; do
             PROVIDER_NAME=$1
             cp $(pwd)/e2e_tests/provider_cfg/$1/config.toml $CONFIG_PATH
             if [ "$PROVIDER_NAME" = "all" ]; then
-                FEATURES="--features=all-providers"
+                FEATURES="--features=all-providers,no-parsec-user-and-clients-group"
             else
-                FEATURES="--features=$1-provider"
+                FEATURES="--features=$1-provider,no-parsec-user-and-clients-group"
             fi
         ;;
         *)


### PR DESCRIPTION
Parsec must be run as user `parsec` and `parsec` must be member of group `parsec-client`.
This is disabled if feature `testing` is specified.

Also auto created `/tmp/parsec` if it does not already exist with ownership set to user `parsec` and group `parsec_clients`. User `parsec` must be a member of `parsec_clients` in order for it to be able to change group ownership to it

Signed-off-by: Samuel Bailey <samuel.bailey@arm.com>