### PR TITLE
Fix sign attribute in PKCS11

### DIFF
--- a/src/providers/pkcs11_provider/utils.rs
+++ b/src/providers/pkcs11_provider/utils.rs
@@ -590,9 +590,9 @@ fn key_pair_usage_flags_to_pkcs11_attributes(
     priv_template: &mut Vec<CK_ATTRIBUTE>,
 ) {
     if usage_flags.sign_hash || usage_flags.sign_message {
-        priv_template.push(CK_ATTRIBUTE::new(CKA_SIGN_RECOVER).with_bool(&CK_TRUE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_SIGN).with_bool(&CK_TRUE));
     } else {
-        priv_template.push(CK_ATTRIBUTE::new(CKA_SIGN_RECOVER).with_bool(&CK_FALSE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_SIGN).with_bool(&CK_FALSE));
     }
 
     if usage_flags.verify_hash || usage_flags.verify_message {


### PR DESCRIPTION
This commit fixes a bug in the conversion process for key attributes in the
PKCS11 provider. Instead of CKA_SIGN_RECOVER, CKA_SIGN is to be used.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>