### PR TITLE
Allow software operations in PKCS11 provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ features = ["docs"]
 default = []
 no-parsec-user-and-clients-group = []
 mbed-crypto-provider = ["psa-crypto"]
-pkcs11-provider = ["pkcs11", "picky-asn1-der", "picky-asn1", "picky-asn1-x509"]
+pkcs11-provider = ["pkcs11", "picky-asn1-der", "picky-asn1", "picky-asn1-x509", "psa-crypto"]
 tpm-provider = ["tss-esapi", "picky-asn1-der", "picky-asn1", "picky-asn1-x509"]
 all-providers = ["tpm-provider", "pkcs11-provider", "mbed-crypto-provider"]
 # The Mbed provider is not included in the docs because of 2 reasons:

--- a/config.toml
+++ b/config.toml
@@ -76,6 +76,9 @@ key_info_manager = "on-disk-manager"
 # (Optional) User pin for authentication with the specific slot. If not set, no authentication will
 # be used.
 #user_pin = "123456"
+# (Optional) Control whether missing public key operation (such as verifying signatures or asymmetric
+# encryption) are fully performed in software. 
+#software_public_operations = false
 
 # Example of a TPM provider configuration
 #[[provider]]

--- a/e2e_tests/provider_cfg/pkcs11/Dockerfile
+++ b/e2e_tests/provider_cfg/pkcs11/Dockerfile
@@ -2,7 +2,12 @@ FROM ubuntu:18.04
 
 RUN apt-get update && \
 	apt-get install -y wget automake autoconf libtool pkg-config && \
-    apt-get install -y curl libssl-dev libgcc1
+    apt-get install -y curl libssl-dev libgcc1 && \
+	apt-get install -y git make gcc python3 python curl wget libgcc1 cmake && \
+	# These libraries are needed for bindgen as it uses libclang.so
+	apt-get install -y clang libclang-dev && \
+	# Needed for Open SSL
+	apt-get install -y pkg-config libssl-dev
 
 WORKDIR /tmp
 RUN wget https://github.com/opendnssec/SoftHSMv2/archive/2.5.0.tar.gz

--- a/e2e_tests/provider_cfg/pkcs11/config.toml
+++ b/e2e_tests/provider_cfg/pkcs11/config.toml
@@ -24,3 +24,4 @@ library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
 # slot_number
+software_public_operations = true

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -69,6 +69,16 @@ impl KeyTriple {
     pub fn belongs_to_provider(&self, provider_id: ProviderID) -> bool {
         self.provider_id == provider_id
     }
+
+    /// Get the key name
+    pub fn key_name(&self) -> &str {
+        &self.key_name
+    }
+
+    /// Get the key name
+    pub fn app_name(&self) -> &ApplicationName {
+        &self.app_name
+    }
 }
 
 /// Converts the error string returned by the ManageKeyInfo methods to
@@ -98,7 +108,7 @@ pub trait ManageKeyInfo {
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn get_all(&self, provider_id: ProviderID) -> Result<Vec<&KeyTriple>, String>;
+    fn get_all(&self, provider_id: ProviderID) -> Result<Vec<(KeyTriple, KeyInfo)>, String>;
 
     /// Inserts a new mapping between the key triple and the key info. If the triple already exists,
     /// overwrite the existing mapping and returns the old `KeyInfo`. Otherwise returns `None`.

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -291,11 +291,12 @@ impl ManageKeyInfo for OnDiskKeyInfoManager {
         }
     }
 
