### PR TITLE
Switch Travis CI build to cron-only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Executing our tests on Arm64 with Travis CI
 # The TPM provider Dockerfile does not build on Arm so the all-providers and tpm-provider tests
 # are not executed on Aarch64.
+if: type = cron
 arch: arm64
 services:
   - docker
@@ -10,11 +11,12 @@ jobs:
       env: DOCKER_IMAGE_NAME=mbed-crypto-provider DOCKER_IMAGE_PATH=e2e_tests/provider_cfg/mbed-crypto SCRIPT="ci.sh mbed-crypto"
     - name: "Integration tests using PKCS 11 provider"
       env: DOCKER_IMAGE_NAME=pkcs11-provider DOCKER_IMAGE_PATH=e2e_tests/provider_cfg/pkcs11 SCRIPT="ci.sh pkcs11"
+  # Re-enabling these for now, we'll need to fix the issues, otherwise the build is just useless
   # PKCS11 tests are failing because of unidentified issues.
   # See https://github.com/parallaxsecond/parsec/issues/116
-  allow_failures:
-    - env: DOCKER_IMAGE_NAME=mbed-crypto-provider DOCKER_IMAGE_PATH=e2e_tests/provider_cfg/mbed-crypto SCRIPT="ci.sh mbed-crypto"
-    - env: DOCKER_IMAGE_NAME=pkcs11-provider DOCKER_IMAGE_PATH=e2e_tests/provider_cfg/pkcs11 SCRIPT="ci.sh pkcs11"
+  # allow_failures:
+  #   - env: DOCKER_IMAGE_NAME=mbed-crypto-provider DOCKER_IMAGE_PATH=e2e_tests/provider_cfg/mbed-crypto SCRIPT="ci.sh mbed-crypto"
+  #   - env: DOCKER_IMAGE_NAME=pkcs11-provider DOCKER_IMAGE_PATH=e2e_tests/provider_cfg/pkcs11 SCRIPT="ci.sh pkcs11"
 script:
   - docker build -t $DOCKER_IMAGE_NAME $DOCKER_IMAGE_PATH
   - docker run -v $(pwd):/tmp/parsec -w /tmp/parsec $DOCKER_IMAGE_NAME /tmp/parsec/$SCRIPT


### PR DESCRIPTION
This commit changes the settings for Travis CI builds to only allow cron
jobs to run (as we now have a very limited number of build minutes
available) and to show them as failed instead of ignoring all failures.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>