### PR TITLE
Bugfix: use `UnixPeerCredentials` instead of `PeerCredentials`

### DIFF
--- a/src/authenticators/unix_peer_credentials_authenticator/mod.rs
+++ b/src/authenticators/unix_peer_credentials_authenticator/mod.rs
@@ -35,7 +35,7 @@ impl Authenticate for UnixPeerCredentialsAuthenticator {
             version_maj: 0,
             version_min: 1,
             version_rev: 0,
-            id: AuthType::PeerCredentials,
+            id: AuthType::UnixPeerCredentials,
         })
     }
 


### PR DESCRIPTION
Really quick bugfix. Looks like is this blocking CI [here](https://github.com/parallaxsecond/parsec/pull/261).