### PR TITLE
Update attribute handling in PKCS11 provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
  "picky",
  "picky-asn1",
  "picky-asn1-der",
- "picky-asn1-x509",
+ "picky-asn1-x509 0.3.0",
  "pkcs11",
  "psa-crypto",
  "rand",
@@ -825,7 +825,7 @@ dependencies = [
  "oid",
  "picky-asn1",
  "picky-asn1-der",
- "picky-asn1-x509",
+ "picky-asn1-x509 0.1.0",
  "rand",
  "rsa 0.2.0",
  "serde",
@@ -862,6 +862,19 @@ name = "picky-asn1-x509"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969171630cdf5c269611dfffdc1e6d749365fc4059b86fe3620d8afa3ddce4e6"
+dependencies = [
+ "base64 0.12.3",
+ "oid",
+ "picky-asn1",
+ "picky-asn1-der",
+ "serde",
+]
+
+[[package]]
+name = "picky-asn1-x509"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b0b354f137550bb42e1f3bafd83c4047006b55903c5b2b41f7997957c716e88"
 dependencies = [
  "base64 0.12.3",
  "oid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ hex = "0.4.2"
 picky = "5.0.0"
 psa-crypto = { version = "0.5.0" , default-features = false, features = ["operations"], optional = true }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
-picky-asn1-x509 = { version = "0.1.0", optional = true }
+picky-asn1-x509 = { version = "0.3.0", optional = true }
 users = "0.10.0"
 libc = "0.2.72"
 

--- a/ci.sh
+++ b/ci.sh
@@ -68,8 +68,10 @@ while [ "$#" -gt 0 ]; do
             cp $(pwd)/e2e_tests/provider_cfg/$1/config.toml $CONFIG_PATH
             if [ "$PROVIDER_NAME" = "all" ]; then
                 FEATURES="--features=all-providers,no-parsec-user-and-clients-group"
+                TEST_FEATURES="--features=all-providers"
             else
                 FEATURES="--features=$1-provider,no-parsec-user-and-clients-group"
+                TEST_FEATURES="--features=$1-provider"
             fi
         ;;
         *)
@@ -134,15 +136,15 @@ pgrep -f target/debug/parsec >/dev/null
 
 if [ "$PROVIDER_NAME" = "all" ]; then
     echo "Execute all-providers tests"
-    RUST_BACKTRACE=1 cargo test --manifest-path ./e2e_tests/Cargo.toml all_providers
-    RUST_BACKTRACE=1 cargo test --manifest-path ./e2e_tests/Cargo.toml config
+    RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml all_providers
+    RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml config
 else
     # Per provider tests
     echo "Execute normal tests"
-    RUST_BACKTRACE=1 cargo test --manifest-path ./e2e_tests/Cargo.toml normal_tests
+    RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml normal_tests
 
     echo "Execute persistent test, before the reload"
-    RUST_BACKTRACE=1 cargo test --manifest-path ./e2e_tests/Cargo.toml persistent_before
+    RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml persistent_before
 
     # Create a fake mapping file for the root application, the provider and a
     # key name of "Test Key". It contains a valid KeyInfo structure.
@@ -170,7 +172,7 @@ else
     sleep 5
 
     echo "Execute persistent test, after the reload"
-    RUST_BACKTRACE=1 cargo test --manifest-path ./e2e_tests/Cargo.toml persistent_after
+    RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml persistent_after
 
     if [ -z "$NO_STRESS_TEST" ]; then
         echo "Shutdown Parsec"
@@ -186,6 +188,6 @@ else
         sleep 5
 
         echo "Execute stress tests"
-        RUST_BACKTRACE=1 cargo test --manifest-path ./e2e_tests/Cargo.toml stress_test
+        RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml stress_test
 	fi
 fi

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -28,3 +28,9 @@ uuid = "0.7.4"
 rsa = "0.3.0"
 picky-asn1-x509 = "0.1.0"
 base64 = "0.12.3"
+
+[features]
+mbed-crypto-provider = []
+tpm-provider = []
+pkcs11-provider = []
+all-providers = ["pkcs11-provider","tpm-provider","mbed-crypto-provider"]

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -252,6 +252,36 @@ impl TestClient {
         )
     }
 
