### PR TITLE
Add new parsec provider using ATECCx08 cryptochip via CryptoAuthentication Library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,8 +982,9 @@ dependencies = [
 
 [[package]]
 name = "parsec-interface"
-version = "0.21.0"
-source = "git+https://github.com/parallaxsecond/parsec-interface-rs.git#de4cbe6161507f74edb9486af09e242fdf439c4c"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2315911063bdd449304da2c4d36ab1816a199c3de13c0efa0e30856305bf49c5"
 dependencies = [
  "bincode",
  "derivative",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,8 +983,7 @@ dependencies = [
 [[package]]
 name = "parsec-interface"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f484fbe6ae8a4f676da07140094a5da5216ac79b17ab72b58ffb31fecfccd8"
+source = "git+https://github.com/parallaxsecond/parsec-interface-rs.git#de4cbe6161507f74edb9486af09e242fdf439c4c"
 dependencies = [
  "bincode",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = "0.21.0"
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs.git"}
 rand = { version = "0.7.3", features = ["small_rng"], optional = true }
 base64 = "0.12.3"
 uuid = "0.8.1"
@@ -38,7 +38,7 @@ structopt = "0.3.17"
 derivative = "2.1.1"
 version = "3.0.0"
 hex = { version = "0.4.2", optional = true }
-psa-crypto = { version = "0.6.0", default-features = false, features = ["operations"], optional = true }
+psa-crypto = { git = "https://github.com/parallaxsecond/rust-psa-crypto", rev = "18dd4dda96d8b61d2e112b9e6ad83e90fe768d78", default-features = false, features = ["operations"], optional = true}
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 picky-asn1-x509 = { version = "0.3.2", optional = true }
 users = "0.10.0"
@@ -51,11 +51,12 @@ spiffe = { git = "https://github.com/hug-dev/rust-spiffe", branch = "refactor-jw
 rand = { version = "0.7.3", features = ["small_rng"] }
 
 [package.metadata.docs.rs]
-features = ["pkcs11-provider", "tpm-provider", "tss-esapi/docs", "mbed-crypto-provider"]
+features = ["pkcs11-provider", "tpm-provider", "tss-esapi/docs", "mbed-crypto-provider", "cryptoauthlib-provider"]
 
 [features]
 default = []
 mbed-crypto-provider = ["psa-crypto"]
 pkcs11-provider = ["pkcs11", "picky-asn1-der", "picky-asn1", "picky-asn1-x509", "psa-crypto", "rand"]
 tpm-provider = ["tss-esapi", "picky-asn1-der", "picky-asn1", "picky-asn1-x509", "hex"]
-all-providers = ["tpm-provider", "pkcs11-provider", "mbed-crypto-provider"]
+cryptoauthlib-provider = []
+all-providers = ["tpm-provider", "pkcs11-provider", "mbed-crypto-provider", "cryptoauthlib-provider"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs.git"}
+parsec-interface = "0.22.0"
 rand = { version = "0.7.3", features = ["small_rng"], optional = true }
 base64 = "0.12.3"
 uuid = "0.8.1"
@@ -38,7 +38,7 @@ structopt = "0.3.17"
 derivative = "2.1.1"
 version = "3.0.0"
 hex = { version = "0.4.2", optional = true }
-psa-crypto = { git = "https://github.com/parallaxsecond/rust-psa-crypto", rev = "18dd4dda96d8b61d2e112b9e6ad83e90fe768d78", default-features = false, features = ["operations"], optional = true}
+psa-crypto = { version = "0.6.1", default-features = false, features = ["operations"], optional = true }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 picky-asn1-x509 = { version = "0.3.2", optional = true }
 users = "0.10.0"

--- a/config.toml
+++ b/config.toml
@@ -131,3 +131,7 @@ key_info_manager = "on-disk-manager"
 # e.g. "str:password", or to represent a string version of a hex value, e.g. "hex:1a2b3c". If no prefix is
 # provided, the value is considered to be a string.
 #owner_hierarchy_auth = "password"
+
+[[provider]]
+provider_type = "CryptoAuthLib"
+key_info_manager = "on-disk-manager"

--- a/config.toml
+++ b/config.toml
@@ -132,6 +132,25 @@ key_info_manager = "on-disk-manager"
 # provided, the value is considered to be a string.
 #owner_hierarchy_auth = "password"
 
-[[provider]]
-provider_type = "CryptoAuthLib"
-key_info_manager = "on-disk-manager"
+# Example of a CryptoAuthLib provider configuration
+# All below parameters depend on what devices, interfaces or parameters are required or supported by 
+# "rust-cryptoauthlib" wrapper for cryptoauthlib and underlying hardware.
+#[[provider]]
+#provider_type = "CryptoAuthLib"
+#key_info_manager = "on-disk-manager"
+# (Required) ATCA device type.
+#   Supported values: "atecc508a", "atecc608a"
+#device_type = "atecc508a"
+# (Required) Interface for ATCA device
+#   Supported values: "i2c"
+#iface_type = "i2c"
+# (Required) Default wake delay for ATCA device
+#wake_delay = 1500
+# (Required) Default number of rx retries for ATCA device
+#rx_retries = 20
+# (Optional - required for i2c) i2c slave addres
+#slave_address = 0xc0
+# (Optional - required for i2c) i2c bus number
+#bus = 1
+# (Optional - required for i2c) i2c bus baud rate
+#baud = 400000

--- a/config.toml
+++ b/config.toml
@@ -138,19 +138,3 @@ key_info_manager = "on-disk-manager"
 #[[provider]]
 #provider_type = "CryptoAuthLib"
 #key_info_manager = "on-disk-manager"
-# (Required) ATCA device type.
-#   Supported values: "atecc508a", "atecc608a"
-#device_type = "atecc508a"
-# (Required) Interface for ATCA device
-#   Supported values: "i2c"
-#iface_type = "i2c"
-# (Required) Default wake delay for ATCA device
-#wake_delay = 1500
-# (Required) Default number of rx retries for ATCA device
-#rx_retries = 20
-# (Optional - required for i2c) i2c slave addres
-#slave_address = 0xc0
-# (Optional - required for i2c) i2c bus number
-#bus = 1
-# (Optional - required for i2c) i2c bus baud rate
-#baud = 400000

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -33,4 +33,5 @@ sha2 = "0.9.1"
 mbed-crypto-provider = []
 tpm-provider = []
 pkcs11-provider = []
-all-providers = ["pkcs11-provider","tpm-provider","mbed-crypto-provider"]
+cryptoauthlib-provider = []
+all-providers = ["pkcs11-provider","tpm-provider","mbed-crypto-provider","cryptoauthlib-provider"]

--- a/e2e_tests/provider_cfg/cryptoauthlib/Dockerfile
+++ b/e2e_tests/provider_cfg/cryptoauthlib/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+
+ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
+
+RUN apt-get update && \
+	apt-get install -y git make gcc python3 python curl wget cmake && \
+	apt-get install -y automake autoconf libtool pkg-config libssl-dev && \
+	# These libraries are needed for bindgen as it uses libclang.so
+	apt-get install -y clang libclang-dev libc6-dev-i386 && \
+	# Install cargo globally to not have to install it for each user for multitenancy tests
+	apt-get install -y cargo
+
+# Add users for multitenancy tests
+RUN useradd -m parsec-client-1
+RUN useradd -m parsec-client-2

--- a/e2e_tests/provider_cfg/cryptoauthlib/config.toml
+++ b/e2e_tests/provider_cfg/cryptoauthlib/config.toml
@@ -14,30 +14,11 @@ socket_path = "/tmp/parsec.sock"
 
 [authenticator]
 auth_type = "Direct"
-#workload_endpoint="unix:///tmp/agent.sock"
 
 [[key_manager]]
 name = "on-disk-manager"
 manager_type = "OnDisk"
 store_path = "./mappings"
-
-[[provider]]
-provider_type = "MbedCrypto"
-key_info_manager = "on-disk-manager"
-
-[[provider]]
-provider_type = "Tpm"
-key_info_manager = "on-disk-manager"
-tcti = "mssim"
-owner_hierarchy_auth = "tpm_pass"
-
-[[provider]]
-provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
-library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
-user_pin = "123456"
-# The slot_number mandatory field is going to replace the following line with a valid number
-# slot_number
 
 [[provider]]
 provider_type = "CryptoAuthLib"

--- a/e2e_tests/tests/all_providers/config/mod.rs
+++ b/e2e_tests/tests/all_providers/config/mod.rs
@@ -55,8 +55,8 @@ fn list_providers() {
             Uuid::parse_str("1c1139dc-ad7c-47dc-ad6b-db6fdb466552").unwrap(), // Mbed crypto provider
             Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap(), // Tpm provider
             Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap(), // Pkcs11 provider
-            Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
             Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap(), // CryptoAuthLib provider
+            Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
         ]
     );
 
@@ -71,8 +71,8 @@ fn list_providers() {
             Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap(), // Pkcs11 provider
             Uuid::parse_str("1c1139dc-ad7c-47dc-ad6b-db6fdb466552").unwrap(), // Mbed crypto provider
             Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap(), // Tpm provider
-            Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
             Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap(), // CryptoAuthLib provider
+            Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
         ]
     );
 }

--- a/e2e_tests/tests/all_providers/config/mod.rs
+++ b/e2e_tests/tests/all_providers/config/mod.rs
@@ -56,6 +56,7 @@ fn list_providers() {
             Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap(), // Tpm provider
             Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap(), // Pkcs11 provider
             Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
+            Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap(), // CryptoAuthLib provider
         ]
     );
 
@@ -71,6 +72,7 @@ fn list_providers() {
             Uuid::parse_str("1c1139dc-ad7c-47dc-ad6b-db6fdb466552").unwrap(), // Mbed crypto provider
             Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap(), // Tpm provider
             Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
+            Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap(), // CryptoAuthLib provider
         ]
     );
 }

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
@@ -33,3 +33,7 @@ library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
 # slot_number
