### PR TITLE
Add ListClients and DeleteClient operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,8 +989,7 @@ dependencies = [
 [[package]]
 name = "parsec-interface"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2315911063bdd449304da2c4d36ab1816a199c3de13c0efa0e30856305bf49c5"
+source = "git+https://github.com/parallaxsecond/parsec-interface-rs?rev=c8a59544fac04df347f51d19323f4a0b5bb9580d#c8a59544fac04df347f51d19323f4a0b5bb9580d"
 dependencies = [
  "bincode",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = "0.22.0"
+parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", rev = "c8a59544fac04df347f51d19323f4a0b5bb9580d" }
 rand = { version = "0.7.3", features = ["small_rng"], optional = true }
 base64 = "0.12.3"
 uuid = "0.8.1"

--- a/e2e_tests/provider_cfg/all/config.toml
+++ b/e2e_tests/provider_cfg/all/config.toml
@@ -14,6 +14,7 @@ socket_path = "/tmp/parsec.sock"
 
 [authenticator]
 auth_type = "Direct"
+admins = [ { name = "list_clients test" }, { name = "1000" }, { name = "client1" }, { name = "spiffe://example.org/parsec-client-1" } ]
 #workload_endpoint="unix:///tmp/agent.sock"
 
 [[key_manager]]

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -53,7 +53,10 @@ impl TestClient {
     /// Creates a TestClient instance.
     pub fn new() -> TestClient {
         // As this method is called in test, it will be called more than once per application.
-        if let Err(_) = env_logger::try_init() {};
+        #[allow(unused_must_use)]
+        {
+            env_logger::try_init();
+        }
 
         let mut basic_client = BasicClient::new_naked();
 
@@ -890,6 +893,18 @@ impl TestClient {
     /// Lists the keys created.
     pub fn list_keys(&mut self) -> Result<Vec<KeyInfo>> {
         self.basic_client.list_keys().map_err(convert_error)
+    }
+
+    /// Lists the clients.
+    pub fn list_clients(&mut self) -> Result<Vec<String>> {
+        self.basic_client.list_clients().map_err(convert_error)
+    }
+
+    /// Delete a client.
+    pub fn delete_client(&mut self, client: String) -> Result<()> {
+        self.basic_client
+            .delete_client(client)
+            .map_err(convert_error)
     }
 
     /// Executes a ping operation.

--- a/e2e_tests/src/stress.rs
+++ b/e2e_tests/src/stress.rs
@@ -330,7 +330,7 @@ impl ServiceChecker {
             .expect("Verification failed");
 
         client
-            .destroy_key(sign_key_name.clone())
+            .destroy_key(sign_key_name)
             .expect("Failed to destroy key");
     }
 
@@ -352,7 +352,7 @@ impl ServiceChecker {
         assert_eq!(plaintext, vec![0xa5; 16]);
 
         client
-            .destroy_key(encr_key_name.clone())
+            .destroy_key(encr_key_name)
             .expect("Failed to destroy key");
     }
 }

--- a/src/authenticators/jwt_svid_authenticator/mod.rs
+++ b/src/authenticators/jwt_svid_authenticator/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! JWT SVID authenticator
 
-use super::{Admin, AdminList, ApplicationName, Authenticate};
+use super::{Admin, AdminList, Application, Authenticate};
 use crate::front::listener::ConnectionMetadata;
 use log::error;
 use parsec_interface::operations::list_authenticators;
@@ -48,7 +48,7 @@ impl Authenticate for JwtSvidAuthenticator {
         &self,
         auth: &RequestAuth,
         _: Option<ConnectionMetadata>,
-    ) -> Result<ApplicationName> {
+    ) -> Result<Application> {
         let svid = Jwt::new(
             str::from_utf8(auth.buffer.expose_secret())
                 .map_err(|e| {
@@ -68,6 +68,6 @@ impl Authenticate for JwtSvidAuthenticator {
         })?;
         let app_name = validate_response.spiffe_id().to_string();
         let is_admin = self.admins.is_admin(&app_name);
-        Ok(ApplicationName::new(app_name, is_admin))
+        Ok(Application::new(app_name, is_admin))
     }
 }

--- a/src/authenticators/mod.rs
+++ b/src/authenticators/mod.rs
@@ -27,6 +27,20 @@ use zeroize::Zeroize;
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ApplicationName {
     name: String,
+}
+
+impl Deref for ApplicationName {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.name
+    }
+}
+
+/// Wrapper for a Parsec application
+#[derive(Debug, Clone)]
+pub struct Application {
+    name: ApplicationName,
     is_admin: bool,
 }
 
@@ -40,7 +54,7 @@ pub trait Authenticate {
     /// operation.
     fn describe(&self) -> Result<list_authenticators::AuthenticatorInfo>;
 
-    /// Authenticates a `RequestAuth` payload and returns the `ApplicationName` if successful. A
+    /// Authenticates a `RequestAuth` payload and returns the `Application` if successful. A
     /// optional `ConnectionMetadata` object is passed in too, since it is sometimes possible to
     /// perform authentication based on the connection's metadata (i.e. as is the case for UNIX
     /// domain sockets with Unix peer credentials).
@@ -52,31 +66,39 @@ pub trait Authenticate {
         &self,
         auth: &RequestAuth,
         meta: Option<ConnectionMetadata>,
-    ) -> Result<ApplicationName>;
+    ) -> Result<Application>;
 }
 
 impl ApplicationName {
-    /// Create a new ApplicationName
-    fn new(name: String, is_admin: bool) -> ApplicationName {
-        ApplicationName { name, is_admin }
-    }
-
     /// Create ApplicationName from name string only
     pub fn from_name(name: String) -> ApplicationName {
-        ApplicationName {
-            name,
-            is_admin: false,
-        }
+        ApplicationName { name }
     }
+}
 
-    /// Get a reference to the inner string
-    pub fn get_name(&self) -> &str {
-        &self.name
+impl Application {
+    /// Create a new Application structure
+    pub fn new(name: String, is_admin: bool) -> Application {
+        Application {
+            name: ApplicationName::from_name(name),
+            is_admin,
+        }
     }
 
     /// Check whether the application is an admin
     pub fn is_admin(&self) -> bool {
         self.is_admin
+    }
+
+    /// Get a reference to the inner ApplicationName string
+    pub fn get_name(&self) -> &ApplicationName {
+        &self.name
+    }
+}
+
+impl From<Application> for ApplicationName {
+    fn from(auth: Application) -> Self {
+        auth.name
     }
 }
 

--- a/src/back/dispatcher.rs
+++ b/src/back/dispatcher.rs
@@ -5,7 +5,7 @@
 //! The dispatcher's role is to direct requests to the provider they specify, if
 //! said provider is available on the system, thus acting as a multiplexer.
 use super::backend_handler::BackEndHandler;
-use crate::authenticators::ApplicationName;
+use crate::authenticators::Application;
 use log::trace;
 use parsec_interface::requests::request::Request;
 use parsec_interface::requests::ProviderID;
@@ -32,18 +32,14 @@ impl Dispatcher {
     /// Returns either the response coming from the backend handler, or a response
     /// containing a status code consistent with the error encountered during
     /// processing.
-    pub fn dispatch_request(
-        &self,
-        request: Request,
-        app_name: Option<ApplicationName>,
-    ) -> Response {
+    pub fn dispatch_request(&self, request: Request, app: Option<Application>) -> Response {
         trace!("dispatch_request ingress");
         if let Some(backend) = self.backends.get(&request.header.provider) {
             if let Err(status) = backend.is_capable(&request) {
                 Response::from_request_header(request.header, status)
             } else {
                 {
-                    let response = backend.execute_request(request, app_name);
+                    let response = backend.execute_request(request, app);
                     trace!("execute_request egress");
                     response
                 }

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -182,3 +182,24 @@ pub fn list_keys(
 
     Ok(keys)
 }
+
+/// Returns a Vec of ApplicationName of clients having keys in the provider.
+///
+/// # Errors
+///
+/// Returns an error as a String if there was a problem accessing the Key Info Manager.
+pub fn list_clients(
+    manager: &dyn ManageKeyInfo,
+    provider_id: ProviderID,
+) -> Result<Vec<ApplicationName>, String> {
+    let key_triples = manager.get_all(provider_id)?;
+    let mut clients = Vec::new();
+
+    for key_triple in key_triples {
+        if !clients.contains(key_triple.app_name()) {
+            let _ = clients.push(key_triple.app_name().clone());
+        }
+    }
+
+    Ok(clients)
+}

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -43,7 +43,7 @@ pub struct OnDiskKeyInfoManager {
 /// being a number from 0 and 255.
 fn key_triple_to_base64_filenames(key_triple: &KeyTriple) -> (String, String, String) {
     (
-        base64::encode_config(key_triple.app_name.get_name().as_bytes(), base64::URL_SAFE),
+        base64::encode_config(key_triple.app_name.as_bytes(), base64::URL_SAFE),
         (key_triple.provider_id as u8).to_string(),
         base64::encode_config(key_triple.key_name.as_bytes(), base64::URL_SAFE),
     )

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -8,9 +8,9 @@ use crate::authenticators::ApplicationName;
 use crate::key_info_managers::ManageKeyInfo;
 use derivative::Derivative;
 use log::trace;
-use parsec_interface::operations::list_keys;
 use parsec_interface::operations::list_keys::KeyInfo;
 use parsec_interface::operations::list_providers::ProviderInfo;
+use parsec_interface::operations::{list_clients, list_keys};
 use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
@@ -57,6 +57,13 @@ impl Provide for Provider {
         let keys: Vec<KeyInfo> = Vec::new();
 
         Ok(list_keys::Result { keys })
+    }
+
+    fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
+        trace!("list_clients ingress");
+        let clients: Vec<String> = Vec::new();
+
+        Ok(list_clients::Result { clients })
     }
 }
 

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -8,7 +8,7 @@ use crate::authenticators::ApplicationName;
 use crate::key_info_managers::{self, KeyTriple, ManageKeyInfo};
 use derivative::Derivative;
 use log::{error, trace};
-use parsec_interface::operations::{list_keys, list_providers::ProviderInfo};
+use parsec_interface::operations::{list_clients, list_keys, list_providers::ProviderInfo};
 use parsec_interface::operations::{
     psa_aead_decrypt, psa_aead_encrypt, psa_asymmetric_decrypt, psa_asymmetric_encrypt,
     psa_destroy_key, psa_export_key, psa_export_public_key, psa_generate_key, psa_generate_random,
@@ -178,6 +178,20 @@ impl Provide for Provider {
                 format_error!("Error occurred when fetching key information", e);
                 ResponseStatus::KeyInfoManagerError
             })?,
+        })
+    }
+
+    fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        Ok(list_clients::Result {
+            clients: key_info_managers::list_clients(store_handle.deref(), ProviderID::MbedCrypto)
+                .map_err(|e| {
+                    format_error!("Error occurred when fetching key information", e);
+                    ResponseStatus::KeyInfoManagerError
+                })?
+                .into_iter()
+                .map(|app_name| app_name.to_string())
+                .collect(),
         })
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -104,10 +104,11 @@ impl ProviderConfig {
 
 use crate::authenticators::ApplicationName;
 use parsec_interface::operations::{
-    list_authenticators, list_keys, list_opcodes, list_providers, ping, psa_aead_decrypt,
-    psa_aead_encrypt, psa_asymmetric_decrypt, psa_asymmetric_encrypt, psa_destroy_key,
-    psa_export_key, psa_export_public_key, psa_generate_key, psa_generate_random, psa_hash_compare,
-    psa_hash_compute, psa_import_key, psa_raw_key_agreement, psa_sign_hash, psa_verify_hash,
+    delete_client, list_authenticators, list_clients, list_keys, list_opcodes, list_providers,
+    ping, psa_aead_decrypt, psa_aead_encrypt, psa_asymmetric_decrypt, psa_asymmetric_encrypt,
+    psa_destroy_key, psa_export_key, psa_export_public_key, psa_generate_key, psa_generate_random,
+    psa_hash_compare, psa_hash_compute, psa_import_key, psa_raw_key_agreement, psa_sign_hash,
+    psa_verify_hash,
 };
 use parsec_interface::requests::{ResponseStatus, Result};
 
@@ -152,6 +153,18 @@ pub trait Provide {
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
         trace!("list_keys ingress");
+        Err(ResponseStatus::PsaErrorNotSupported)
+    }
+
+    /// Lists all clients currently having data in the service.
+    fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
+        trace!("list_clients ingress");
+        Err(ResponseStatus::PsaErrorNotSupported)
+    }
+
+    /// Delete all data a client has in the service..
+    fn delete_client(&self, _op: delete_client::Operation) -> Result<delete_client::Result> {
+        trace!("delete_client ingress");
         Err(ResponseStatus::PsaErrorNotSupported)
     }
 

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -9,7 +9,7 @@ use crate::authenticators::ApplicationName;
 use crate::key_info_managers::{self, KeyInfo, KeyTriple, ManageKeyInfo};
 use derivative::Derivative;
 use log::{error, info, trace, warn};
-use parsec_interface::operations::{list_keys, list_providers::ProviderInfo};
+use parsec_interface::operations::{list_clients, list_keys, list_providers::ProviderInfo};
 use parsec_interface::operations::{
     psa_asymmetric_decrypt, psa_asymmetric_encrypt, psa_destroy_key, psa_export_public_key,
     psa_generate_key, psa_import_key, psa_sign_hash, psa_verify_hash,
@@ -222,6 +222,20 @@ impl Provide for Provider {
                     format_error!("Error occurred when fetching key information", e);
                     ResponseStatus::KeyInfoManagerError
                 })?,
+        })
+    }
+
+    fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
+        let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+        Ok(list_clients::Result {
+            clients: key_info_managers::list_clients(store_handle.deref(), ProviderID::Pkcs11)
+                .map_err(|e| {
+                    format_error!("Error occurred when fetching key information", e);
+                    ResponseStatus::KeyInfoManagerError
+                })?
+                .into_iter()
+                .map(|app_name| app_name.to_string())
+                .collect(),
         })
     }
 


### PR DESCRIPTION
Also adds multitenancy tests for those operations and for the admin
feature. Splits the ApplicationName structure into Application and
ApplicationName to only deal with key names in the Key Info Managers and
not the admin status which is not relevent there.

Fix #309 
Fix #311 
