### PR TITLE
Add multitenancy tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,8 +704,7 @@ dependencies = [
 [[package]]
 name = "psa-crypto"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8cd6b7efe9e3853f86c82f89763a070df8b7caf8c289bf0074acbf8470fd11"
+source = "git+https://github.com/parallaxsecond/rust-psa-crypto?rev=a1647d64e19e6e46baad708b84c2b5d0d3b543c7#a1647d64e19e6e46baad708b84c2b5d0d3b543c7"
 dependencies = [
  "log",
  "psa-crypto-sys",
@@ -715,9 +714,8 @@ dependencies = [
 
 [[package]]
 name = "psa-crypto-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63710d569a7919a2a4c130e336953e9970a6f6e1fc94baa6c116fbdfc4f06060"
+version = "0.5.1"
+source = "git+https://github.com/parallaxsecond/rust-psa-crypto?rev=a1647d64e19e6e46baad708b84c2b5d0d3b543c7#a1647d64e19e6e46baad708b84c2b5d0d3b543c7"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ users = "0.10.0"
 libc = "0.2.77"
 anyhow = "1.0.32"
 
+[patch.crates-io]
+psa-crypto = { git = "https://github.com/parallaxsecond/rust-psa-crypto", rev = "a1647d64e19e6e46baad708b84c2b5d0d3b543c7" }
+
 [dev-dependencies]
 rand = { version = "0.7.3", features = ["small_rng"] }
 

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -14,9 +14,12 @@ publish = false
 
 [dependencies]
 serde = { version = "1.0.115", features = ["derive"] }
-parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust", rev = "dbd449a9e736f9f972e5489fb2d67949b93484dc", features = ["testing"] }
+parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust", rev = "3f7dfc7bd06bea7cb3aa38cdcb270af7b8899f89", features = ["testing"] }
 log = "0.4.11"
 rand = "0.7.3"
+
+[patch.crates-io]
+psa-crypto = { git = "https://github.com/parallaxsecond/rust-psa-crypto", rev = "22a505bedce1c21246ce5c3cf41ea97b0b781830" }
 
 [dev-dependencies]
 ring = "0.16.15"

--- a/e2e_tests/provider_cfg/all/Dockerfile
+++ b/e2e_tests/provider_cfg/all/Dockerfile
@@ -6,7 +6,9 @@ RUN apt-get update && \
 	apt-get install -y git make gcc python3 python curl wget cmake && \
 	apt-get install -y automake autoconf libtool pkg-config libssl-dev && \
 	# These libraries are needed for bindgen as it uses libclang.so
-	apt-get install -y clang libclang-dev libc6-dev-i386
+	apt-get install -y clang libclang-dev libc6-dev-i386 && \
+	# Install cargo globally to not have to install it for each user for multitenancy tests
+	apt-get install -y cargo
 
 WORKDIR /tmp
 RUN wget https://github.com/ARMmbed/mbed-crypto/archive/mbedcrypto-2.0.0.tar.gz
@@ -44,6 +46,6 @@ RUN cd SoftHSMv2-2.5.0 \
 # and is found with the find_slot_number script.
 RUN softhsm2-util --init-token --slot 0 --label "Parsec Tests" --pin 123456 --so-pin 123456
 
-# Install Rust toolchain
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+# Add users for multitenancy tests
+RUN useradd -m parsec-client-1
+RUN useradd -m parsec-client-2

--- a/e2e_tests/src/stress.rs
+++ b/e2e_tests/src/stress.rs
@@ -107,7 +107,7 @@ impl StressTestWorker {
         // Create unique client auth
         let auth = generate_string(10);
         info!("Worker with auth `{}` starting.", auth);
-        client.set_auth(auth);
+        client.set_default_auth(Some(auth));
 
         // Create sign/verify key
         let sign_key_name = generate_string(10);

--- a/e2e_tests/tests/all_providers/mod.rs
+++ b/e2e_tests/tests/all_providers/mod.rs
@@ -3,4 +3,5 @@
 
 mod config;
 mod cross;
+mod multitenancy;
 mod normal;

--- a/e2e_tests/tests/all_providers/multitenancy.rs
+++ b/e2e_tests/tests/all_providers/multitenancy.rs
@@ -1,0 +1,69 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use e2e_tests::TestClient;
+use parsec_client::core::interface::requests::{ProviderID, ResponseStatus};
+
+// These tests are executed by different users in the following order:
+// 1. client1_before is executed as parsec-client-1
+// 2. client2 is executed as parsec-client-2
+// 3. client1_after is executed as parsec-client-1
+//
+// They are executed against all possible authenticators in Parsec.
+
+#[test]
+fn client1_before() {
+    // Create one key on each provider
+    let mut client = TestClient::new();
+    client.do_not_destroy_keys();
+    client.set_default_auth(Some("client1".to_string()));
+
+    let key = String::from("multitenant");
+
+    for provider in [ProviderID::MbedCrypto, ProviderID::Pkcs11, ProviderID::Tpm].iter() {
+        client.set_provider(*provider);
+        client.generate_rsa_sign_key(key.clone()).unwrap();
+    }
+}
+
+#[test]
+fn client2() {
+    let mut client = TestClient::new();
+    client.set_default_auth(Some("client2".to_string()));
+
+    let key = String::from("multitenant");
+
+    // Try to list those keys
+    let keys = client.list_keys().unwrap();
+    assert!(keys.is_empty());
+
+    for provider in [ProviderID::MbedCrypto, ProviderID::Pkcs11, ProviderID::Tpm].iter() {
+        client.set_provider(*provider);
+        assert_eq!(
+            client.export_public_key(key.clone()).unwrap_err(),
+            ResponseStatus::PsaErrorDoesNotExist
+        );
+        assert_eq!(
+            client.destroy_key(key.clone()).unwrap_err(),
+            ResponseStatus::PsaErrorDoesNotExist
+        );
+        client.generate_rsa_sign_key(key.clone()).unwrap();
+        client.destroy_key(key.clone()).unwrap();
+    }
+}
+
+#[test]
+fn client1_after() {
+    let mut client = TestClient::new();
+    client.set_default_auth(Some("client1".to_string()));
+
+    // Verify all keys are still there and can be used
+    let keys = client.list_keys().unwrap();
+    assert_eq!(keys.len(), 3);
+
+    // Destroy the keys
+    let key = String::from("multitenant");
+    for provider in [ProviderID::MbedCrypto, ProviderID::Pkcs11, ProviderID::Tpm].iter() {
+        client.set_provider(*provider);
+        client.destroy_key(key.clone()).unwrap();
+    }
+}

--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -116,7 +116,7 @@ fn sign_verify_with_provider_discovery() -> Result<()> {
 #[test]
 fn list_keys() {
     let mut client = TestClient::new();
-    client.set_auth("list_keys test".to_string());
+    client.set_default_auth(Some("list_keys test".to_string()));
 
     let keys = client.list_keys().expect("list_keys failed");
 

--- a/e2e_tests/tests/per_provider/normal_tests/auth.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/auth.rs
@@ -11,10 +11,10 @@ fn two_auths_same_key_name() -> Result<()> {
     let auth1 = String::from("first_client");
     let auth2 = String::from("second_client");
 
-    client.set_auth(auth1);
+    client.set_default_auth(Some(auth1));
     client.generate_rsa_sign_key(key_name.clone())?;
 
-    client.set_auth(auth2);
+    client.set_default_auth(Some(auth2));
     client.generate_rsa_sign_key(key_name)
 }
 
@@ -25,10 +25,10 @@ fn delete_wrong_key() -> Result<()> {
     let auth1 = String::from("first_client");
     let auth2 = String::from("second_client");
 
-    client.set_auth(auth1);
+    client.set_default_auth(Some(auth1));
     client.generate_rsa_sign_key(key_name.clone())?;
 
-    client.set_auth(auth2);
+    client.set_default_auth(Some(auth2));
     let status = client
         .destroy_key(key_name)
         .expect_err("Destroying key should have failed");

--- a/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
@@ -129,7 +129,7 @@ fn wrong_permitted_algorithm() {
 
     // The Mbed Crypto provider currently does not support other algorithms than the RSA PKCS 1v15
     // signing algorithm with hash when checking policies only.
-    if client.provider().unwrap() == ProviderID::MbedCrypto {
+    if client.provider() == ProviderID::MbedCrypto {
         return;
     }
 

--- a/e2e_tests/tests/per_provider/persistent_after.rs
+++ b/e2e_tests/tests/per_provider/persistent_after.rs
@@ -28,7 +28,7 @@ fn reuse_to_sign() -> Result<()> {
 fn should_have_been_deleted() {
     let mut client = TestClient::new();
 
-    if client.provider().unwrap() == ProviderID::Tpm {
+    if client.provider() == ProviderID::Tpm {
         // This test does not make sense for the TPM Provider.
         return;
     }


### PR DESCRIPTION
This PR adds multitenancy tests which execute various operations under different users and check that one user can not use the keys of another one.

Fix #245 