+
+[[provider]]
+provider_type = "CryptoAuthLib"
+key_info_manager = "on-disk-manager"

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
@@ -33,3 +33,7 @@ provider_type = "Tpm"
 key_info_manager = "on-disk-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "tpm_pass"
+
+[[provider]]
+provider_type = "CryptoAuthLib"
+key_info_manager = "on-disk-manager"

--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 fn list_providers() {
     let mut client = TestClient::new();
     let providers = client.list_providers().expect("list providers failed");
-    assert_eq!(providers.len(), 4);
+    assert_eq!(providers.len(), 5);
     let uuids: HashSet<Uuid> = providers.iter().map(|p| p.uuid).collect();
     // Core provider
     assert!(uuids.contains(&Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap()));
@@ -19,6 +19,8 @@ fn list_providers() {
     assert!(uuids.contains(&Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap()));
     // TPM provider
     assert!(uuids.contains(&Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap()));
+    // CryptoAuthLib provider
+    assert!(uuids.contains(&Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap()));
 }
 
 #[test]
@@ -38,6 +40,7 @@ fn list_opcodes() {
     let mut client = TestClient::new();
     let mut crypto_providers_hsm = HashSet::new();
     let mut core_provider_opcodes = HashSet::new();
+    let mut crypto_providers_cal = HashSet::new();
 
     let _ = crypto_providers_hsm.insert(Opcode::PsaGenerateKey);
     let _ = crypto_providers_hsm.insert(Opcode::PsaDestroyKey);
@@ -88,6 +91,12 @@ fn list_opcodes() {
             .list_opcodes(ProviderID::MbedCrypto)
             .expect("list providers failed"),
         crypto_providers_mbed_crypto
+    );
+    assert_eq!(
+        client
+            .list_opcodes(ProviderID::CryptoAuthLib)
+            .expect("list providers failed"),
+            crypto_providers_cal
     );
 }
 

--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -40,7 +40,6 @@ fn list_opcodes() {
     let mut client = TestClient::new();
     let mut crypto_providers_hsm = HashSet::new();
     let mut core_provider_opcodes = HashSet::new();
-    let mut crypto_providers_cal = HashSet::new();
 
     let _ = crypto_providers_hsm.insert(Opcode::PsaGenerateKey);
     let _ = crypto_providers_hsm.insert(Opcode::PsaDestroyKey);
@@ -91,12 +90,6 @@ fn list_opcodes() {
             .list_opcodes(ProviderID::MbedCrypto)
             .expect("list providers failed"),
         crypto_providers_mbed_crypto
-    );
-    assert_eq!(
-        client
-            .list_opcodes(ProviderID::CryptoAuthLib)
-            .expect("list providers failed"),
-            crypto_providers_cal
     );
 }
 
@@ -150,7 +143,7 @@ fn list_keys() {
         .collect();
 
     assert_eq!(key_names.len(), 3);
-    assert!(key_names.contains(&(key1.clone(),ProviderID::MbedCrypto)));
-    assert!(key_names.contains(&(key2.clone(),ProviderID::Pkcs11)));
-    assert!(key_names.contains(&(key3.clone(),ProviderID::Tpm)));
+    assert!(key_names.contains(&(key1.clone(), ProviderID::MbedCrypto)));
+    assert!(key_names.contains(&(key2.clone(), ProviderID::Pkcs11)));
+    assert!(key_names.contains(&(key3.clone(), ProviderID::Tpm)));
 }

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -1,0 +1,89 @@
+// Copyright 2019 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! Microchip CryptoAuthentication Library provider
+//!
+//! This provider is a hardware based implementation of PSA Crypto, Mbed Crypto.
+use super::Provide;
+use crate::key_info_managers::ManageKeyInfo;
+use derivative::Derivative;
+use log::trace;
+use std::collections::HashSet;
+use std::io::{Error, ErrorKind};
+use std::sync::{Arc, RwLock};
+use uuid::Uuid;
+
+use parsec_interface::operations::list_providers::ProviderInfo;
+use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
+
+const SUPPORTED_OPCODES: [Opcode; 0] = [];
+
+/// CryptoAuthLib provider structure
+#[derive(Derivative)]
+#[derivative(Debug, Clone, Copy)]
+pub struct Provider {
+    // device: rust_cryptoauthlib::AtcaDevice,
+}
+
+impl Provider {
+    /// Creates and initialise a new instance of CryptoAuthLibProvider
+    fn new(_key_info_store: Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>) -> Option<Provider> {
+        Some(Provider {})
+    }
+}
+
+impl Provide for Provider {
+    fn describe(&self) -> Result<(ProviderInfo, HashSet<Opcode>)> {
+        trace!("describe ingress");
+        Ok((ProviderInfo {
+            // Assigned UUID for this provider: b8ba81e2-e9f7-4bdd-b096-a29d0019960c
+            uuid: Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").or(Err(ResponseStatus::InvalidEncoding))?,
+            description: String::from("User space hardware provider, utilizing MicrochipTech CryptoAuthentication Library for ATECCx08 chips"),
+            vendor: String::from("Arm"),
+            version_maj: 0,
+            version_min: 1,
+            version_rev: 0,
+            id: ProviderID::CryptoAuthLib,
+        }, SUPPORTED_OPCODES.iter().copied().collect()))
+    }
+}
+
+/// CryptoAuthentication Library Provider builder
+#[derive(Default, Derivative)]
+#[derivative(Debug)]
+pub struct ProviderBuilder {
+    #[derivative(Debug = "ignore")]
+    key_info_store: Option<Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>>,
+}
+
+impl ProviderBuilder {
+    /// Create a new CryptoAuthLib builder
+    pub fn new() -> ProviderBuilder {
+        ProviderBuilder {
+            key_info_store: None,
+        }
+    }
+
+    /// Add a KeyInfo manager
+    pub fn with_key_info_store(
+        mut self,
+        key_info_store: Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>,
+    ) -> ProviderBuilder {
+        self.key_info_store = Some(key_info_store);
+
+        self
+    }
+
+    /// Attempt to build CryptoAuthLib Provider
+    pub fn build(self) -> std::io::Result<Provider> {
+        Provider::new(
+            self.key_info_store
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "missing key info store"))?,
+        )
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                "CryptoAuthLib Provider initialization failed",
+            )
+        })
+    }
+}

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -4,16 +4,18 @@
 //!
 //! This provider is a hardware based implementation of PSA Crypto, Mbed Crypto.
 use super::Provide;