-    fn get_all(&self, provider_id: ProviderID) -> Result<Vec<&KeyTriple>, String> {
+    fn get_all(&self, provider_id: ProviderID) -> Result<Vec<(KeyTriple, KeyInfo)>, String> {
         Ok(self
             .key_store
-            .keys()
-            .filter(|key_triple| key_triple.belongs_to_provider(provider_id))
+            .iter()
+            .filter(|(key_triple, _)| key_triple.belongs_to_provider(provider_id))
+            .map(|(key_triple, key_info)| (key_triple.clone(), key_info.clone()))
             .collect())
     }
 

--- a/src/providers/mbed_provider/mod.rs
+++ b/src/providers/mbed_provider/mod.rs
@@ -98,8 +98,8 @@ impl MbedProvider {
             // Delete those who are not present and add to the local_store the ones present.
             match store_handle.get_all(ProviderID::MbedCrypto) {
                 Ok(key_triples) => {
-                    for key_triple in key_triples.iter().cloned() {
-                        let key_id = match key_management::get_key_id(key_triple, &*store_handle) {
+                    for (key_triple, _) in key_triples.iter().cloned() {
+                        let key_id = match key_management::get_key_id(&key_triple, &*store_handle) {
                             Ok(key_id) => key_id,
                             Err(response_status) => {
                                 error!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...", key_triple, response_status);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -37,6 +37,7 @@ pub enum ProviderConfig {
         library_path: String,
         slot_number: usize,
         user_pin: Option<String>,
+        software_public_operations: Option<bool>,
     },
     Tpm {
         key_info_manager: String,

--- a/src/providers/pkcs11_provider/asym_encryption.rs
+++ b/src/providers/pkcs11_provider/asym_encryption.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Pkcs11Provider;
-use super::{key_management::get_key_info, utils, KeyPairType, ReadWriteSession, Session};
+use super::{utils, KeyPairType, ReadWriteSession, Session};
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::KeyTriple;
 use log::{info, trace};
@@ -18,8 +18,7 @@ impl Pkcs11Provider {
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, key_attributes) = self.get_key_info(&key_triple)?;
 
         op.validate(key_attributes)?;
 
@@ -69,8 +68,7 @@ impl Pkcs11Provider {
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, key_attributes) = self.get_key_info(&key_triple)?;
 
         op.validate(key_attributes)?;
 

--- a/src/providers/pkcs11_provider/asym_encryption.rs
+++ b/src/providers/pkcs11_provider/asym_encryption.rs
@@ -7,7 +7,7 @@ use crate::key_info_managers::KeyTriple;
 use log::{info, trace};
 use parsec_interface::operations::psa_algorithm::Algorithm;
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
-use parsec_interface::requests::{ProviderID, Result};
+use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
 use std::convert::TryFrom;
 use utils::CkMechanism;
 
@@ -105,6 +105,44 @@ impl Pkcs11Provider {
             Err(e) => {
                 format_error!("Failed to initialize decrypting operation", e);
                 Err(utils::to_response_status(e))
+            }
+        }
+    }
+
+    pub(super) fn software_psa_asymmetric_encrypt_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_asymmetric_encrypt::Operation,
+    ) -> Result<psa_asymmetric_encrypt::Result> {
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
+        let (_, key_attributes) = self.get_key_info(&key_triple)?;
+
+        op.validate(key_attributes)?;
+
+        let pub_key_id = self.find_or_create_pub_key_id(&key_triple)?;
+        let salt_buff = op.salt.as_ref().map(|salt| salt.as_slice());
+        let alg = op.alg;
+        let buffer_size = key_attributes.asymmetric_encrypt_output_size(alg)?;
+        let mut ciphertext = vec![0u8; buffer_size];
+
+        info!("Encrypting plaintext with PSA Crypto");
+        match psa_crypto::operations::asym_encryption::encrypt(
+            pub_key_id,
+            alg,
+            &op.plaintext,
+            salt_buff,
+            &mut ciphertext,
+        ) {
+            Ok(output_size) => {
+                ciphertext.resize(output_size, 0);
+                Ok(psa_asymmetric_encrypt::Result {
+                    ciphertext: ciphertext.into(),
+                })
+            }
+            Err(error) => {
+                let error = ResponseStatus::from(error);
+                format_error!("Asymmetric encryption failed", error);
+                Err(error)
             }
         }
     }

--- a/src/providers/pkcs11_provider/asym_sign.rs
+++ b/src/providers/pkcs11_provider/asym_sign.rs
@@ -7,7 +7,7 @@ use crate::key_info_managers::KeyTriple;
 use log::{info, trace};
 use parsec_interface::operations::psa_algorithm::Algorithm;
 use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
-use parsec_interface::requests::{ProviderID, Result};
+use parsec_interface::requests::{ProviderID, ResponseStatus, Result};
 use std::convert::TryFrom;
 use utils::CkMechanism;
 
@@ -101,6 +101,34 @@ impl Pkcs11Provider {
             Err(e) => {
                 format_error!("Failed to initialize verifying operation", e);
                 Err(utils::to_response_status(e))
+            }
+        }
+    }
+
+    pub(super) fn software_psa_verify_hash_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_verify_hash::Operation,
+    ) -> Result<psa_verify_hash::Result> {
+        let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
+        let (_, key_attributes) = self.get_key_info(&key_triple)?;
+
+        op.validate(key_attributes)?;
+
+        let pub_key_id = self.find_or_create_pub_key_id(&key_triple)?;
+
+        info!("Verifying signature with PSA Crypto");
+        match psa_crypto::operations::asym_signature::verify_hash(
+            pub_key_id,
+            op.alg,
+            &op.hash,
+            &op.signature,
+        ) {
+            Ok(()) => Ok(psa_verify_hash::Result {}),
+            Err(error) => {
+                let error = ResponseStatus::from(error);
+                format_error!("Verify hash failed", error);
+                Err(error)
             }
         }
     }

--- a/src/providers/pkcs11_provider/asym_sign.rs
+++ b/src/providers/pkcs11_provider/asym_sign.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Pkcs11Provider;
-use super::{key_management::get_key_info, utils, KeyPairType, ReadWriteSession, Session};
+use super::{utils, KeyPairType, ReadWriteSession, Session};
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::KeyTriple;
 use log::{info, trace};
@@ -18,8 +18,7 @@ impl Pkcs11Provider {
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, key_attributes) = self.get_key_info(&key_triple)?;
 
         op.validate(key_attributes)?;
 
@@ -66,8 +65,7 @@ impl Pkcs11Provider {
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, key_attributes) = self.get_key_info(&key_triple)?;
 
         op.validate(key_attributes)?;
 

--- a/src/providers/pkcs11_provider/key_management.rs
+++ b/src/providers/pkcs11_provider/key_management.rs
@@ -1,11 +1,10 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use super::{utils, KeyInfo, KeyPairType, LocalIdStore, Pkcs11Provider, ReadWriteSession, Session};
+use super::{utils, KeyPairType, Pkcs11Provider, ReadWriteSession, Session};
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::KeyTriple;
-use crate::key_info_managers::{self, ManageKeyInfo};
-use log::{error, info, trace, warn};
-use parsec_interface::operations::psa_key_attributes::*;
+use log::{error, info, trace};
+use parsec_interface::operations::psa_key_attributes::Type;
 use parsec_interface::operations::{
     psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
 };
@@ -15,80 +14,6 @@ use picky_asn1::wrapper::IntegerAsn1;
 use picky_asn1_x509::RSAPublicKey;
 use pkcs11::types::{CKR_OK, CK_ATTRIBUTE, CK_OBJECT_HANDLE, CK_SESSION_HANDLE};
 use std::mem;
-
-/// Gets a key identifier and key attributes from the Key Info Manager.
-pub fn get_key_info(
-    key_triple: &KeyTriple,
-    store_handle: &dyn ManageKeyInfo,
-) -> Result<([u8; 4], Attributes)> {
-    match store_handle.get(key_triple) {
-        Ok(Some(key_info)) => {
-            if key_info.id.len() == 4 {
-                let mut dst = [0; 4];
-                dst.copy_from_slice(&key_info.id);
-                Ok((dst, key_info.attributes))
-            } else {
-                error!("Stored Key ID is not valid.");
-                Err(ResponseStatus::KeyInfoManagerError)
-            }
-        }
-        Ok(None) => Err(ResponseStatus::PsaErrorDoesNotExist),
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
-}
-
-pub fn create_key_id(
-    key_triple: KeyTriple,
-    key_attributes: Attributes,
-    store_handle: &mut dyn ManageKeyInfo,
-    local_ids_handle: &mut LocalIdStore,
-) -> Result<[u8; 4]> {
-    let mut key_id = rand::random::<[u8; 4]>();
-    while local_ids_handle.contains(&key_id) {
-        key_id = rand::random::<[u8; 4]>();
-    }
-    let key_info = KeyInfo {
-        id: key_id.to_vec(),
-        attributes: key_attributes,
-    };
-    match store_handle.insert(key_triple.clone(), key_info) {
-        Ok(insert_option) => {
-            if insert_option.is_some() {
-                if crate::utils::GlobalConfig::log_error_details() {
-                    warn!("Overwriting Key triple mapping ({})", key_triple);
-                } else {
-                    warn!("Overwriting Key triple mapping");
-                }
-            }
-            let _ = local_ids_handle.insert(key_id);
-
-            Ok(key_id)
-        }
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
-}
-
-pub fn remove_key_id(
-    key_triple: &KeyTriple,
-    key_id: [u8; 4],
-    store_handle: &mut dyn ManageKeyInfo,
-    local_ids_handle: &mut LocalIdStore,
-) -> Result<()> {
-    match store_handle.remove(key_triple) {
-        Ok(_) => {
-            let _ = local_ids_handle.remove(&key_id);
-            Ok(())
-        }
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
-}
-
-pub fn key_info_exists(key_triple: &KeyTriple, store_handle: &dyn ManageKeyInfo) -> Result<bool> {
-    match store_handle.exists(key_triple) {
-        Ok(val) => Ok(val),
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
-}
 
 impl Pkcs11Provider {
     /// Find the PKCS 11 object handle corresponding to the key ID and the key type (public,
@@ -151,20 +76,10 @@ impl Pkcs11Provider {
         let key_attributes = op.attributes;
 
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
-        if key_info_exists(&key_triple, &*store_handle)? {
+        if self.key_info_exists(&key_triple) {
             return Err(ResponseStatus::PsaErrorAlreadyExists);
         }
-        let key_id = create_key_id(
-            key_triple.clone(),
-            key_attributes,
-            &mut *store_handle,
-            &mut local_ids_handle,
-        )?;
+        let key_id = self.create_key_id(key_triple.clone(), key_attributes)?;
 
         let (mech, mut pub_template, mut priv_template, mut allowed_mechanism) =
             utils::parsec_to_pkcs11_params(key_attributes, &key_id)?;
@@ -178,12 +93,7 @@ impl Pkcs11Provider {
 
         let session = Session::new(self, ReadWriteSession::ReadWrite).or_else(|err| {
             format_error!("Error creating a new session", err);
-            remove_key_id(
-                &key_triple,
-                key_id,
-                &mut *store_handle,
-                &mut local_ids_handle,
-            )?;
+            self.remove_key_id(&key_triple, key_id)?;
             Err(err)
         })?;
 
@@ -204,12 +114,7 @@ impl Pkcs11Provider {
             Ok(_key) => Ok(psa_generate_key::Result {}),
             Err(e) => {
                 format_error!("Generate Key Pair operation failed", e);
-                remove_key_id(
-                    &key_triple,
-                    key_id,
-                    &mut *store_handle,
-                    &mut local_ids_handle,
-                )?;
+                self.remove_key_id(&key_triple, key_id)?;
                 Err(utils::to_response_status(e))
             }
         }
@@ -228,43 +133,23 @@ impl Pkcs11Provider {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
-        if key_info_exists(&key_triple, &*store_handle)? {
+        if self.key_info_exists(&key_triple) {
             return Err(ResponseStatus::PsaErrorAlreadyExists);
         }
-        let key_id = create_key_id(
-            key_triple.clone(),
-            key_attributes,
-            &mut *store_handle,
-            &mut local_ids_handle,
-        )?;
+        let key_id = self.create_key_id(key_triple.clone(), key_attributes)?;
 
         let mut template: Vec<CK_ATTRIBUTE> = Vec::new();
 
         let public_key: RSAPublicKey = picky_asn1_der::from_bytes(op.data.expose_secret())
             .or_else(|e| {
                 format_error!("Failed to parse RsaPublicKey data", e);
-                remove_key_id(
-                    &key_triple,
-                    key_id,
-                    &mut *store_handle,
-                    &mut local_ids_handle,
-                )?;
+                self.remove_key_id(&key_triple, key_id)?;
                 Err(ResponseStatus::PsaErrorInvalidArgument)
             })?;
 
         if public_key.modulus.is_negative() || public_key.public_exponent.is_negative() {
             error!("Only positive modulus and public exponent are supported.");
-            remove_key_id(
-                &key_triple,
-                key_id,
-                &mut *store_handle,
-                &mut local_ids_handle,
-            )?;
+            self.remove_key_id(&key_triple, key_id)?;
             return Err(ResponseStatus::PsaErrorInvalidArgument);
         }
 
@@ -281,6 +166,8 @@ impl Pkcs11Provider {
             } else {
                 error!("`bits` field of key attributes must be either 0 or equal to the size of the key in `data`.");
             }
+
+            self.remove_key_id(&key_triple, key_id)?;
             return Err(ResponseStatus::PsaErrorInvalidArgument);
         }
 
@@ -320,12 +207,7 @@ impl Pkcs11Provider {
 
         let session = Session::new(self, ReadWriteSession::ReadWrite).or_else(|err| {
             format_error!("Error creating a new session", err);
-            remove_key_id(
-                &key_triple,
-                key_id,
-                &mut *store_handle,
-                &mut local_ids_handle,
-            )?;
+            self.remove_key_id(&key_triple, key_id)?;
             Err(err)
         })?;
 
@@ -344,12 +226,7 @@ impl Pkcs11Provider {
             Ok(_key) => Ok(psa_import_key::Result {}),
             Err(e) => {
                 format_error!("Import operation failed", e);
-                remove_key_id(
-                    &key_triple,
-                    key_id,
-                    &mut *store_handle,
-                    &mut local_ids_handle,
-                )?;
+                self.remove_key_id(&key_triple, key_id)?;
                 Err(utils::to_response_status(e))
             }
         }
@@ -362,8 +239,7 @@ impl Pkcs11Provider {
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, _key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, _key_attributes) = self.get_key_info(&key_triple)?;
 
         let session = Session::new(self, ReadWriteSession::ReadOnly)?;
         if crate::utils::GlobalConfig::log_error_details() {
@@ -458,12 +334,7 @@ impl Pkcs11Provider {
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, key_name);
-        let mut store_handle = self
-            .key_info_store
-            .write()
-            .expect("Key store lock poisoned");
-        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
-        let (key_id, _) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, _) = self.get_key_info(&key_triple)?;
 
         let session = Session::new(self, ReadWriteSession::ReadWrite)?;
         if crate::utils::GlobalConfig::log_error_details() {
@@ -510,12 +381,7 @@ impl Pkcs11Provider {
             }
         };
 
-        remove_key_id(
-            &key_triple,
-            key_id,
-            &mut *store_handle,
-            &mut local_ids_handle,
-        )?;
+        self.remove_key_id(&key_triple, key_id)?;
 
         Ok(psa_destroy_key::Result {})
     }

--- a/src/providers/pkcs11_provider/key_metadata.rs
+++ b/src/providers/pkcs11_provider/key_metadata.rs
@@ -1,0 +1,115 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::{KeyInfo, KeyMetadata, Pkcs11Provider};
+use crate::key_info_managers;
+use crate::key_info_managers::KeyTriple;
+use log::{error, warn};
+use parsec_interface::operations::psa_key_attributes::*;
+use parsec_interface::requests::{ResponseStatus, Result};
+
+impl Pkcs11Provider {
+    /// Gets a key identifier and key attributes from the Key Info Manager.
+    pub(super) fn get_key_info(&self, key_triple: &KeyTriple) -> Result<([u8; 4], Attributes)> {
+        let store_handle = self.key_info_store.read().expect("Local ID lock poisoned");
+        let key_metadata_cache = self
+            .key_metadata_cache
+            .read()
+            .expect("Key metadata cache lock poisoned");
+        if let Some(KeyMetadata {
+            pkcs11_id,
+            attributes,
+            ..
+        }) = key_metadata_cache.get(key_triple)
+        {
+            return Ok((*pkcs11_id, *attributes));
+        }
+        match store_handle.get(key_triple) {
+            Ok(Some(key_info)) => {
+                if key_info.id.len() == 4 {
+                    let mut dst = [0; 4];
+                    dst.copy_from_slice(&key_info.id);
+                    Ok((dst, key_info.attributes))
+                } else {
+                    error!("Stored Key ID is not valid.");
+                    Err(ResponseStatus::KeyInfoManagerError)
+                }
+            }
+            Ok(None) => Err(ResponseStatus::PsaErrorDoesNotExist),
+            Err(string) => Err(key_info_managers::to_response_status(string)),
+        }
+    }
+
+    pub(super) fn create_key_id(
+        &self,
+        key_triple: KeyTriple,
+        key_attributes: Attributes,
+    ) -> Result<[u8; 4]> {
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        let mut key_metadata_cache = self
+            .key_metadata_cache
+            .write()
+            .expect("Key metadata cache lock poisoned");
+        let mut key_id = rand::random::<[u8; 4]>();
+        while local_ids_handle.contains(&key_id) {
+            key_id = rand::random::<[u8; 4]>();
+        }
+        let key_info = KeyInfo {
+            id: key_id.to_vec(),
+            attributes: key_attributes,
+        };
+        match store_handle.insert(key_triple.clone(), key_info) {
+            Ok(insert_option) => {
+                if insert_option.is_some() {
+                    if crate::utils::GlobalConfig::log_error_details() {
+                        warn!("Overwriting Key triple mapping ({})", key_triple);
+                    } else {
+                        warn!("Overwriting Key triple mapping");
+                    }
+                }
+                let _ = local_ids_handle.insert(key_id);
+
+                let _ = key_metadata_cache.insert(
+                    key_triple,
+                    KeyMetadata {
+                        pkcs11_id: key_id,
+                        attributes: key_attributes,
+                    },
+                );
+                Ok(key_id)
+            }
+            Err(string) => Err(key_info_managers::to_response_status(string)),
+        }
+    }
+
+    pub(super) fn remove_key_id(&self, key_triple: &KeyTriple, key_id: [u8; 4]) -> Result<()> {
+        let mut store_handle = self
+            .key_info_store
+            .write()
+            .expect("Key store lock poisoned");
+        let mut local_ids_handle = self.local_ids.write().expect("Local ID lock poisoned");
+        let mut key_metadata_cache = self
+            .key_metadata_cache
+            .write()
+            .expect("Key metadata cache lock poisoned");
+        match store_handle.remove(key_triple) {
+            Ok(_) => {
+                let _ = local_ids_handle.remove(&key_id);
+                let _ = key_metadata_cache.remove(key_triple);
+                Ok(())
+            }
+            Err(string) => Err(key_info_managers::to_response_status(string)),
+        }
+    }
+
+    pub(super) fn key_info_exists(&self, key_triple: &KeyTriple) -> bool {
+        let key_metadata_cache = self
+            .key_metadata_cache
+            .read()
+            .expect("Key metadata cache lock poisoned");
+        key_metadata_cache.contains_key(key_triple)
+    }
+}

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -272,6 +272,7 @@ unsafe fn get_provider(
             library_path,
             slot_number,
             user_pin,
+            software_public_operations,
             ..
         } => {
             info!("Creating a PKCS 11 Provider.");
@@ -281,6 +282,7 @@ unsafe fn get_provider(
                     .with_pkcs11_library_path(library_path.clone())
                     .with_slot_number(*slot_number)
                     .with_user_pin(user_pin.clone())
+                    .with_software_public_operations(*software_public_operations)
                     .build()?,
             ))
         }


### PR DESCRIPTION
This commit modifies the PKCS11 provider so that it allows public key
operations to be performed in software, conditioned on a configuration
flag. If said flag is set, the public part of the key is exported from
PKCS11 and imported into PSA Crypto, and the operation is performed
using an implementation of PSA Crypto.

Changes have also been made to the way key metadata is handled, moving
some of the helper functions onto the `Pkcs11Provider` as methods. A key
matadata cache was also added, to speed up the operations requiring
access to key information.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>