### PR TITLE
Add asymmetric encryption support to TPM provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chrono"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
+
+[[package]]
 name = "clang-sys"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,8 +788,10 @@ dependencies = [
  "psa-crypto",
  "rand",
  "ring",
+ "rsa 0.3.0",
  "sd-notify",
  "serde",
+ "sha2",
  "signal-hook",
  "std-semaphore",
  "structopt",
@@ -796,6 +809,17 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
+dependencies = [
+ "base64 0.12.3",
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "petgraph"
@@ -820,7 +844,7 @@ dependencies = [
  "picky-asn1-der",
  "picky-asn1-x509",
  "rand",
- "rsa",
+ "rsa 0.2.0",
  "serde",
  "serde_json",
  "sha-1",
@@ -1127,6 +1151,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3648b669b10afeab18972c105e284a7b953a669b0be3514c27f9b17acab2f9cd"
+dependencies = [
+ "byteorder",
+ "digest",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pem",
+ "rand",
+ "sha2",
+ "simple_asn1",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1326,17 @@ checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
  "arc-swap",
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -1447,6 +1504,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "4.0.6-alpha.1"
+version = "4.0.8-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8f9ff449fd89c67e15cd20c565c28b11f50a8e8d2ca45f600ded6a02875b85"
+checksum = "f2e699debe6392012e06a57157ce6f288f9ca0e0b2ae1ad3304ff07a977bcfec"
 dependencies = [
  "bindgen",
  "bitfield",
@@ -1481,6 +1548,7 @@ dependencies = [
  "pkg-config",
  "regex",
  "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ log = { version = "0.4.8", features = ["serde"] }
 pkcs11 = { version = "0.4.0", optional = true }
 picky-asn1-der = { version = "0.2.2", optional = true }
 picky-asn1 = { version = "0.2.1", optional = true }
-tss-esapi = { version = "4.0.6-alpha.1", optional = true }
+tss-esapi = { version = "4.0.8-alpha.1", optional = true }
 bincode = "1.1.4"
 structopt = "0.3.5"
 derivative = "2.1.1"
@@ -49,6 +49,9 @@ libc = "0.2.72"
 [dev-dependencies]
 ring = "0.16.12"
 lazy_static = "1.4.0"
+rsa = "0.3.0"
+rand = "0.7.3"
+sha2 = "0.9.1"
 
 [build-dependencies]
 bindgen = "0.54.0"

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -17,7 +17,7 @@ num_cpus = "1.13.0"
 picky-asn1-der = "0.2.2"
 picky-asn1 = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
-sha2 = "0.8.1"
+sha2 = "0.9.1"
 parsec-client = { version = "0.7.0", features = ["testing"] }
 log = "0.4.8"
 rand = "0.7.3"

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -17,7 +17,7 @@ use parsec_client::core::interface::operations::psa_algorithm::{
     Algorithm, AsymmetricEncryption, AsymmetricSignature, Hash,
 };
 use parsec_client::core::interface::operations::psa_key_attributes::{
-    Attributes, Lifetime, Policy, Type, UsageFlags, EccFamily,
+    Attributes, EccFamily, Lifetime, Policy, Type, UsageFlags,
 };
 use parsec_client::core::interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use parsec_client::core::secrecy::{ExposeSecret, Secret};
@@ -222,12 +222,17 @@ impl TestClient {
         )
     }
 
-    pub fn generate_ecc_key_pair_secpk1_deterministic_ecdsa_sha256(&mut self, key_name: String) -> Result<()> {
+    pub fn generate_ecc_key_pair_secpk1_deterministic_ecdsa_sha256(
+        &mut self,
+        key_name: String,
+    ) -> Result<()> {
         self.generate_key(
             key_name,
             Attributes {
                 lifetime: Lifetime::Persistent,
-                key_type: Type::EccKeyPair {curve_family: EccFamily::SecpK1},
+                key_type: Type::EccKeyPair {
+                    curve_family: EccFamily::SecpK1,
+                },
                 bits: 256,
                 policy: Policy {
                     usage_flags: UsageFlags {
@@ -244,7 +249,8 @@ impl TestClient {
                     },
                     permitted_algorithms: AsymmetricSignature::DeterministicEcdsa {
                         hash_alg: Hash::Sha256.into(),
-                    }.into(),
+                    }
+                    .into(),
                 },
             },
         )
@@ -273,7 +279,11 @@ impl TestClient {
 
     /// Import a 1024 bit RSA key pair
     /// The key pair can only be used for encryption and decryption with RSA PKCS 1v15
-    pub fn import_rsa_key_pair_for_encryption(&mut self, key_name: String, data: Vec<u8>) -> Result<()> {
+    pub fn import_rsa_key_pair_for_encryption(
+        &mut self,
+        key_name: String,
+        data: Vec<u8>,
+    ) -> Result<()> {
         self.import_key(
             key_name,
             Attributes {
@@ -439,6 +449,38 @@ impl TestClient {
             AsymmetricEncryption::RsaPkcs1v15Crypt,
             &ciphertext,
             None,
+        )
+    }
+
+    pub fn asymmetric_encrypt_message_with_rsaoaep_sha256(
+        &mut self,
+        key_name: String,
+        plaintext: Vec<u8>,
+        salt: Vec<u8>,
+    ) -> Result<Vec<u8>> {
+        self.asymmetric_encrypt_message(
+            key_name,
+            AsymmetricEncryption::RsaOaep {
+                hash_alg: Hash::Sha256,
+            },
+            &plaintext,
+            Some(&salt),
+        )
+    }
+
+    pub fn asymmetric_decrypt_message_with_rsaoaep_sha256(
+        &mut self,
+        key_name: String,
+        ciphertext: Vec<u8>,
+        salt: Vec<u8>,
+    ) -> Result<Vec<u8>> {
+        self.asymmetric_decrypt_message(
+            key_name,
+            AsymmetricEncryption::RsaOaep {
+                hash_alg: Hash::Sha256,
+            },
+            &ciphertext,
+            Some(&salt),
         )
     }
 

--- a/e2e_tests/tests/all_providers/mod.rs
+++ b/e2e_tests/tests/all_providers/mod.rs
@@ -52,7 +52,7 @@ fn list_opcodes() {
         client
             .list_opcodes(ProviderID::Tpm)
             .expect("list providers failed"),
-        crypto_providers_opcodes
+        crypto_providers_inc_encrypt_opcodes
     );
     assert_eq!(
         client

--- a/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use e2e_tests::TestClient;
-use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
+use parsec_client::core::interface::requests::{Opcode, ProviderID, ResponseStatus};
 use rand::rngs::OsRng;
 use rsa::{PaddingScheme, PublicKey, RSAPublicKey};
 
@@ -37,7 +37,7 @@ const ORIGINAL_MESSAGE: &str = "This is a test!";
 
 #[test]
 fn simple_asym_encrypt_rsa_pkcs() {
-    let key_name = String::from("asym_encrypt_and_decrypt_rsa_pkcs");
+    let key_name = String::from("simple_asym_encrypt_rsa_pkcs");
     let mut client = TestClient::new();
 
     if !client.is_operation_supported(Opcode::PsaAsymmetricEncrypt) {
@@ -50,6 +50,59 @@ fn simple_asym_encrypt_rsa_pkcs() {
     let _ciphertext = client
         .asymmetric_encrypt_message_with_rsapkcs1v15(key_name, PLAINTEXT_MESSAGE.to_vec())
         .unwrap();
+}
+
+#[test]
+fn simple_asym_encrypt_rsa_oaep() {
+    let key_name = String::from("simple_asym_encrypt_rsa_oaep");
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaAsymmetricEncrypt) {
+        return;
+    }
+
+    client
+        .generate_rsa_encryption_keys_rsaoaep_sha256(key_name.clone())
+        .unwrap();
+    let _ciphertext = client
+        .asymmetric_encrypt_message_with_rsaoaep_sha256(
+            key_name,
+            PLAINTEXT_MESSAGE.to_vec(),
+            vec![],
+        )
+        .unwrap();
+}
+
+// Test is ignored as TPMs do not support labels that don't end in a 0 byte
+// A resolution for this has not been reached yet, so keeping as is
+// See: https://github.com/parallaxsecond/parsec/issues/217
+#[ignore]
+#[test]
+fn simple_asym_decrypt_oaep_with_salt() {
+    let key_name = String::from("simple_asym_decrypt_oaep_with_salt");
+    let salt = String::from("some random label").as_bytes().to_vec();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaAsymmetricEncrypt) {
+        return;
+    }
+
+    client
+        .generate_rsa_encryption_keys_rsaoaep_sha256(key_name.clone())
+        .unwrap();
+    let ciphertext = client
+        .asymmetric_encrypt_message_with_rsaoaep_sha256(
+            key_name.clone(),
+            PLAINTEXT_MESSAGE.to_vec(),
+            salt.clone(),
+        )
+        .unwrap();
+
+    let plaintext = client
+        .asymmetric_decrypt_message_with_rsaoaep_sha256(key_name, ciphertext, salt)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT_MESSAGE[..], &plaintext[..]);
 }
 
 #[test]
@@ -179,13 +232,53 @@ fn asym_encrypt_verify_decrypt_with_rsa_crate() {
     assert_eq!(&PLAINTEXT_MESSAGE[..], &plaintext[..]);
 }
 
+// Test is ignored as TPMs do not support labels that don't end in a 0 byte
+// A resolution for this has not been reached yet, so keeping as is
+// See: https://github.com/parallaxsecond/parsec/issues/217
+#[ignore]
+#[test]
+fn asym_encrypt_verify_decrypt_with_rsa_crate_oaep() {
+    let key_name = String::from("asym_encrypt_verify_decrypt_with_rsa_crate_oaep");
+    let label = String::from("encryption label");
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaAsymmetricDecrypt) {
+        return;
+    }
+
+    client
+        .generate_rsa_encryption_keys_rsaoaep_sha256(key_name.clone())
+        .unwrap();
+    let pub_key = client.export_public_key(key_name.clone()).unwrap();
+
+    let rsa_pub_key = RSAPublicKey::from_pkcs1(&pub_key).unwrap();
+    let ciphertext = rsa_pub_key
+        .encrypt(
+            &mut OsRng,
+            PaddingScheme::new_oaep_with_label::<sha2::Sha256, &str>(&label),
+            &PLAINTEXT_MESSAGE,
+        )
+        .unwrap();
+
+    let label_bytes = label.as_bytes().to_vec();
+    let plaintext = client
+        .asymmetric_decrypt_message_with_rsaoaep_sha256(key_name, ciphertext, label_bytes)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT_MESSAGE[..], &plaintext[..]);
+}
+
 /// Uses key pair generated online to decrypt a message that has been pre-encrypted
 #[test]
 fn asym_verify_decrypt_with_internet() {
     let key_name = String::from("asym_derify_decrypt_with_pick");
     let mut client = TestClient::new();
 
-    if !client.is_operation_supported(Opcode::PsaAsymmetricDecrypt) {
+    // Check if decrypt is supported
+    // TPM does not support importing "general use keys"
+    if !client.is_operation_supported(Opcode::PsaAsymmetricDecrypt)
+        || client.provider().unwrap() == ProviderID::Tpm
+    {
         return;
     }
 

--- a/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
@@ -116,8 +116,8 @@ fn simple_sign_hash() -> Result<()> {
     let key_name = String::from("simple_sign_hash");
     let mut client = TestClient::new();
     let mut hasher = Sha256::new();
-    hasher.input(b"Bob wrote this message.");
-    let hash = hasher.result().to_vec();
+    hasher.update(b"Bob wrote this message.");
+    let hash = hasher.finalize().to_vec();
 
     client.generate_rsa_sign_key(key_name.clone())?;
 
@@ -131,8 +131,8 @@ fn sign_hash_not_permitted() -> Result<()> {
     let key_name = String::from("sign_hash_not_permitted");
     let mut client = TestClient::new();
     let mut hasher = Sha256::new();
-    hasher.input(b"Bob wrote this message.");
-    let hash = hasher.result().to_vec();
+    hasher.update(b"Bob wrote this message.");
+    let hash = hasher.finalize().to_vec();
 
     let attributes = Attributes {
         lifetime: Lifetime::Persistent,
@@ -193,8 +193,8 @@ fn simple_verify_hash() -> Result<()> {
     let mut client = TestClient::new();
 
     let mut hasher = Sha256::new();
-    hasher.input(b"Bob wrote this message.");
-    let hash = hasher.result().to_vec();
+    hasher.update(b"Bob wrote this message.");
+    let hash = hasher.finalize().to_vec();
 
     client.generate_rsa_sign_key(key_name.clone())?;
 
@@ -207,8 +207,8 @@ fn verify_hash_not_permitted() -> Result<()> {
     let key_name = String::from("verify_hash_not_permitted");
     let mut client = TestClient::new();
     let mut hasher = Sha256::new();
-    hasher.input(b"Bob wrote this message.");
-    let hash = hasher.result().to_vec();
+    hasher.update(b"Bob wrote this message.");
+    let hash = hasher.finalize().to_vec();
 
     let attributes = Attributes {
         lifetime: Lifetime::Persistent,
@@ -251,8 +251,8 @@ fn verify_hash_bad_format() -> Result<()> {
     let key_name = String::from("verify_hash_bad_format");
     let mut client = TestClient::new();
     let mut hasher = Sha256::new();
-    hasher.input(b"Bob wrote this message.");
-    let good_hash = hasher.result().to_vec();
+    hasher.update(b"Bob wrote this message.");
+    let good_hash = hasher.finalize().to_vec();
     let hash1 = vec![0xEE; 255];
     let hash2 = vec![0xBB; 257];
 
@@ -277,8 +277,8 @@ fn fail_verify_hash() -> Result<()> {
     let mut client = TestClient::new();
 
     let mut hasher = Sha256::new();
-    hasher.input(b"Bob wrote this message.");
-    let hash = hasher.result().to_vec();
+    hasher.update(b"Bob wrote this message.");
+    let hash = hasher.finalize().to_vec();
 
     client.generate_rsa_sign_key(key_name.clone())?;
 
@@ -298,8 +298,8 @@ fn fail_verify_hash2() -> Result<()> {
     let mut client = TestClient::new();
 
     let mut hasher = Sha256::new();
-    hasher.input(b"Bob wrote this message.");
-    let mut hash = hasher.result().to_vec();
+    hasher.update(b"Bob wrote this message.");
+    let mut hash = hasher.finalize().to_vec();
 
     client.generate_rsa_sign_key(key_name.clone())?;
 

--- a/src/providers/tpm_provider/asym_encryption.rs
+++ b/src/providers/tpm_provider/asym_encryption.rs
@@ -1,0 +1,117 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::{key_management, utils, TpmProvider};
+use crate::authenticators::ApplicationName;
+use crate::key_info_managers::KeyTriple;
+use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
+use parsec_interface::requests::{ProviderID, Result};
+use std::convert::TryInto;
+use std::ops::Deref;
+
+impl TpmProvider {
+    pub(super) fn psa_asymmetric_encrypt_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_asymmetric_encrypt::Operation,
+    ) -> Result<psa_asymmetric_encrypt::Result> {
+        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, op.key_name.clone());
+
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let (password_context, key_attributes) =
+            key_management::get_password_context(&*store_handle, key_triple)?;
+
+        op.validate(key_attributes)?;
+
+        match esapi_context.rsa_encrypt(
+            password_context.context,
+            Some(
+                password_context
+                    .auth_value
+                    .try_into()
+                    .map_err(utils::to_response_status)?,
+            ),
+            op.plaintext
+                .deref()
+                .clone()
+                .try_into()
+                .map_err(utils::to_response_status)?,
+            utils::convert_asym_scheme_to_tpm(op.alg.into())?,
+            match op.salt {
+                Some(salt) => Some(
+                    salt.deref()
+                        .to_vec()
+                        .try_into()
+                        .map_err(utils::to_response_status)?,
+                ),
+                None => None,
+            },
+        ) {
+            Ok(ciphertext) => Ok(psa_asymmetric_encrypt::Result {
+                ciphertext: ciphertext.value().to_vec().into(),
+            }),
+            Err(tss_error) => {
+                let error = utils::to_response_status(tss_error);
+                format_error!("Encryption failed", tss_error);
+                Err(error)
+            }
+        }
+    }
+
+    pub(super) fn psa_asymmetric_decrypt_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_asymmetric_decrypt::Operation,
+    ) -> Result<psa_asymmetric_decrypt::Result> {
+        let key_triple = KeyTriple::new(app_name, ProviderID::Tpm, op.key_name.clone());
+
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        let mut esapi_context = self
+            .esapi_context
+            .lock()
+            .expect("ESAPI Context lock poisoned");
+
+        let (password_context, key_attributes) =
+            key_management::get_password_context(&*store_handle, key_triple)?;
+
+        op.validate(key_attributes)?;
+
+        match esapi_context.rsa_decrypt(
+            password_context.context,
+            Some(
+                password_context
+                    .auth_value
+                    .try_into()
+                    .map_err(utils::to_response_status)?,
+            ),
+            op.ciphertext
+                .deref()
+                .clone()
+                .try_into()
+                .map_err(utils::to_response_status)?,
+            utils::convert_asym_scheme_to_tpm(op.alg.into())?,
+            match op.salt {
+                Some(salt) => Some(
+                    salt.deref()
+                        .to_vec()
+                        .try_into()
+                        .map_err(utils::to_response_status)?,
+                ),
+                None => None,
+            },
+        ) {
+            Ok(plaintext) => Ok(psa_asymmetric_decrypt::Result {
+                plaintext: plaintext.value().to_vec().into(),
+            }),
+            Err(tss_error) => {
+                let error = utils::to_response_status(tss_error);
+                format_error!("Encryption failed", tss_error);
+                Err(error)
+            }
+        }
+    }
+}

--- a/src/providers/tpm_provider/mod.rs
+++ b/src/providers/tpm_provider/mod.rs
@@ -11,8 +11,8 @@ use derivative::Derivative;
 use log::{info, trace};
 use parsec_interface::operations::list_providers::ProviderInfo;
 use parsec_interface::operations::{
-    psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key, psa_sign_hash,
-    psa_verify_hash,
+    psa_asymmetric_decrypt, psa_asymmetric_encrypt, psa_destroy_key, psa_export_public_key,
+    psa_generate_key, psa_import_key, psa_sign_hash, psa_verify_hash,
 };
 use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use std::collections::HashSet;
@@ -23,17 +23,20 @@ use tss_esapi::constants::algorithm::{Cipher, HashingAlgorithm};
 use tss_esapi::Tcti;
 use uuid::Uuid;
 
+mod asym_encryption;
 mod asym_sign;
 mod key_management;
 mod utils;
 
-const SUPPORTED_OPCODES: [Opcode; 6] = [
+const SUPPORTED_OPCODES: [Opcode; 8] = [
     Opcode::PsaGenerateKey,
     Opcode::PsaDestroyKey,
     Opcode::PsaSignHash,
     Opcode::PsaVerifyHash,
     Opcode::PsaImportKey,
     Opcode::PsaExportPublicKey,
+    Opcode::PsaAsymmetricDecrypt,
+    Opcode::PsaAsymmetricEncrypt,
 ];
 
 const ROOT_KEY_SIZE: u16 = 2048;
@@ -140,6 +143,24 @@ impl Provide for TpmProvider {
     ) -> Result<psa_verify_hash::Result> {
         trace!("psa_verify_hash ingress");
         self.psa_verify_hash_internal(app_name, op)
+    }
+
+    fn psa_asymmetric_encrypt(
+        &self,
+        app_name: ApplicationName,
+        op: psa_asymmetric_encrypt::Operation,
+    ) -> Result<psa_asymmetric_encrypt::Result> {
+        trace!("psa_asymmetric_encrypt ingress");
+        self.psa_asymmetric_encrypt_internal(app_name, op)
+    }
+
+    fn psa_asymmetric_decrypt(
+        &self,
+        app_name: ApplicationName,
+        op: psa_asymmetric_decrypt::Operation,
+    ) -> Result<psa_asymmetric_decrypt::Result> {
+        trace!("psa_asymmetric_decrypt ingress");
+        self.psa_asymmetric_decrypt_internal(app_name, op)
     }
 }
 

--- a/src/providers/tpm_provider/utils.rs
+++ b/src/providers/tpm_provider/utils.rs
@@ -123,7 +123,7 @@ pub fn parsec_to_tpm_params(attributes: Attributes) -> Result<KeyParams> {
     }
 }
 
-fn convert_asym_scheme_to_tpm(algorithm: Algorithm) -> Result<AsymSchemeUnion> {
+pub fn convert_asym_scheme_to_tpm(algorithm: Algorithm) -> Result<AsymSchemeUnion> {
     match algorithm {
         Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
             hash_alg: SignHash::Specific(hash_alg),
@@ -131,6 +131,12 @@ fn convert_asym_scheme_to_tpm(algorithm: Algorithm) -> Result<AsymSchemeUnion> {
         Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa {
             hash_alg: SignHash::Specific(hash_alg),
         }) => Ok(AsymSchemeUnion::ECDSA(convert_hash_to_tpm(hash_alg)?)),
+        Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaPkcs1v15Crypt) => {
+            Ok(AsymSchemeUnion::RSAES)
+        }
+        Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaOaep { hash_alg }) => {
+            Ok(AsymSchemeUnion::RSAOAEP(convert_hash_to_tpm(hash_alg)?))
+        }
         _ => Err(ResponseStatus::PsaErrorNotSupported),
     }
 }

--- a/tests/providers/tpm.rs
+++ b/tests/providers/tpm.rs
@@ -4,15 +4,17 @@ use lazy_static::lazy_static;
 use parsec_interface::operations::psa_algorithm::*;
 use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::operations::{
-    psa_export_public_key, psa_generate_key, psa_sign_hash, psa_verify_hash,
+    psa_asymmetric_decrypt, psa_export_public_key, psa_generate_key, psa_sign_hash, psa_verify_hash,
 };
 use parsec_interface::requests::ResponseStatus;
 use parsec_service::authenticators::ApplicationName;
 use parsec_service::key_info_managers::on_disk_manager::OnDiskKeyInfoManagerBuilder;
 use parsec_service::providers::tpm_provider::{TpmProvider, TpmProviderBuilder};
 use parsec_service::providers::Provide;
+use rand::rngs::OsRng;
 use ring::digest;
 use ring::signature::{self, UnparsedPublicKey};
+use rsa::{PaddingScheme, PublicKey, RSAPublicKey};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -63,6 +65,36 @@ fn gen_rsa_sign_key_op(key_name: String) -> psa_generate_key::Operation {
                 permitted_algorithms: Algorithm::AsymmetricSignature(
                     AsymmetricSignature::RsaPkcs1v15Sign {
                         hash_alg: Hash::Sha256.into(),
+                    },
+                ),
+            },
+        },
+    }
+}
+
+fn gen_rsa_encrypt_key_op(key_name: String) -> psa_generate_key::Operation {
+    psa_generate_key::Operation {
+        key_name,
+        attributes: Attributes {
+            lifetime: Lifetime::Persistent,
+            key_type: Type::RsaKeyPair,
+            bits: 2048,
+            policy: Policy {
+                usage_flags: UsageFlags {
+                    export: true,
+                    copy: false,
+                    cache: false,
+                    encrypt: true,
+                    decrypt: true,
+                    sign_message: false,
+                    sign_hash: false,
+                    verify_message: false,
+                    verify_hash: false,
+                    derive: false,
+                },
+                permitted_algorithms: Algorithm::AsymmetricEncryption(
+                    AsymmetricEncryption::RsaOaep {
+                        hash_alg: Hash::Sha256,
                     },
                 ),
             },
@@ -205,4 +237,50 @@ fn wildcard_hash_not_supported() {
         TPM_PROVIDER.psa_generate_key(app_name, op).unwrap_err(),
         ResponseStatus::PsaErrorNotSupported
     );
+}
+
+#[test]
+fn asym_encrypt_with_crate() {
+    let key_name = String::from("key_name");
+    let initial_plaintext = b"This is one nice plaintext".to_vec();
+    let label = String::from_utf8(vec![1, 2, 3, 4, 5, 6, 7, 0]).unwrap();
+    let app_name = ApplicationName::new(String::from("asym_encrypt_with_ring"));
+    let _ = TPM_PROVIDER
+        .psa_generate_key(app_name.clone(), gen_rsa_encrypt_key_op(key_name.clone()))
+        .unwrap();
+
+    let psa_export_public_key::Result { data } = TPM_PROVIDER
+        .psa_export_public_key(
+            app_name.clone(),
+            psa_export_public_key::Operation {
+                key_name: key_name.clone(),
+            },
+        )
+        .unwrap();
+
+    let rsa_pub_key = RSAPublicKey::from_pkcs1(&data).unwrap();
+
+    let ciphertext = rsa_pub_key
+        .encrypt(
+            &mut OsRng,
+            PaddingScheme::new_oaep_with_label::<sha2::Sha256, &str>(&label),
+            &initial_plaintext,
+        )
+        .unwrap();
+
+    let psa_asymmetric_decrypt::Result { plaintext } = TPM_PROVIDER
+        .psa_asymmetric_decrypt(
+            app_name,
+            psa_asymmetric_decrypt::Operation {
+                alg: AsymmetricEncryption::RsaOaep {
+                    hash_alg: Hash::Sha256,
+                },
+                key_name,
+                ciphertext: ciphertext.into(),
+                salt: Some(label.as_bytes().to_vec().into()),
+            },
+        )
+        .unwrap();
+
+    assert_eq!(&initial_plaintext[..], &plaintext[..]);
 }


### PR DESCRIPTION
This commit adds support for asymmetric encryption to the TPM provider.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

Implements #217 