+use crate::authenticators::ApplicationName;
 use crate::key_info_managers::ManageKeyInfo;
 use derivative::Derivative;
 use log::trace;
+use parsec_interface::operations::list_keys;
+use parsec_interface::operations::list_keys::KeyInfo;
+use parsec_interface::operations::list_providers::ProviderInfo;
+use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
-
-use parsec_interface::operations::list_providers::ProviderInfo;
-use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 
 const SUPPORTED_OPCODES: [Opcode; 0] = [];
 
@@ -44,6 +46,17 @@ impl Provide for Provider {
             version_rev: 0,
             id: ProviderID::CryptoAuthLib,
         }, SUPPORTED_OPCODES.iter().copied().collect()))
+    }
+
+    fn list_keys(
+        &self,
+        _app_name: ApplicationName,
+        _op: list_keys::Operation,
+    ) -> Result<list_keys::Result> {
+        trace!("list_keys ingress");
+        let keys: Vec<KeyInfo> = Vec::new();
+
+        Ok(list_keys::Result { keys })
     }
 }
 

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Contributors to the Parsec project.
+// Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! Microchip CryptoAuthentication Library provider
 //!

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -23,6 +23,9 @@ pub mod mbed_crypto;
 #[cfg(feature = "tpm-provider")]
 pub mod tpm;
 
