### PR TITLE
Add admin configuration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,6 +64,16 @@ timeout = 200 # in milliseconds
 # https://parallaxsecond.github.io/parsec-book/parsec_security/secure_deployment.html
 auth_type = "UnixPeerCredentials"
 
+# List of admins to be identified by the authenticator.
+# The "name" field of each entry in the list must contain the application name (as required by the
+# identifier in `auth_type`). For example, for `UnixPeerCredentials`, the names should be UIDs of
+# the admin users.
+# WARNING: Admins have special privileges and access to operations that are not permitted for normal
+# users of the service. Only enable this feature with some list of admins if you are confident
+# about the need for those permissions.
+# Read more here: https://parallaxsecond.github.io/parsec-book/parsec_client/operations/index.html#core-operations
+#admins = [ { name = "admin_1" }, { name = "admin_2" } ]
+
 # (Required only for JwtSvid) Location of the Workload API endpoint
 # WARNING: only use this authenticator if the Workload API socket is TRUSTED. A malicious entity
 # owning that socket would have access to all the keys owned by clients using this authentication

--- a/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
@@ -289,7 +289,7 @@ fn fail_verify_hash() -> Result<()> {
 
     let mut signature = client.sign_with_rsa_sha256(key_name.clone(), hash.clone())?;
     // Modify signature
-    signature[4] += 1;
+    signature[4] ^= 1;
     let status = client
         .verify_with_rsa_sha256(key_name, hash, signature)
         .unwrap_err();

--- a/src/authenticators/unix_peer_credentials_authenticator/mod.rs
+++ b/src/authenticators/unix_peer_credentials_authenticator/mod.rs
@@ -9,8 +9,7 @@
 //!
 //! Currently, the stringified UID is used as the application name.
 
-use super::ApplicationName;
-use super::Authenticate;
+use super::{Admin, AdminList, ApplicationName, Authenticate};
 use crate::front::listener::ConnectionMetadata;
 use log::error;
 use parsec_interface::operations::list_authenticators;
@@ -21,8 +20,19 @@ use parsec_interface::secrecy::ExposeSecret;
 use std::convert::TryInto;
 
 /// Unix peer credentials authenticator.
-#[derive(Copy, Clone, Debug)]
-pub struct UnixPeerCredentialsAuthenticator;
+#[derive(Clone, Debug)]
+pub struct UnixPeerCredentialsAuthenticator {
+    admins: AdminList,
+}
+
+impl UnixPeerCredentialsAuthenticator {
+    /// Create new Unix peer credentials authenticator
+    pub fn new(admins: Vec<Admin>) -> Self {
+        UnixPeerCredentialsAuthenticator {
+            admins: admins.into(),
+        }
+    }
+}
 
 impl Authenticate for UnixPeerCredentialsAuthenticator {
     fn describe(&self) -> Result<list_authenticators::AuthenticatorInfo> {
@@ -76,7 +86,9 @@ impl Authenticate for UnixPeerCredentialsAuthenticator {
         // Authentication is successful if the _actual_ UID from the Unix peer credentials equals
         // the self-declared UID in the authentication request.
         if uid == expected_uid {
-            Ok(ApplicationName(uid.to_string()))
+            let app_name = uid.to_string();
+            let is_admin = self.admins.is_admin(&app_name);
+            Ok(ApplicationName::new(app_name, is_admin))
         } else {
             error!("Declared UID in authentication request does not match the process's UID.");
             Err(ResponseStatus::AuthenticationError)
@@ -86,7 +98,7 @@ impl Authenticate for UnixPeerCredentialsAuthenticator {
 
 #[cfg(test)]
 mod test {
-    use super::super::Authenticate;
+    use super::super::{Admin, Authenticate};
     use super::UnixPeerCredentialsAuthenticator;
     use crate::front::domain_socket::peer_credentials;
     use crate::front::listener::ConnectionMetadata;
@@ -108,7 +120,9 @@ mod test {
             peer_credentials::peer_cred(&_sock_b).unwrap(),
         );
 
-        let authenticator = UnixPeerCredentialsAuthenticator {};
+        let authenticator = UnixPeerCredentialsAuthenticator {
+            admins: Default::default(),
+        };
 
         let req_auth_data = cred_a.uid.to_le_bytes().to_vec();
         let req_auth = RequestAuth::new(req_auth_data);
@@ -123,6 +137,7 @@ mod test {
             .expect("Failed to authenticate");
 
         assert_eq!(auth_name.get_name(), get_current_uid().to_string());
+        assert_eq!(auth_name.is_admin, false);
     }
 
     #[test]
@@ -137,7 +152,9 @@ mod test {
             peer_credentials::peer_cred(&_sock_b).unwrap(),
         );
 
-        let authenticator = UnixPeerCredentialsAuthenticator {};
+        let authenticator = UnixPeerCredentialsAuthenticator {
+            admins: Default::default(),
+        };
 
         let wrong_uid = cred_a.uid + 1;
         let wrong_req_auth_data = wrong_uid.to_le_bytes().to_vec();
@@ -163,7 +180,9 @@ mod test {
             peer_credentials::peer_cred(&_sock_b).unwrap(),
         );
 
-        let authenticator = UnixPeerCredentialsAuthenticator {};
+        let authenticator = UnixPeerCredentialsAuthenticator {
+            admins: Default::default(),
+        };
 
         let garbage_data = rand::thread_rng().gen::<[u8; 32]>().to_vec();
         let req_auth = RequestAuth::new(garbage_data);
@@ -179,12 +198,46 @@ mod test {
 
     #[test]
     fn unsuccessful_authentication_no_metadata() {
-        let authenticator = UnixPeerCredentialsAuthenticator {};
+        let authenticator = UnixPeerCredentialsAuthenticator {
+            admins: Default::default(),
+        };
         let req_auth = RequestAuth::new("secret".into());
 
         let conn_metadata = None;
         let auth_result = authenticator.authenticate(&req_auth, conn_metadata);
         assert_eq!(auth_result, Err(ResponseStatus::AuthenticationError));
+    }
+
+    #[test]
+    fn admin_check() {
+        // Create two connected sockets.
+        let (sock_a, _sock_b) = UnixStream::pair().unwrap();
+        let (cred_a, _cred_b) = (
+            peer_credentials::peer_cred(&sock_a).unwrap(),
+            peer_credentials::peer_cred(&_sock_b).unwrap(),
+        );
+
+        let authenticator = UnixPeerCredentialsAuthenticator {
+            admins: vec![Admin {
+                name: get_current_uid().to_string(),
+            }]
+            .into(),
+        };
+
+        let req_auth_data = cred_a.uid.to_le_bytes().to_vec();
+        let req_auth = RequestAuth::new(req_auth_data);
+        let conn_metadata = Some(ConnectionMetadata::UnixPeerCredentials {
+            uid: cred_a.uid,
+            gid: cred_a.gid,
+            pid: None,
+        });
+
+        let auth_name = authenticator
+            .authenticate(&req_auth, conn_metadata)
+            .expect("Failed to authenticate");
+
+        assert_eq!(auth_name.get_name(), get_current_uid().to_string());
+        assert_eq!(auth_name.is_admin, true);
     }
 
     #[test]

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -75,7 +75,7 @@ fn base64_data_triple_to_key_triple(
     provider_id: ProviderID,
     key_name: &[u8],
 ) -> Result<KeyTriple, String> {
-    let app_name = ApplicationName::new(base64_data_to_string(app_name)?);
+    let app_name = ApplicationName::from_name(base64_data_to_string(app_name)?);
     let key_name = base64_data_to_string(key_name)?;
 
     Ok(KeyTriple {
@@ -531,7 +531,7 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/big_names_ascii_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
 
-        let big_app_name_ascii = ApplicationName::new("  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string());
+        let big_app_name_ascii = ApplicationName::from_name("  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string());
         let big_key_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
 
         let key_triple = KeyTriple::new(big_app_name_ascii, ProviderID::Core, big_key_name_ascii);
@@ -549,7 +549,7 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/big_names_emoticons_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
 
-        let big_app_name_emoticons = ApplicationName::new("😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮".to_string());
+        let big_app_name_emoticons = ApplicationName::from_name("😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮".to_string());
         let big_key_name_emoticons = "😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮".to_string();
 
         let key_triple = KeyTriple::new(
@@ -570,12 +570,12 @@ mod test {
     fn create_and_load() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/create_and_load_mappings");
 
-        let app_name1 = ApplicationName::new("😀 Application One 😀".to_string());
+        let app_name1 = ApplicationName::from_name("😀 Application One 😀".to_string());
         let key_name1 = "😀 Key One 😀".to_string();
         let key_triple1 = KeyTriple::new(app_name1, ProviderID::Core, key_name1);
         let key_info1 = test_key_info();
 
-        let app_name2 = ApplicationName::new("😇 Application Two 😇".to_string());
+        let app_name2 = ApplicationName::from_name("😇 Application Two 😇".to_string());
         let key_name2 = "😇 Key Two 😇".to_string();
         let key_triple2 = KeyTriple::new(app_name2, ProviderID::MbedCrypto, key_name2);
         let key_info2 = KeyInfo {
@@ -583,7 +583,7 @@ mod test {
             attributes: test_key_attributes(),
         };
 
-        let app_name3 = ApplicationName::new("😈 Application Three 😈".to_string());
+        let app_name3 = ApplicationName::from_name("😈 Application Three 😈".to_string());
         let key_name3 = "😈 Key Three 😈".to_string();
         let key_triple3 = KeyTriple::new(app_name3, ProviderID::Core, key_name3);
         let key_info3 = KeyInfo {
@@ -617,7 +617,7 @@ mod test {
 
     fn new_key_triple(key_name: String) -> KeyTriple {
         KeyTriple::new(
-            ApplicationName::new("Testing Application 😎".to_string()),
+            ApplicationName::from_name("Testing Application 😎".to_string()),
             ProviderID::MbedCrypto,
             key_name,
         )

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -398,16 +398,27 @@ fn build_authenticators(config: &AuthenticatorConfig) -> Vec<(AuthType, Authenti
     let mut authenticators: Vec<(AuthType, Authenticator)> = Vec::new();
 
     match config {
-        AuthenticatorConfig::Direct => {
-            authenticators.push((AuthType::Direct, Box::from(DirectAuthenticator {})))
-        }
-        AuthenticatorConfig::UnixPeerCredentials => authenticators.push((
-            AuthType::UnixPeerCredentials,
-            Box::from(UnixPeerCredentialsAuthenticator {}),
+        AuthenticatorConfig::Direct { admins } => authenticators.push((
+            AuthType::Direct,
+            Box::from(DirectAuthenticator::new(
+                admins.as_ref().cloned().unwrap_or_default(),
+            )),
         )),
-        AuthenticatorConfig::JwtSvid { workload_endpoint } => authenticators.push((
+        AuthenticatorConfig::UnixPeerCredentials { admins } => authenticators.push((
+            AuthType::UnixPeerCredentials,
+            Box::from(UnixPeerCredentialsAuthenticator::new(
+                admins.as_ref().cloned().unwrap_or_default(),
+            )),
+        )),
+        AuthenticatorConfig::JwtSvid {
+            workload_endpoint,
+            admins,
+        } => authenticators.push((
             AuthType::JwtSvid,
-            Box::from(JwtSvidAuthenticator::new(workload_endpoint.to_string())),
+            Box::from(JwtSvidAuthenticator::new(
+                workload_endpoint.to_string(),
+                admins.as_ref().cloned().unwrap_or_default(),
+            )),
         )),
     };
 


### PR DESCRIPTION
This commit adds support for authenticators to identify admin
applications. The admin app names can be configured from the config.toml
file and lead to the ApplicationName having a flag set indicating
whether the app is an admin or not.

Fixes #308 