### PR TITLE
Add `buffer_size_limit` config option for providers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,6 +31,10 @@
 # such as key names or policies
 #log_error_details = false
 
+# Decide how large (in bytes) buffers inside responses from this provider can be. Requests that ask
+# for buffers larger than this threshold will be rejected. Defaults to 1MB.
+#buffer_size_limit = 1048576
+
 # (Required) Configuration for the service IPC listener component.
 [listener]
 # (Required) Type of IPC that the service will support.

--- a/src/utils/global_config.rs
+++ b/src/utils/global_config.rs
@@ -1,19 +1,22 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use std::sync::atomic::AtomicBool;
+use crate::utils::service_builder::DEFAULT_BUFFER_SIZE_LIMIT;
 use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 
 /// Configuration values that affect most or all the
 /// components of the service.
 #[derive(Default, Debug)]
 pub struct GlobalConfig {
     log_error_details: AtomicBool,
+    buffer_size_limit: AtomicUsize,
 }
 
 impl GlobalConfig {
     const fn new() -> Self {
         GlobalConfig {
             log_error_details: AtomicBool::new(false),
+            buffer_size_limit: AtomicUsize::new(DEFAULT_BUFFER_SIZE_LIMIT), // 1 MB
         }
     }
 
@@ -22,18 +25,26 @@ impl GlobalConfig {
     pub fn log_error_details() -> bool {
         GLOBAL_CONFIG.log_error_details.load(Ordering::Relaxed)
     }
+
+    /// Fetch the size limit for buffers within responses (in bytes).
+    /// information about the error
+    pub fn buffer_size_limit() -> usize {
+        GLOBAL_CONFIG.buffer_size_limit.load(Ordering::Relaxed)
+    }
 }
 
 static GLOBAL_CONFIG: GlobalConfig = GlobalConfig::new();
 
 pub(super) struct GlobalConfigBuilder {
     log_error_details: bool,
+    buffer_size_limit: Option<usize>,
 }
 
 impl GlobalConfigBuilder {
     pub fn new() -> Self {
         GlobalConfigBuilder {
             log_error_details: false,
+            buffer_size_limit: None,
         }
     }
 
@@ -43,9 +54,19 @@ impl GlobalConfigBuilder {
         self
     }
 
+    pub fn with_buffer_size_limit(mut self, buffer_size_limit: usize) -> Self {
+        self.buffer_size_limit = Some(buffer_size_limit);
+
+        self
+    }
+
     pub fn build(self) {
         GLOBAL_CONFIG
             .log_error_details
             .store(self.log_error_details, Ordering::Relaxed);
+        GLOBAL_CONFIG.buffer_size_limit.store(
+            self.buffer_size_limit.unwrap_or(DEFAULT_BUFFER_SIZE_LIMIT),
+            Ordering::Relaxed,
+        );
     }
 }

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -53,6 +53,9 @@ const WIRE_PROTOCOL_VERSION_MAJOR: u8 = 1;
 /// Default value for the limit on the request body size (in bytes) - equal to 1MB
 const DEFAULT_BODY_LEN_LIMIT: usize = 1 << 19;
 
+/// Default value for the limit on the buffer size for response (in bytes) - equal to 1MB
+pub const DEFAULT_BUFFER_SIZE_LIMIT: usize = 1 << 20;
+
 type KeyInfoManager = Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>;
 type Provider = Arc<dyn Provide + Send + Sync>;
 type Authenticator = Box<dyn Authenticate + Send + Sync>;
@@ -66,6 +69,7 @@ pub struct CoreSettings {
     pub body_len_limit: Option<usize>,
     pub log_error_details: Option<bool>,
     pub allow_root: Option<bool>,
+    pub buffer_size_limit: Option<usize>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -96,6 +100,12 @@ impl ServiceBuilder {
     pub fn build_service(config: &ServiceConfig) -> Result<FrontEndHandler> {
         GlobalConfigBuilder::new()
             .with_log_error_details(config.core_settings.log_error_details.unwrap_or(false))
+            .with_buffer_size_limit(
+                config
+                    .core_settings
+                    .buffer_size_limit
+                    .unwrap_or(DEFAULT_BUFFER_SIZE_LIMIT),
+            )
             .build();
 
         let key_info_managers =


### PR DESCRIPTION
The buffer size limit can be used to cap the maximum allowed buffer size
sent in a response. Requests that ask for buffers larger than this value
will be automatically rejected.