+#[cfg(feature = "cryptoauthlib-provider")]
+pub mod cryptoauthlib;
+
 /// Provider configuration structure
 /// For providers configs in Parsec config.toml we use a format similar
 /// to the one described in the Internally Tagged Enum representation
@@ -59,6 +62,11 @@ pub enum ProviderConfig {
         /// Owner Hierarchy Authentication
         owner_hierarchy_auth: String,
     },
+    /// Microchip CryptoAuthentication Library provider configuration
+    CryptoAuthLib {
+        /// Name of the Key Info Manager to use
+        key_info_manager: String,
+    },
 }
 
 impl ProviderConfig {
@@ -77,6 +85,10 @@ impl ProviderConfig {
                 ref key_info_manager,
                 ..
             } => key_info_manager,
+            ProviderConfig::CryptoAuthLib {
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
         }
     }
     /// Get the Provider ID of the provider
@@ -85,6 +97,7 @@ impl ProviderConfig {
             ProviderConfig::MbedCrypto { .. } => ProviderID::MbedCrypto,
             ProviderConfig::Pkcs11 { .. } => ProviderID::Pkcs11,
             ProviderConfig::Tpm { .. } => ProviderID::Tpm,
+            ProviderConfig::CryptoAuthLib { .. } => ProviderID::CryptoAuthLib,
         }
     }
 }


