### PR TITLE
Add check to prevent the Parsec service from running as root

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,11 @@
 
 # (Required) Core settings apply to the service as a whole rather than to individual components within it.
 [core_settings]
+# Whether or not to allow the service to run as the root user. If this is false, the service will refuse to
+# start if it is run as root. If this is true, the safety check is disabled and the service will be allowed to
+# start even if it is being run as root. The recommended (and default) setting is FALSE; allowing Parsec to
+# run as root violates the principle of least privilege.
+#allow_root = false
 # Size of the thread pool used for processing requests. Defaults to the number of processors on
 # the machine.
 #thread_pool_size = 8

--- a/e2e_tests/provider_cfg/all/config.toml
+++ b/e2e_tests/provider_cfg/all/config.toml
@@ -3,6 +3,10 @@
 log_timestamp = false
 log_error_details = true
 
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
 [listener]
 listener_type = "DomainSocket"
 timeout = 200 # in milliseconds

--- a/e2e_tests/provider_cfg/mbed-crypto/config.toml
+++ b/e2e_tests/provider_cfg/mbed-crypto/config.toml
@@ -3,6 +3,10 @@
 log_timestamp = false
 log_error_details = true
 
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
 [listener]
 listener_type = "DomainSocket"
 # The timeout needs to be smaller than the test client timeout (five seconds) as it is testing

--- a/e2e_tests/provider_cfg/pkcs11/config.toml
+++ b/e2e_tests/provider_cfg/pkcs11/config.toml
@@ -3,6 +3,10 @@
 log_timestamp = false
 log_error_details = true
 
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
 [listener]
 listener_type = "DomainSocket"
 # The timeout needs to be smaller than the test client timeout (five seconds) as it is testing

--- a/e2e_tests/provider_cfg/tpm/config.toml
+++ b/e2e_tests/provider_cfg/tpm/config.toml
@@ -3,6 +3,10 @@
 log_timestamp = false
 log_error_details = true
 
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
 [listener]
 listener_type = "DomainSocket"
 # The timeout needs to be smaller than the test client timeout (five seconds) as it is testing

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -63,6 +63,7 @@ pub struct CoreSettings {
     pub log_timestamp: Option<bool>,
     pub body_len_limit: Option<usize>,
     pub log_error_details: Option<bool>,
+    pub allow_root: Option<bool>,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This commit introduces a guard at the top of `main` to ensure that
Parsec is not being run as root. Disallowing the Parsec service from
running as root reduces attack surface in line with the principle of
least privilege.

This behaviour can be overridden by setting the `PARSEC_ALLOW_ROOT`
environment variable.

Signed-off-by: Joe Ellis <joe.ellis@arm.com>