### PR TITLE
Create `Connection` abstraction for client communication

### DIFF
--- a/src/authenticators/mod.rs
+++ b/src/authenticators/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod direct_authenticator;
 
+use crate::front::listener::ConnectionMetadata;
 use parsec_interface::requests::request::RequestAuth;
 use parsec_interface::requests::Result;
 
@@ -24,12 +25,19 @@ pub struct ApplicationName(String);
 ///
 /// Interface that must be implemented for each authentication type available for the service.
 pub trait Authenticate {
-    /// Authenticates a `RequestAuth` payload and returns the `ApplicationName` if successfull.
+    /// Authenticates a `RequestAuth` payload and returns the `ApplicationName` if successful. A
+    /// optional `ConnectionMetadata` object is passed in too, since it is sometimes possible to
+    /// perform authentication based on the connection's metadata (i.e. as is the case for UNIX
+    /// domain sockets with peer credentials).
     ///
     /// # Errors
     ///
     /// If the authentification fails, returns a `ResponseStatus::AuthenticationError`.
-    fn authenticate(&self, auth: &RequestAuth) -> Result<ApplicationName>;
+    fn authenticate(
+        &self,
+        auth: &RequestAuth,
+        meta: Option<ConnectionMetadata>,
+    ) -> Result<ApplicationName>;
 }
 
 impl ApplicationName {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -125,10 +125,10 @@ fn main() -> Result<()> {
             info!("Parsec configuration reloaded.");
         }
 
-        if let Some(stream) = listener.accept() {
+        if let Some(connection) = listener.accept() {
             let front_end_handler = front_end_handler.clone();
             threadpool.execute(move || {
-                front_end_handler.handle_request(stream);
+                front_end_handler.handle_request(connection);
                 trace!("handle_request egress");
             });
         } else {

--- a/src/front/listener.rs
+++ b/src/front/listener.rs
@@ -5,6 +5,7 @@
 //! The [`Listen`](https://parallaxsecond.github.io/parsec-book/parsec_service/listeners.html)
 //! trait acts as an interface for the operations that must be supported by any implementation
 //! of the IPC mechanism used as a Parsec front.
+use derivative::Derivative;
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -23,6 +24,23 @@ pub enum ListenerType {
 pub struct ListenerConfig {
     pub listener_type: ListenerType,
     pub timeout: u64,
+}
+
+/// Specifies metadata associated with a connection, if any.
+#[derive(Copy, Clone, Debug)]
+pub enum ConnectionMetadata {
+    // TODO: nothing here right now. Metadata types will be added as needed.
+}
+
+/// Represents a connection to a single client. Contains a stream, used for communication with the
+/// client, and some metadata associated with the connection that might be useful elsewhere (i.e.
+/// authentication, etc).
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct Connection {
+    #[derivative(Debug = "ignore")]
+    pub stream: Box<dyn ReadWrite + Send>,
+    pub metadata: Option<ConnectionMetadata>,
 }
 
 /// IPC front manager interface
@@ -45,5 +63,5 @@ pub trait Listen {
     /// # Panics
     ///
     /// If the listener has not been initialised before, with the `init` method.
-    fn accept(&self) -> Option<Box<dyn ReadWrite + Send>>;
+    fn accept(&self) -> Option<Connection>;
 }


### PR DESCRIPTION
This commit is in response to issue #199. Here, we introduce a
`Connection` struct which currently contains two things:

* `stream` -- an object representing the communication stream between
  client and service.
* `metadata` -- an enum instance that captures metadata about the
  connection.

This abstraction allows us to carry more information forwards toward the
frontend/authenticator/... .

Specifically, this abstraction was created with UNIX domain sockets in
mind (but the usefulness is not limited here). UNIX domain sockets allow
incoming connections to be queried for peer metadata, which is a triple
(uid, gid, pid) of the peer process that is connecting. Under certain
configurations, this can be used for authentication.

This commit places us in a position of being able to use said metadata
for authentication if needed.

Signed-off-by: Joe Ellis <joe.ellis@arm.com>