### PR TITLE
Improve key metadata handling

### DIFF
--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -77,6 +77,16 @@ impl KeyTriple {
     pub fn belongs_to_provider(&self, provider_id: ProviderID) -> bool {
         self.provider_id == provider_id
     }
+
+    /// Get the key name
+    pub fn key_name(&self) -> &str {
+        &self.key_name
+    }
+
+    /// Get the app name
+    pub fn app_name(&self) -> &ApplicationName {
+        &self.app_name
+    }
 }
 
 /// Converts the error string returned by the ManageKeyInfo methods to

--- a/src/providers/mbed_crypto_provider/mod.rs
+++ b/src/providers/mbed_crypto_provider/mod.rs
@@ -105,7 +105,7 @@ impl MbedCryptoProvider {
             match store_handle.get_all(ProviderID::MbedCrypto) {
                 Ok(key_triples) => {
                     for key_triple in key_triples.iter().cloned() {
-                        let key_id = match key_management::get_key_id(key_triple, &*store_handle) {
+                        let key_id = match key_management::get_key_id(&key_triple, &*store_handle) {
                             Ok(key_id) => key_id,
                             Err(response_status) => {
                                 error!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...", key_triple, response_status);

--- a/src/providers/pkcs11_provider/asym_encryption.rs
+++ b/src/providers/pkcs11_provider/asym_encryption.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Pkcs11Provider;
-use super::{key_management::get_key_info, utils, KeyPairType, ReadWriteSession, Session};
+use super::{utils, KeyPairType, ReadWriteSession, Session};
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::KeyTriple;
 use log::{info, trace};
@@ -18,8 +18,7 @@ impl Pkcs11Provider {
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, key_attributes) = self.get_key_info(&key_triple)?;
 
         op.validate(key_attributes)?;
 
@@ -69,8 +68,7 @@ impl Pkcs11Provider {
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, key_attributes) = self.get_key_info(&key_triple)?;
 
         op.validate(key_attributes)?;
 

--- a/src/providers/pkcs11_provider/asym_sign.rs
+++ b/src/providers/pkcs11_provider/asym_sign.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Pkcs11Provider;
-use super::{key_management::get_key_info, utils, KeyPairType, ReadWriteSession, Session};
+use super::{utils, KeyPairType, ReadWriteSession, Session};
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::KeyTriple;
 use log::{info, trace};
@@ -18,8 +18,7 @@ impl Pkcs11Provider {
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, key_attributes) = self.get_key_info(&key_triple)?;
 
         op.validate(key_attributes)?;
 
@@ -66,8 +65,7 @@ impl Pkcs11Provider {
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
         let key_triple = KeyTriple::new(app_name, ProviderID::Pkcs11, op.key_name.clone());
-        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
-        let (key_id, key_attributes) = get_key_info(&key_triple, &*store_handle)?;
+        let (key_id, key_attributes) = self.get_key_info(&key_triple)?;
 
         op.validate(key_attributes)?;
 

--- a/src/providers/pkcs11_provider/key_metadata.rs
+++ b/src/providers/pkcs11_provider/key_metadata.rs
@@ -1,0 +1,109 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::LocalIdStore;
+use super::{KeyInfo, Pkcs11Provider};
+use crate::key_info_managers;
+use crate::key_info_managers::{KeyTriple, ManageKeyInfo};
+use log::{error, warn};
+use parsec_interface::operations::psa_key_attributes::*;
+use parsec_interface::requests::{ResponseStatus, Result};
+use std::sync::RwLock;
+
+impl Pkcs11Provider {
+    // This function returns the `RWLocks` found on the `Pkcs11Provider`
+    // in the order in which they should *always* be taken. Changing the order
+    // of locking in one method can very easily result in deadlocking.
+    pub(super) fn get_ordered_locks<'a>(
+        &'a self,
+    ) -> (
+        &'a RwLock<dyn ManageKeyInfo + Send + Sync>,
+        &'a RwLock<LocalIdStore>,
+    ) {
+        (&self.key_info_store, &self.local_ids)
+    }
+
+    /// Gets a key identifier and key attributes from the Key Info Manager.
+    pub(super) fn get_key_info(&self, key_triple: &KeyTriple) -> Result<([u8; 4], Attributes)> {
+        let locks = self.get_ordered_locks();
+        let store_handle = locks.0.read().expect("Local ID lock poisoned");
+        match store_handle.get(key_triple) {
+            Ok(Some(key_info)) => {
+                if key_info.id.len() == 4 {
+                    let mut dst = [0; 4];
+                    dst.copy_from_slice(&key_info.id);
+                    Ok((dst, key_info.attributes))
+                } else {
+                    error!("Stored Key ID is not valid.");
+                    Err(ResponseStatus::KeyInfoManagerError)
+                }
+            }
+            Ok(None) => Err(ResponseStatus::PsaErrorDoesNotExist),
+            Err(string) => Err(key_info_managers::to_response_status(string)),
+        }
+    }
+
+    pub(super) fn create_key_id(
+        &self,
+        key_triple: KeyTriple,
+        key_attributes: Attributes,
+    ) -> Result<[u8; 4]> {
+        let locks = self.get_ordered_locks();
+        let mut store_handle = locks.0.write().expect("Key store lock poisoned");
+        let mut local_ids_handle = locks.1.write().expect("Local ID lock poisoned");
+        let mut key_id = rand::random::<[u8; 4]>();
+        while local_ids_handle.contains(&key_id) {
+            key_id = rand::random::<[u8; 4]>();
+        }
+        let key_info = KeyInfo {
+            id: key_id.to_vec(),
+            attributes: key_attributes,
+        };
+        match store_handle.insert(key_triple.clone(), key_info) {
+            Ok(insert_option) => {
+                if insert_option.is_some() {
+                    if crate::utils::GlobalConfig::log_error_details() {
+                        warn!("Overwriting Key triple mapping ({})", key_triple);
+                    } else {
+                        warn!("Overwriting Key triple mapping");
+                    }
+                }
+                let _ = local_ids_handle.insert(key_id);
+                Ok(key_id)
+            }
+            Err(string) => Err(key_info_managers::to_response_status(string)),
+        }
+    }
+
+    pub(super) fn remove_key_id(&self, key_triple: &KeyTriple) -> Result<[u8; 4]> {
+        let locks = self.get_ordered_locks();
+        let mut store_handle = locks.0.write().expect("Key store lock poisoned");
+        let mut local_ids_handle = locks.1.write().expect("Local ID lock poisoned");
+        match store_handle.remove(key_triple) {
+            Ok(Some(key_info)) => {
+                let mut key_id = [0; 4];
+                if key_info.id.len() == 4 {
+                    key_id.copy_from_slice(&key_info.id);
+                } else {
+                    error!("Key info contained invalid key ID");
+                    return Err(ResponseStatus::PsaErrorDataCorrupt);
+                };
+                let _ = local_ids_handle.remove(&key_id);
+                Ok(key_id)
+            }
+            Ok(None) => {
+                error!("Did not find expected key info.");
+                Err(ResponseStatus::PsaErrorDoesNotExist)
+            }
+            Err(string) => Err(key_info_managers::to_response_status(string)),
+        }
+    }
+
+    pub(super) fn key_info_exists(&self, key_triple: &KeyTriple) -> Result<bool> {
+        let locks = self.get_ordered_locks();
+        let store_handle = locks.0.read().expect("Key store lock poisoned");
+        match store_handle.exists(key_triple) {
+            Ok(val) => Ok(val),
+            Err(string) => Err(key_info_managers::to_response_status(string)),
+        }
+    }
+}


### PR DESCRIPTION
This commit improves the handling of key metadata in the PKCS11
provider, allowing the provider to cache metadata in memory instead of
always requesting it from the key info manager.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>