### PR TITLE
Improve error message on service startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
 name = "parsec-service"
 version = "0.5.0"
 dependencies = [
+ "anyhow",
  "base64",
  "bincode",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 picky-asn1-x509 = { version = "0.3.2", optional = true }
 users = "0.10.0"
 libc = "0.2.77"
+anyhow = "1.0.32"
 
 [dev-dependencies]
 rand = { version = "0.7.3", features = ["small_rng"] }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -39,10 +39,11 @@
 // This one is hard to avoid.
 #![allow(clippy::multiple_crate_versions)]
 
+use anyhow::Result;
 use log::{info, trace};
 use parsec_service::utils::{ServiceBuilder, ServiceConfig};
 use signal_hook::{flag, SIGHUP, SIGTERM};
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, ErrorKind};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -101,7 +102,8 @@ fn main() -> Result<()> {
             ErrorKind::Other,
             "Insecure configuration; the Parsec service should not be running as root! You can \
              modify `allow_root` in the config file to bypass this check (not recommended).",
-        ));
+        )
+        .into());
     }
 
     log_setup(&config);

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -21,13 +21,14 @@ use crate::key_info_managers::on_disk_manager::{
 };
 use crate::key_info_managers::{KeyInfoManagerConfig, KeyInfoManagerType, ManageKeyInfo};
 use crate::providers::{core_provider::CoreProviderBuilder, Provide, ProviderConfig};
+use anyhow::Result;
 use log::{error, warn, LevelFilter};
 use parsec_interface::operations_protobuf::ProtobufConverter;
 use parsec_interface::requests::AuthType;
 use parsec_interface::requests::{BodyType, ProviderID};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -126,7 +127,7 @@ impl ServiceBuilder {
 
         if providers.is_empty() {
             error!("Parsec needs at least one provider to start. No valid provider could be created from the configuration.");
-            return Err(Error::new(ErrorKind::InvalidData, "need one provider"));
+            return Err(Error::new(ErrorKind::InvalidData, "need one provider").into());
         }
 
         // The authenticators supported by the Parsec service.
@@ -330,7 +331,7 @@ unsafe fn get_provider(
                 "Provider \"{:?}\" chosen in the configuration was not compiled in Parsec binary.",
                 config
             );
-            Err(Error::new(ErrorKind::InvalidData, "provider not compiled"))
+            Err(Error::new(ErrorKind::InvalidData, "provider not compiled").into())
         }
     }
 }


### PR DESCRIPTION
This commit improves the way we handle messages at service startup and
adds more context information to filesystem-related errors.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>