### PR DESCRIPTION
Definition of new structures and their interfaces.
## Known issues
### Version mismatch of psa-crypto
There is a version mismatch in a dependent library (psa-crypto) between parsec-interface and parsec on appropriate master/HEAD versions:
- parsec-interface depends on git https://github.com/parallaxsecond/rust-psa-crypto#rev18dd4dda96d8b61d2e112b9e6ad83e90fe768d78
- parsec depends on depends on official version 6.0.0 from crates.io

The solution is to

- assign a new version to psa-crypto (git/hash) as discussed elsewhere
- update the package meta-data on crates.io
- use this new version in both parsec-interface and parsec

As a workaround this PR modifies parsec/Cargo.toml to have the same psa-crypto as a parsec-interface.

### Wrong parsec-interface version number being used
The parsec-interface extension (add an CryptoAuthLib entry to providers' enumeration) was not followed by package version increase nor the package meta-data on crates.io was updated. This PR addressed an issue with parsec-interface version for parsec compilation purposes but there are still issues with e2e-tests.
#### Issues with e2e-tests
The e2e-tests depend on parsec-client that depends on parsec-interface and it is affected by the previously mentioned versioning issues. 
 
Summary TODO points 
- [x] assign a new version to psa-crypto and update crate's meta-data on crates.io
- [x] update both parsec and parsec-interface to use this new psa-crypto version
- [x] assign a new version to parsec-interface and update its metadata on crates.io
- [x] update parsec and parsec-client to use this new parsec-interface

Signed-off-by: Robert Drazkowski <Robert.Drazkowski@globallogic.com>