+    #[allow(deprecated)]
+    pub fn generate_rsa_encryption_keys_rsaoaep_sha1(&mut self, key_name: String) -> Result<()> {
+        self.generate_key(
+            key_name,
+            Attributes {
+                lifetime: Lifetime::Persistent,
+                key_type: Type::RsaKeyPair,
+                bits: 1024,
+                policy: Policy {
+                    usage_flags: UsageFlags {
+                        sign_hash: false,
+                        verify_hash: false,
+                        sign_message: false,
+                        verify_message: false,
+                        export: true,
+                        encrypt: true,
+                        decrypt: true,
+                        cache: false,
+                        copy: false,
+                        derive: false,
+                    },
+                    permitted_algorithms: AsymmetricEncryption::RsaOaep {
+                        hash_alg: Hash::Sha1,
+                    }
+                    .into(),
+                },
+            },
+        )
+    }
+
     pub fn generate_ecc_key_pair_secpk1_deterministic_ecdsa_sha256(
         &mut self,
         key_name: String,
@@ -604,6 +634,40 @@ impl TestClient {
             key_name,
             AsymmetricEncryption::RsaOaep {
                 hash_alg: Hash::Sha256,
+            },
+            &ciphertext,
+            Some(&salt),
+        )
+    }
+
+    #[allow(deprecated)]
+    pub fn asymmetric_encrypt_message_with_rsaoaep_sha1(
+        &mut self,
+        key_name: String,
+        plaintext: Vec<u8>,
+        salt: Vec<u8>,
+    ) -> Result<Vec<u8>> {
+        self.asymmetric_encrypt_message(
+            key_name,
+            AsymmetricEncryption::RsaOaep {
+                hash_alg: Hash::Sha1,
+            },
+            &plaintext,
+            Some(&salt),
+        )
+    }
+
+    #[allow(deprecated)]
+    pub fn asymmetric_decrypt_message_with_rsaoaep_sha1(
+        &mut self,
+        key_name: String,
+        ciphertext: Vec<u8>,
+        salt: Vec<u8>,
+    ) -> Result<Vec<u8>> {
+        self.asymmetric_decrypt_message(
+            key_name,
+            AsymmetricEncryption::RsaOaep {
+                hash_alg: Hash::Sha1,
             },
             &ciphertext,
             Some(&salt),

--- a/e2e_tests/tests/all_providers/mod.rs
+++ b/e2e_tests/tests/all_providers/mod.rs
@@ -33,10 +33,10 @@ fn list_opcodes() {
     let _ = crypto_providers_hsm.insert(Opcode::PsaVerifyHash);
     let _ = crypto_providers_hsm.insert(Opcode::PsaImportKey);
     let _ = crypto_providers_hsm.insert(Opcode::PsaExportPublicKey);
+    let _ = crypto_providers_hsm.insert(Opcode::PsaAsymmetricDecrypt);
+    let _ = crypto_providers_hsm.insert(Opcode::PsaAsymmetricEncrypt);
 
-    let mut crypto_providers_tpm = crypto_providers_hsm.clone();
-    let _ = crypto_providers_tpm.insert(Opcode::PsaAsymmetricDecrypt);
-    let _ = crypto_providers_tpm.insert(Opcode::PsaAsymmetricEncrypt);
+    let crypto_providers_tpm = crypto_providers_hsm.clone();
 
     let mut crypto_providers_mbed_crypto = crypto_providers_tpm.clone();
     let _ = crypto_providers_mbed_crypto.insert(Opcode::PsaHashCompute);

--- a/src/providers/pkcs11_provider/mod.rs
+++ b/src/providers/pkcs11_provider/mod.rs
@@ -11,8 +11,8 @@ use derivative::Derivative;
 use log::{error, info, trace, warn};
 use parsec_interface::operations::list_providers::ProviderInfo;
 use parsec_interface::operations::{
-    psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key, psa_sign_hash,
-    psa_verify_hash,
+    psa_asymmetric_decrypt, psa_asymmetric_encrypt, psa_destroy_key, psa_export_public_key,
+    psa_generate_key, psa_import_key, psa_sign_hash, psa_verify_hash,
 };
 use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use pkcs11::types::{CKF_OS_LOCKING_OK, CK_C_INITIALIZE_ARGS, CK_SLOT_ID};
@@ -25,17 +25,20 @@ use uuid::Uuid;
 
 type LocalIdStore = HashSet<[u8; 4]>;
 
+mod asym_encryption;
 mod asym_sign;
 mod key_management;
 mod utils;
 
-const SUPPORTED_OPCODES: [Opcode; 6] = [
+const SUPPORTED_OPCODES: [Opcode; 8] = [
     Opcode::PsaGenerateKey,
     Opcode::PsaDestroyKey,
     Opcode::PsaSignHash,
     Opcode::PsaVerifyHash,
     Opcode::PsaImportKey,
     Opcode::PsaExportPublicKey,
+    Opcode::PsaAsymmetricDecrypt,
+    Opcode::PsaAsymmetricEncrypt,
 ];
 
 /// Provider for Public Key Cryptography Standard #11
@@ -245,6 +248,24 @@ impl Provide for Pkcs11Provider {
     ) -> Result<psa_verify_hash::Result> {
         trace!("psa_verify_hash ingress");
         self.psa_verify_hash_internal(app_name, op)
+    }
+
+    fn psa_asymmetric_encrypt(
+        &self,
+        app_name: ApplicationName,
+        op: psa_asymmetric_encrypt::Operation,
+    ) -> Result<psa_asymmetric_encrypt::Result> {
+        trace!("psa_asymmetric_encrypt ingress");
+        self.psa_asymmetric_encrypt_internal(app_name, op)
+    }
+
+    fn psa_asymmetric_decrypt(
+        &self,
+        app_name: ApplicationName,
+        op: psa_asymmetric_decrypt::Operation,
+    ) -> Result<psa_asymmetric_decrypt::Result> {
+        trace!("psa_asymmetric_decrypt ingress");
+        self.psa_asymmetric_decrypt_internal(app_name, op)
     }
 }
 

--- a/src/providers/pkcs11_provider/utils.rs
+++ b/src/providers/pkcs11_provider/utils.rs
@@ -1,14 +1,275 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-
 use super::Pkcs11Provider;
 use log::error;
 use log::{info, trace, warn};
+use parsec_interface::operations::psa_algorithm::*;
+use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::requests::ResponseStatus;
 use parsec_interface::requests::Result;
+use picky_asn1_x509::{AlgorithmIdentifier, DigestInfo, SHAVariant};
 use pkcs11::errors::Error;
 use pkcs11::types::*;
 use pkcs11::types::{CKF_RW_SESSION, CKF_SERIAL_SESSION, CKU_USER};
+use std::convert::{TryFrom, TryInto};
+use std::pin::Pin;
+
+// Public exponent value for all RSA keys.
+const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
+
+/// Abstraction over CK_MECHANISM_TYPE
+#[derive(Debug, Copy, Clone)]
+pub enum CkMechanismType {
+    CkmRsaPkcs,
+    CkmRsaPkcsPss,
+    CkmRsaPkcsOaep,
+    CkmSha1,
+    CkmSha256,
+    CkmSha384,
+    CkmSha512,
+}
+
+impl From<CkMechanismType> for CK_MECHANISM_TYPE {
+    fn from(mech_type: CkMechanismType) -> Self {
+        match mech_type {
+            CkMechanismType::CkmRsaPkcs => CKM_RSA_PKCS,
+            CkMechanismType::CkmRsaPkcsPss => CKM_RSA_PKCS_PSS,
+            CkMechanismType::CkmRsaPkcsOaep => CKM_RSA_PKCS_OAEP,
+            CkMechanismType::CkmSha1 => CKM_SHA_1,
+            CkMechanismType::CkmSha256 => CKM_SHA256,
+            CkMechanismType::CkmSha384 => CKM_SHA384,
+            CkMechanismType::CkmSha512 => CKM_SHA512,
+        }
+    }
+}
+
+pub fn mech_type_to_allowed_mech_attribute(mech_type: &mut CK_MECHANISM_TYPE) -> CK_ATTRIBUTE {
+    let param: CK_MECHANISM_TYPE_PTR = mech_type;
+    let mut allowed_mechanisms_attr = CK_ATTRIBUTE::new(CKA_ALLOWED_MECHANISMS);
+    allowed_mechanisms_attr.ulValueLen = ::std::mem::size_of::<CK_MECHANISM_TYPE>();
+    allowed_mechanisms_attr.pValue = param as CK_VOID_PTR;
+    allowed_mechanisms_attr
+}
+
+/// Abstraction over CK_MECHANISM
+///
+/// The parameters are only there if needed.
+#[derive(Debug)]
+pub enum CkMechanism {
+    CkmRsaPkcs,
+    CkmRsaPkcsPss(CkRsaPkcsPssParams),
+    CkmRsaPkcsOaep(CkRsaPkcsOaepParams),
+    CkmSha1,
+    CkmSha256,
+    CkmSha384,
+    CkmSha512,
+}
+
+#[derive(Debug)]
+pub enum CParams {
+    CkmRsaPkcsPssParams(Pin<Box<CK_RSA_PKCS_PSS_PARAMS>>),
+    CkmRsaPkcsOaepParams(Pin<Box<CK_RSA_PKCS_OAEP_PARAMS>>),
+}
+
+#[derive(Debug)]
+pub struct CkRsaPkcsPssParams {
+    hash_alg: CkMechanismType,
+    mgf: CkRsaPkcsMgfType,
+    s_len: usize,
+}
+
+impl CkRsaPkcsPssParams {
+    pub fn as_c_type(&self) -> CK_RSA_PKCS_PSS_PARAMS {
+        CK_RSA_PKCS_PSS_PARAMS {
+            hashAlg: self.hash_alg.into(),
+            mgf: self.mgf.into(),
+            sLen: self.s_len,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CkRsaPkcsOaepParams {
+    hash_alg: CkMechanismType,
+    mgf: CkRsaPkcsMgfType,
+    source: CkRsaPkcsOaepSourceType,
+    source_data: Vec<u8>,
+}
+
+impl CkRsaPkcsOaepParams {
+    pub fn as_c_type(&mut self) -> CK_RSA_PKCS_OAEP_PARAMS {
+        CK_RSA_PKCS_OAEP_PARAMS {
+            hashAlg: self.hash_alg.into(),
+            mgf: self.mgf.into(),
+            source: self.source.into(),
+            pSourceData: if self.source_data.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                self.source_data.as_mut_ptr() as CK_VOID_PTR
+            },
+            ulSourceDataLen: self.source_data.len(),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum CkRsaPkcsOaepSourceType {
+    CkzDataSpecified,
+}
+
+impl From<CkRsaPkcsOaepSourceType> for CK_RSA_PKCS_OAEP_SOURCE_TYPE {
+    fn from(source: CkRsaPkcsOaepSourceType) -> Self {
+        match source {
+            CkRsaPkcsOaepSourceType::CkzDataSpecified => CKZ_DATA_SPECIFIED,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum CkRsaPkcsMgfType {
+    CkgMgf1Sha1,
+    CkgMgf1Sha256,
+    CkgMgf1Sha384,
+    CkgMgf1Sha512,
+    CkgMgf1Sha224,
+}
+
+impl From<CkRsaPkcsMgfType> for CK_RSA_PKCS_MGF_TYPE {
+    fn from(mgf: CkRsaPkcsMgfType) -> Self {
+        match mgf {
+            CkRsaPkcsMgfType::CkgMgf1Sha1 => CKG_MGF1_SHA1,
+            CkRsaPkcsMgfType::CkgMgf1Sha256 => CKG_MGF1_SHA256,
+            CkRsaPkcsMgfType::CkgMgf1Sha384 => CKG_MGF1_SHA384,
+            CkRsaPkcsMgfType::CkgMgf1Sha512 => CKG_MGF1_SHA512,
+            CkRsaPkcsMgfType::CkgMgf1Sha224 => CKG_MGF1_SHA224,
+        }
+    }
+}
+
+impl CkMechanism {
+    /// Get the mechanism type
+    fn mech_type(&self) -> CkMechanismType {
+        match self {
+            CkMechanism::CkmRsaPkcs => CkMechanismType::CkmRsaPkcs,
+            CkMechanism::CkmRsaPkcsPss(_) => CkMechanismType::CkmRsaPkcsPss,
+            CkMechanism::CkmRsaPkcsOaep(_) => CkMechanismType::CkmRsaPkcsOaep,
+            CkMechanism::CkmSha1 => CkMechanismType::CkmSha1,
+            CkMechanism::CkmSha256 => CkMechanismType::CkmSha256,
+            CkMechanism::CkmSha384 => CkMechanismType::CkmSha384,
+            CkMechanism::CkmSha512 => CkMechanismType::CkmSha512,
+        }
+    }
+}
+
+impl TryFrom<Hash> for CkMechanism {
+    type Error = ResponseStatus;
+
+    fn try_from(alg: Hash) -> Result<Self> {
+        match alg {
+            #[allow(deprecated)]
+            Hash::Sha1 => Ok(CkMechanism::CkmSha1),
+            Hash::Sha256 => Ok(CkMechanism::CkmSha256),
+            Hash::Sha384 => Ok(CkMechanism::CkmSha384),
+            Hash::Sha512 => Ok(CkMechanism::CkmSha512),
+            _ => Err(ResponseStatus::PsaErrorNotSupported),
+        }
+    }
+}
+
+impl TryFrom<Hash> for CkRsaPkcsMgfType {
+    type Error = ResponseStatus;
+
+    fn try_from(alg: Hash) -> Result<Self> {
+        match alg {
+            #[allow(deprecated)]
+            Hash::Sha1 => Ok(CkRsaPkcsMgfType::CkgMgf1Sha1),
+            Hash::Sha256 => Ok(CkRsaPkcsMgfType::CkgMgf1Sha256),
+            Hash::Sha384 => Ok(CkRsaPkcsMgfType::CkgMgf1Sha384),
+            Hash::Sha512 => Ok(CkRsaPkcsMgfType::CkgMgf1Sha512),
+            _ => Err(ResponseStatus::PsaErrorNotSupported),
+        }
+    }
+}
+
+impl TryFrom<Algorithm> for CkMechanism {
+    type Error = ResponseStatus;
+
+    fn try_from(alg: Algorithm) -> Result<Self> {
+        match alg {
+            Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign { .. })
+            | Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaPkcs1v15Crypt { .. }) => {
+                Ok(CkMechanism::CkmRsaPkcs)
+            }
+            Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPss {
+                hash_alg: SignHash::Specific(hash_alg),
+            }) => Ok(CkMechanism::CkmRsaPkcsPss(CkRsaPkcsPssParams {
+                hash_alg: CkMechanism::try_from(hash_alg)?.mech_type(),
+                mgf: hash_alg.try_into()?,
+                s_len: hash_alg.hash_length(),
+            })),
+            Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaOaep { hash_alg }) => {
+                Ok(CkMechanism::CkmRsaPkcsOaep(CkRsaPkcsOaepParams {
+                    hash_alg: CkMechanism::try_from(hash_alg)?.mech_type(),
+                    mgf: hash_alg.try_into()?,
+                    source: CkRsaPkcsOaepSourceType::CkzDataSpecified,
+                    source_data: Vec::new(),
+                }))
+            }
+            _ => Err(ResponseStatus::PsaErrorNotSupported),
+        }
+    }
+}
+
+impl CkMechanism {
+    pub fn as_c_type(&mut self) -> (CK_MECHANISM, Option<CParams>) {
+        match self {
+            CkMechanism::CkmRsaPkcs
+            | CkMechanism::CkmSha1
+            | CkMechanism::CkmSha256
+            | CkMechanism::CkmSha384
+            | CkMechanism::CkmSha512 => (
+                CK_MECHANISM {
+                    mechanism: self.mech_type().into(),
+                    pParameter: std::ptr::null_mut(),
+                    ulParameterLen: 0,
+                },
+                None,
+            ),
+            CkMechanism::CkmRsaPkcsPss(ref params) => {
+                let mut params = Box::pin(params.as_c_type());
+                let len = ::std::mem::size_of::<CK_RSA_PKCS_PSS_PARAMS>();
+                let p_params: CK_RSA_PKCS_PSS_PARAMS_PTR = params.as_mut().get_mut();
+                (
+                    CK_MECHANISM {
+                        mechanism: self.mech_type().into(),
+                        pParameter: p_params as CK_VOID_PTR,
+                        ulParameterLen: len,
+                    },
+                    Some(CParams::CkmRsaPkcsPssParams(params)),
+                )
+            }
+            CkMechanism::CkmRsaPkcsOaep(ref mut params) => {
+                let mut params = Box::pin(params.as_c_type());
+                let len = ::std::mem::size_of::<CK_RSA_PKCS_OAEP_PARAMS>();
+                //ERROR: that does not work because the address of params might change when it is
+                //moved out of the function.
+                //I think raw pointers must be made only if the object pointed at will not move
+                //before the pointer is dereferenced.
+                //That would mean that raw pointers must be made in the same lifetime than the
+                //PKCS11 that will use them.
+                let p_params: CK_RSA_PKCS_OAEP_PARAMS_PTR = params.as_mut().get_mut();
+                (
+                    CK_MECHANISM {
+                        mechanism: self.mech_type().into(),
+                        pParameter: p_params as CK_VOID_PTR,
+                        ulParameterLen: len,
+                    },
+                    Some(CParams::CkmRsaPkcsOaepParams(params)),
+                )
+            }
+        }
+    }
+}
 
 /// Convert the PKCS 11 library specific error values to ResponseStatus values that are returned on
 /// the wire protocol
@@ -257,4 +518,135 @@ impl Drop for Session<'_> {
             }
         }
     }
+}
+
+/// This function converts key parameters from Parsec flavour to PKCS11 flavour
+///
+/// The return type is a tuple with:
+/// * mechanism for key generation
+/// * attributes list for public key
+/// * attributes list for private key
+/// * allowed mechanism for the two halves of the key
+pub fn parsec_to_pkcs11_params(
+    attributes: Attributes,
+    key_id: &[u8],
+) -> Result<(
+    CK_MECHANISM,
+    Vec<CK_ATTRIBUTE>,
+    Vec<CK_ATTRIBUTE>,
+    CK_MECHANISM_TYPE,
+)> {
+    match attributes.key_type {
+        Type::RsaKeyPair => {
+            let mechanism = CK_MECHANISM {
+                mechanism: CKM_RSA_PKCS_KEY_PAIR_GEN,
+                pParameter: std::ptr::null_mut(),
+                ulParameterLen: 0,
+            };
+
+            let mut priv_template: Vec<CK_ATTRIBUTE> = Vec::new();
+            priv_template.push(CK_ATTRIBUTE::new(CKA_TOKEN).with_bool(&CK_TRUE));
+            priv_template.push(CK_ATTRIBUTE::new(CKA_ID).with_bytes(key_id));
+
+            let mut pub_template: Vec<CK_ATTRIBUTE> = Vec::new();
+            pub_template.push(CK_ATTRIBUTE::new(CKA_ID).with_bytes(key_id));
+            pub_template.push(CK_ATTRIBUTE::new(CKA_TOKEN).with_bool(&CK_TRUE));
+            pub_template.push(CK_ATTRIBUTE::new(CKA_PRIVATE).with_bool(&CK_FALSE));
+            pub_template.push(CK_ATTRIBUTE::new(CKA_PUBLIC_EXPONENT).with_bytes(&PUBLIC_EXPONENT));
+            pub_template.push(CK_ATTRIBUTE::new(CKA_MODULUS_BITS).with_ck_ulong(&attributes.bits));
+
+            key_pair_usage_flags_to_pkcs11_attributes(
+                attributes.policy.usage_flags,
+                &mut pub_template,
+                &mut priv_template,
+            );
+
+            Ok((
+                mechanism,
+                pub_template,
+                priv_template,
+                CkMechanism::try_from(attributes.policy.permitted_algorithms)?
+                    .mech_type()
+                    .into(),
+            ))
+        }
+        _ => Err(ResponseStatus::PsaErrorNotSupported),
+    }
+}
+
+fn key_pair_usage_flags_to_pkcs11_attributes(
+    usage_flags: UsageFlags,
+    pub_template: &mut Vec<CK_ATTRIBUTE>,
+    priv_template: &mut Vec<CK_ATTRIBUTE>,
+) {
+    if usage_flags.sign_hash || usage_flags.sign_message {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_SIGN_RECOVER).with_bool(&CK_TRUE));
+    } else {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_SIGN_RECOVER).with_bool(&CK_FALSE));
+    }
+
+    if usage_flags.verify_hash || usage_flags.verify_message {
+        pub_template.push(CK_ATTRIBUTE::new(CKA_VERIFY).with_bool(&CK_TRUE));
+    } else {
+        pub_template.push(CK_ATTRIBUTE::new(CKA_VERIFY).with_bool(&CK_FALSE));
+    }
+
+    if usage_flags.encrypt {
+        pub_template.push(CK_ATTRIBUTE::new(CKA_ENCRYPT).with_bool(&CK_TRUE));
+    } else {
+        pub_template.push(CK_ATTRIBUTE::new(CKA_ENCRYPT).with_bool(&CK_FALSE));
+    }
+
+    if usage_flags.decrypt {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_DECRYPT).with_bool(&CK_TRUE));
+    } else {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_DECRYPT).with_bool(&CK_FALSE));
+    }
+
+    if usage_flags.derive {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_DERIVE).with_bool(&CK_TRUE));
+    } else {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_DERIVE).with_bool(&CK_FALSE));
+    }
+
+    if usage_flags.export {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_EXTRACTABLE).with_bool(&CK_FALSE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_SENSITIVE).with_bool(&CK_TRUE));
+    } else {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_EXTRACTABLE).with_bool(&CK_TRUE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_SENSITIVE).with_bool(&CK_FALSE));
+    }
+
+    if usage_flags.copy {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_COPYABLE).with_bool(&CK_TRUE));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_COPYABLE).with_bool(&CK_TRUE));
+    } else {
+        priv_template.push(CK_ATTRIBUTE::new(CKA_COPYABLE).with_bool(&CK_FALSE));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_COPYABLE).with_bool(&CK_FALSE));
+    }
+}
+
+/// Format the input data into ASN1 DigestInfo bytes
+pub fn digest_info(alg: AsymmetricSignature, hash: Vec<u8>) -> Result<Vec<u8>> {
+    let oid = match alg {
+        AsymmetricSignature::RsaPkcs1v15Sign {
+            hash_alg: SignHash::Specific(Hash::Sha224),
+        } => AlgorithmIdentifier::new_sha(SHAVariant::SHA2_224),
+        AsymmetricSignature::RsaPkcs1v15Sign {
+            hash_alg: SignHash::Specific(Hash::Sha256),
+        } => AlgorithmIdentifier::new_sha(SHAVariant::SHA2_256),
+        AsymmetricSignature::RsaPkcs1v15Sign {
+            hash_alg: SignHash::Specific(Hash::Sha384),
+        } => AlgorithmIdentifier::new_sha(SHAVariant::SHA2_384),
+        AsymmetricSignature::RsaPkcs1v15Sign {
+            hash_alg: SignHash::Specific(Hash::Sha512),
+        } => AlgorithmIdentifier::new_sha(SHAVariant::SHA2_512),
+        _ => return Err(ResponseStatus::PsaErrorNotSupported),
+    };
+    picky_asn1_der::to_vec(&DigestInfo {
+        oid,
+        digest: hash.into(),
+    })
+    // should not fail - if it does, there's some error in our stack
+    .map_err(|_| ResponseStatus::PsaErrorGenericError)
 }


### PR DESCRIPTION
This commit updates the way we handle parameters for the PKCS11
provider, making the process of adding support for new key types more
straight forward.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>