### PR TITLE
Added support for PsaHashCompute to CryptoAuthLib provider.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,8 @@ dependencies = [
 [[package]]
 name = "cryptoauthlib-sys"
 version = "0.1.0"
-source = "git+https://github.com/RobertDrazkowskiGL/rust-cryptoauthlib.git#bda56f3651c13d6816e6446d1235ce08ee47a91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95690a04d479e3253e706abae479fa45cb5d638c1ba158fb0717a379aa4e152e"
 dependencies = [
  "cmake",
 ]
@@ -1461,7 +1462,8 @@ dependencies = [
 [[package]]
 name = "rust-cryptoauthlib"
 version = "0.1.0"
-source = "git+https://github.com/RobertDrazkowskiGL/rust-cryptoauthlib.git#bda56f3651c13d6816e6446d1235ce08ee47a91b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0df6ceab23eaa85ae6352d14e17ddcfaaa1232e1e474826eee4f50f30b26661"
 dependencies = [
  "cryptoauthlib-sys",
  "strum_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cryptoauthlib-sys"
+version = "0.1.0"
+source = "git+https://github.com/RobertDrazkowskiGL/rust-cryptoauthlib.git#bda56f3651c13d6816e6446d1235ce08ee47a91b"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "derivative"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1057,7 @@ dependencies = [
  "pkcs11",
  "psa-crypto",
  "rand 0.8.2",
+ "rust-cryptoauthlib",
  "sd-notify",
  "serde",
  "signal-hook",
@@ -1450,6 +1459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-cryptoauthlib"
+version = "0.1.0"
+source = "git+https://github.com/RobertDrazkowskiGL/rust-cryptoauthlib.git#bda56f3651c13d6816e6446d1235ce08ee47a91b"
+dependencies = [
+ "cryptoauthlib-sys",
+ "strum_macros",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1659,18 @@ checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
+dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ libc = "0.2.77"
 anyhow = "1.0.32"
 # Using a fork until the JWT support is merged into the main rust-spiffe repository
 spiffe = { git = "https://github.com/hug-dev/rust-spiffe", branch = "refactor-jwt" }
+rust-cryptoauthlib = { git = "https://github.com/RobertDrazkowskiGL/rust-cryptoauthlib.git", optional = true }
 
 [dev-dependencies]
 rand = { version = "0.8.2", features = ["small_rng"] }
@@ -58,5 +59,5 @@ default = []
 mbed-crypto-provider = ["psa-crypto"]
 pkcs11-provider = ["pkcs11", "picky-asn1-der", "picky-asn1", "picky-asn1-x509", "psa-crypto", "rand"]
 tpm-provider = ["tss-esapi", "picky-asn1-der", "picky-asn1", "picky-asn1-x509", "hex"]
-cryptoauthlib-provider = []
+cryptoauthlib-provider = ["rust-cryptoauthlib"]
 all-providers = ["tpm-provider", "pkcs11-provider", "mbed-crypto-provider", "cryptoauthlib-provider"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ libc = "0.2.77"
 anyhow = "1.0.32"
 # Using a fork until the JWT support is merged into the main rust-spiffe repository
 spiffe = { git = "https://github.com/hug-dev/rust-spiffe", branch = "refactor-jwt" }
-rust-cryptoauthlib = { git = "https://github.com/RobertDrazkowskiGL/rust-cryptoauthlib.git", optional = true }
+#rust-cryptoauthlib = { git = "https://github.com/RobertDrazkowskiGL/rust-cryptoauthlib.git", optional = true }
+rust-cryptoauthlib = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 rand = { version = "0.8.2", features = ["small_rng"] }

--- a/config.toml
+++ b/config.toml
@@ -143,8 +143,24 @@ key_info_manager = "on-disk-manager"
 #owner_hierarchy_auth = "password"
 
 # Example of a CryptoAuthLib provider configuration
-# All below parameters depend on what devices, interfaces or parameters are required or supported by 
+# All below parameters depend on what devices, interfaces or parameters are required or supported by
 # "rust-cryptoauthlib" wrapper for cryptoauthlib and underlying hardware.
 #[[provider]]
 #provider_type = "CryptoAuthLib"
 #key_info_manager = "on-disk-manager"
+# (Required) ATCA device type.
+#   Supported values: "atecc508a", "atecc608a"
+#device_type = "atecc508a"
+# (Required) Interface for ATCA device
+#   Supported values: "i2c"
+#iface_type = "i2c"
+# (Required) Default wake delay for ATCA device
+#wake_delay = 1500
+# (Required) Default number of rx retries for ATCA device
+#rx_retries = 20
+# (Optional - required for i2c) i2c slave addres
+#slave_address = 0xc0
+# (Optional - required for i2c) i2c bus number
+#bus = 1
+# (Optional - required for i2c) i2c bus baud rate
+#baud = 400000

--- a/e2e_tests/provider_cfg/all/config.toml
+++ b/e2e_tests/provider_cfg/all/config.toml
@@ -43,3 +43,11 @@ user_pin = "123456"
 [[provider]]
 provider_type = "CryptoAuthLib"
 key_info_manager = "on-disk-manager"
+device_type = "atecc508a"
+iface_type = "i2c"
+wake_delay = 1500
+rx_retries = 20
+# i2c parameters for i2c-pseudo proxy
+slave_address = 0xc0
+bus = 1
+baud = 400000

--- a/e2e_tests/provider_cfg/cryptoauthlib/config.toml
+++ b/e2e_tests/provider_cfg/cryptoauthlib/config.toml
@@ -23,3 +23,11 @@ store_path = "./mappings"
 [[provider]]
 provider_type = "CryptoAuthLib"
 key_info_manager = "on-disk-manager"
+device_type = "atecc508a"
+iface_type = "i2c"
+wake_delay = 1500
+rx_retries = 20
+# i2c parameters for i2c-pseudo proxy
+slave_address = 0xc0
+bus = 1
+baud = 400000

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
@@ -37,3 +37,11 @@ user_pin = "123456"
 [[provider]]
 provider_type = "CryptoAuthLib"
 key_info_manager = "on-disk-manager"
+device_type = "atecc508a"
+iface_type = "i2c"
+wake_delay = 1500
+rx_retries = 20
+# i2c parameters for i2c-pseudo proxy
+slave_address = 0xc0
+bus = 1
+baud = 400000

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
@@ -37,3 +37,11 @@ owner_hierarchy_auth = "tpm_pass"
 [[provider]]
 provider_type = "CryptoAuthLib"
 key_info_manager = "on-disk-manager"
+device_type = "atecc508a"
+iface_type = "i2c"
+wake_delay = 1500
+rx_retries = 20
+# i2c parameters for i2c-pseudo proxy
+slave_address = 0xc0
+bus = 1
+baud = 400000

--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -44,6 +44,7 @@ fn list_opcodes() {
     let mut client = TestClient::new();
     let mut crypto_providers_hsm = HashSet::new();
     let mut core_provider_opcodes = HashSet::new();
+    let mut crypto_providers_cal = HashSet::new();
 
     let _ = crypto_providers_hsm.insert(Opcode::PsaGenerateKey);
     let _ = crypto_providers_hsm.insert(Opcode::PsaDestroyKey);
@@ -71,6 +72,9 @@ fn list_opcodes() {
     let _ = core_provider_opcodes.insert(Opcode::ListOpcodes);
     let _ = core_provider_opcodes.insert(Opcode::ListKeys);
 
+    // Not that much to be tested ATM
+    let _ = crypto_providers_cal.insert(Opcode::PsaHashCompute);
+
     assert_eq!(
         client
             .list_opcodes(ProviderID::Core)
@@ -94,6 +98,12 @@ fn list_opcodes() {
             .list_opcodes(ProviderID::MbedCrypto)
             .expect("list providers failed"),
         crypto_providers_mbed_crypto
+    );
+    assert_eq!(
+        client
+            .list_opcodes(ProviderID::CryptoAuthLib)
+            .expect("list providers failed"),
+            crypto_providers_cal
     );
 }
 

--- a/src/providers/cryptoauthlib/hash.rs
+++ b/src/providers/cryptoauthlib/hash.rs
@@ -1,0 +1,33 @@
+// Copyright 2020 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::Provider;
+use parsec_interface::operations::psa_algorithm::Hash;
+use parsec_interface::operations::psa_hash_compute;
+use parsec_interface::requests::{ResponseStatus, Result};
+
+impl Provider {
+    pub(super) fn psa_hash_compute_internal(
+        &self,
+        op: psa_hash_compute::Operation,
+    ) -> Result<psa_hash_compute::Result> {
+        let mut hash = vec![0u8; op.alg.hash_length()];
+        let message = op.input.to_vec();
+        match op.alg {
+            Hash::Sha256 => match rust_cryptoauthlib::atcab_sha(message, &mut hash) {
+                rust_cryptoauthlib::AtcaStatus::AtcaSuccess => {
+                    Ok(psa_hash_compute::Result { hash: hash.into() })
+                }
+                err => {
+                    let error = ResponseStatus::PsaErrorGenericError;
+                    format_error!("Hash computation failed ", err);
+                    Err(error)
+                }
+            },
+            _ => {
+                let error = ResponseStatus::PsaErrorNotSupported;
+                format_error!("Unsupported hash algorithm ", error);
+                Err(error)
+            }
+        }
+    }
+}

--- a/src/providers/cryptoauthlib/hash.rs
+++ b/src/providers/cryptoauthlib/hash.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Contributors to the Parsec project.
+// Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
 use parsec_interface::operations::psa_algorithm::Hash;
@@ -11,18 +11,21 @@ impl Provider {
         op: psa_hash_compute::Operation,
     ) -> Result<psa_hash_compute::Result> {
         let mut hash = vec![0u8; op.alg.hash_length()];
-        let message = op.input.to_vec();
         match op.alg {
-            Hash::Sha256 => match rust_cryptoauthlib::atcab_sha(message, &mut hash) {
-                rust_cryptoauthlib::AtcaStatus::AtcaSuccess => {
-                    Ok(psa_hash_compute::Result { hash: hash.into() })
+            Hash::Sha256 => {
+                let message = op.input.to_vec();
+                let err = rust_cryptoauthlib::atcab_sha(message, &mut hash);
+                match err {
+                    rust_cryptoauthlib::AtcaStatus::AtcaSuccess => {
+                        Ok(psa_hash_compute::Result { hash: hash.into() })
+                    }
+                    _ => {
+                        let error = ResponseStatus::PsaErrorGenericError;
+                        format_error!("Hash computation failed ", err);
+                        Err(error)
+                    }
                 }
-                err => {
-                    let error = ResponseStatus::PsaErrorGenericError;
-                    format_error!("Hash computation failed ", err);
-                    Err(error)
-                }
-            },
+            }
             _ => {
                 let error = ResponseStatus::PsaErrorNotSupported;
                 format_error!("Unsupported hash algorithm ", error);

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Microchip CryptoAuthentication Library provider
 //!
-//! This provider is a hardware based implementation of PSA Crypto, Mbed Crypto.
+//! This provider implements Parsec operations using CryptoAuthentication
+//! Library backed by the ATECCx08 cryptochip.
+
 use super::Provide;
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::ManageKeyInfo;
@@ -17,19 +19,31 @@ use std::io::{Error, ErrorKind};
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
-const SUPPORTED_OPCODES: [Opcode; 0] = [];
+use parsec_interface::operations::psa_hash_compute;
+
+mod hash;
+
+const SUPPORTED_OPCODES: [Opcode; 1] = [Opcode::PsaHashCompute];
 
 /// CryptoAuthLib provider structure
 #[derive(Derivative)]
-#[derivative(Debug, Clone, Copy)]
+#[derivative(Debug, Clone)]
 pub struct Provider {
-    // device: rust_cryptoauthlib::AtcaDevice,
+    device: rust_cryptoauthlib::AtcaDevice,
 }
 
 impl Provider {
     /// Creates and initialise a new instance of CryptoAuthLibProvider
-    fn new(_key_info_store: Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>) -> Option<Provider> {
-        Some(Provider {})
+    fn new(
+        _key_info_store: Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>,
+        atca_iface: rust_cryptoauthlib::AtcaIfaceCfg,
+    ) -> Option<Provider> {
+        let device = match rust_cryptoauthlib::atcab_init(atca_iface) {
+            rust_cryptoauthlib::AtcaStatus::AtcaSuccess => rust_cryptoauthlib::atcab_get_device(),
+            _ => return None,
+        };
+        let cryptoauthlib_provider = Provider { device };
+        Some(cryptoauthlib_provider)
     }
 }
 
@@ -65,6 +79,14 @@ impl Provide for Provider {
 
         Ok(list_clients::Result { clients })
     }
+
+    fn psa_hash_compute(
+        &self,
+        op: psa_hash_compute::Operation,
+    ) -> Result<psa_hash_compute::Result> {
+        trace!("psa_hash_compute ingress");
+        self.psa_hash_compute_internal(op)
+    }
 }
 
 /// CryptoAuthentication Library Provider builder
@@ -73,6 +95,13 @@ impl Provide for Provider {
 pub struct ProviderBuilder {
     #[derivative(Debug = "ignore")]
     key_info_store: Option<Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>>,
+    device_type: Option<String>,
+    iface_type: Option<String>,
+    wake_delay: Option<u16>,
+    rx_retries: Option<i32>,
+    slave_address: Option<u8>,
+    bus: Option<u8>,
+    baud: Option<u32>,
 }
 
 impl ProviderBuilder {
@@ -80,6 +109,13 @@ impl ProviderBuilder {
     pub fn new() -> ProviderBuilder {
         ProviderBuilder {
             key_info_store: None,
+            device_type: None,
+            iface_type: None,
+            wake_delay: None,
+            rx_retries: None,
+            slave_address: None,
+            bus: None,
+            baud: None,
         }
     }
 
@@ -93,11 +129,105 @@ impl ProviderBuilder {
         self
     }
 
+    /// Specify the ATECC device to be used
+    pub fn with_device_type(mut self, device_type: String) -> ProviderBuilder {
+        self.device_type = match device_type.as_str() {
+            "atecc508a" | "atecc608a" => Some(device_type),
+            _ => None,
+        };
+
+        self
+    }
+
+    /// Specify an interface type (expected: "i2c")
+    pub fn with_iface_type(mut self, iface_type: String) -> ProviderBuilder {
+        self.iface_type = match iface_type.as_str() {
+            "i2c" => Some(iface_type),
+            _ => None,
+        };
+
+        self
+    }
+
+    /// Specify a wake delay
+    pub fn with_wake_delay(mut self, wake_delay: u16) -> ProviderBuilder {
+        self.wake_delay = Some(wake_delay);
+
+        self
+    }
+
+    /// Specify number of rx retries
+    pub fn with_rx_retries(mut self, rx_retries: i32) -> ProviderBuilder {
+        self.rx_retries = Some(rx_retries);
+
+        self
+    }
+
+    /// Specify i2c slave address of ATECC device
+    pub fn with_slave_address(mut self, slave_address: u8) -> ProviderBuilder {
+        self.slave_address = Some(slave_address);
+
+        self
+    }
+
+    /// Specify i2c bus for ATECC device
+    pub fn with_bus(mut self, bus: u8) -> ProviderBuilder {
+        self.bus = Some(bus);
+
+        self
+    }
+
+    /// Specify i2c baudrate
+    pub fn with_baud(mut self, baud: u32) -> ProviderBuilder {
+        self.baud = Some(baud);
+
+        self
+    }
+
     /// Attempt to build CryptoAuthLib Provider
     pub fn build(self) -> std::io::Result<Provider> {
+        let iface_type = match self.iface_type {
+            Some(x) => match x.as_str() {
+                "i2c" => rust_cryptoauthlib::atca_iface_setup_i2c(
+                    self.device_type.ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, "missing atecc device type")
+                    })?,
+                    self.wake_delay.ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, "missing atecc wake delay")
+                    })?,
+                    self.rx_retries.ok_or_else(|| {
+                        Error::new(
+                            ErrorKind::InvalidData,
+                            "missing rx retries number for atecc",
+                        )
+                    })?,
+                    Some(self.slave_address.ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, "missing atecc i2c slave address")
+                    })?),
+                    Some(self.bus.ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, "missing atecc i2c bus")
+                    })?),
+                    Some(self.baud.ok_or_else(|| {
+                        Error::new(ErrorKind::InvalidData, "missing atecc i2c baud rate")
+                    })?),
+                ),
+                _ => return Err(Error::new(ErrorKind::InvalidData, "Unknown inteface type")),
+            },
+            None => return Err(Error::new(ErrorKind::InvalidData, "Missing inteface type")),
+        };
+
         Provider::new(
             self.key_info_store
                 .ok_or_else(|| Error::new(ErrorKind::InvalidData, "missing key info store"))?,
+            match iface_type {
+                Ok(x) => x,
+                Err(_x) => {
+                    return Err(Error::new(
+                        ErrorKind::InvalidData,
+                        "CryptoAuthLib inteface setup failed",
+                    ))
+                }
+            },
         )
         .ok_or_else(|| {
             Error::new(

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -4,7 +4,6 @@
 //!
 //! This provider implements Parsec operations using CryptoAuthentication
 //! Library backed by the ATECCx08 cryptochip.
-
 use super::Provide;
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::ManageKeyInfo;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -66,6 +66,20 @@ pub enum ProviderConfig {
     CryptoAuthLib {
         /// Name of the Key Info Manager to use
         key_info_manager: String,
+        /// ATECC Device type
+        device_type: String,
+        /// Interface type
+        iface_type: String,
+        /// Wake delay
+        wake_delay: u16,
+        /// Number of rx retries
+        rx_retries: i32,
+        /// I2C slave address
+        slave_address: Option<u8>,
+        /// I2C bus
+        bus: Option<u8>,
+        /// I2C baud rate
+        baud: Option<u32>,
     },
 }
 

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -336,11 +336,27 @@ unsafe fn get_provider(
             ))
         }
         #[cfg(feature = "cryptoauthlib-provider")]
-        ProviderConfig::CryptoAuthLib { .. } => {
+        ProviderConfig::CryptoAuthLib {
+            device_type,
+            iface_type,
+            wake_delay,
+            rx_retries,
+            slave_address,
+            bus,
+            baud,
+            ..
+        } => {
             info!("Creating a CryptoAuthentication Library Provider.");
             Ok(Arc::new(
                 CryptoAuthLibProviderBuilder::new()
                     .with_key_info_store(key_info_manager)
+                    .with_device_type(device_type.to_string())
+                    .with_iface_type(iface_type.to_string())
+                    .with_wake_delay(*wake_delay)
+                    .with_rx_retries(*rx_retries)
+                    .with_slave_address(slave_address.unwrap())
+                    .with_bus(bus.unwrap())
+                    .with_baud(baud.unwrap())
                     .build()?,
             ))
         }


### PR DESCRIPTION
The callback implementation is accompanied by required infrastructure enhancements, making possible provider instantiation using a real ATECCx08 hardware.
Known limitation: ATECCx08 family supports SHA256 hash only.

Signed-off-by: Robert Drazkowski <Robert.Drazkowski@globallogic.com>