### PR TITLE
Use newest TSS crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,13 +94,12 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "clap",
  "env_logger",
@@ -178,13 +183,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.6.7",
 ]
 
 [[package]]
@@ -250,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
@@ -427,7 +432,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -560,12 +576,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -680,6 +693,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if 1.0.0",
  "winapi 0.3.9",
 ]
 
@@ -988,8 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "parsec-interface"
-version = "0.22.0"
-source = "git+https://github.com/parallaxsecond/parsec-interface-rs?rev=c8a59544fac04df347f51d19323f4a0b5bb9580d#c8a59544fac04df347f51d19323f4a0b5bb9580d"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdcc6d05ad58d941ee3059f12e5316af2da840658d5575ff807bcb38ac06681b"
 dependencies = [
  "bincode",
  "derivative",
@@ -1011,7 +1035,7 @@ name = "parsec-service"
 version = "0.6.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.0",
  "bincode",
  "derivative",
  "env_logger",
@@ -1024,7 +1048,7 @@ dependencies = [
  "picky-asn1-x509",
  "pkcs11",
  "psa-crypto",
- "rand",
+ "rand 0.8.2",
  "sd-notify",
  "serde",
  "signal-hook",
@@ -1085,11 +1109,11 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0e481be061b377156b1e3421b81aff7360d95a572097f76196981601bb4206"
+checksum = "b8501e799b4c18bac0a6e74672126b1826df41178dcf076eec9ddefd93edcb11"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "oid",
  "picky-asn1",
  "picky-asn1-der",
@@ -1160,7 +1184,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aca6d67e4c8613bfe455599d0233d00735f85df2001f6bfd9bb7ac0496b10af"
 dependencies = [
- "libloading",
+ "libloading 0.5.2",
  "num-bigint 0.2.6",
 ]
 
@@ -1280,9 +1304,9 @@ checksum = "86473d5f16580f10b131a0bf0afb68f8e029d1835d33a00f37281b05694e5312"
 
 [[package]]
 name = "psa-crypto"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c3a5990accd6b60d1be439217bace44981487173734598ff0f6744921b9b1b"
+checksum = "bb3056637beffada9b2c6f0f53d5891f649d25f360f6411895615606942282e0"
 dependencies = [
  "log",
  "psa-crypto-sys",
@@ -1292,21 +1316,15 @@ dependencies = [
 
 [[package]]
 name = "psa-crypto-sys"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a060d4d38d17bd0d4238660348653bad2365dec22eafac3c505ff319714c6b67"
+checksum = "858453d52d3668ceaf0d3a6c5fbfd181ea4c230559eb08b8d2ba125fde177bcc"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "walkdir",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1323,12 +1341,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
- "rand_pcg",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1338,7 +1367,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1347,7 +1386,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.1",
 ]
 
 [[package]]
@@ -1356,16 +1404,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
-name = "rand_pcg"
-version = "0.2.1"
+name = "rand_hc"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -1505,9 +1553,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1629,7 +1677,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -1771,9 +1819,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tss-esapi"
-version = "4.0.9-alpha.1"
+version = "4.0.10-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a09d4314f5c2e87e86838a56363c35a941004a64a89af135ab9e2d0b6bddc5f4"
+checksum = "eeaaec68e3832d2ab7ad322aa4ec5e8f13aa5004e1d058ede8337575a48d0310"
 dependencies = [
  "bindgen",
  "bitfield",
@@ -1839,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "users"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
 dependencies = [
  "libc",
  "log",
@@ -1903,6 +1951,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,37 +18,37 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", rev = "c8a59544fac04df347f51d19323f4a0b5bb9580d" }
-rand = { version = "0.7.3", features = ["small_rng"], optional = true }
-base64 = "0.12.3"
+parsec-interface = "0.23.0"
+rand = { version = "0.8.2", features = ["small_rng"], optional = true }
+base64 = "0.13.0"
 uuid = "0.8.1"
 threadpool = "1.8.1"
-signal-hook = "0.1.16"
+signal-hook = "0.3.4"
 sd-notify = "0.1.1"
 toml = "0.5.6"
 serde = { version = "1.0.115", features = ["derive"] }
-env_logger = "0.7.1"
+env_logger = "0.8.2"
 log = { version = "0.4.11", features = ["serde"] }
 pkcs11 = { version = "0.5.0", optional = true }
 picky-asn1-der = { version = "0.2.4", optional = true }
 picky-asn1 = { version = "0.3.0", optional = true }
-tss-esapi = { version = "4.0.9-alpha.1", optional = true }
+tss-esapi = { version = "4.0.10-alpha.2", optional = true }
 bincode = "1.3.1"
 structopt = "0.3.17"
 derivative = "2.1.1"
 version = "3.0.0"
 hex = { version = "0.4.2", optional = true }
-psa-crypto = { version = "0.6.1", default-features = false, features = ["operations"], optional = true }
+psa-crypto = { version = "0.7.0", default-features = false, features = ["operations"], optional = true }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
-picky-asn1-x509 = { version = "0.3.2", optional = true }
-users = "0.10.0"
+picky-asn1-x509 = { version = "0.4.0", optional = true }
+users = "0.11.0"
 libc = "0.2.77"
 anyhow = "1.0.32"
 # Using a fork until the JWT support is merged into the main rust-spiffe repository
 spiffe = { git = "https://github.com/hug-dev/rust-spiffe", branch = "refactor-jwt" }
 
 [dev-dependencies]
-rand = { version = "0.7.3", features = ["small_rng"] }
+rand = { version = "0.8.2", features = ["small_rng"] }
 
 [package.metadata.docs.rs]
 features = ["pkcs11-provider", "tpm-provider", "tss-esapi/docs", "mbed-crypto-provider", "cryptoauthlib-provider"]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -42,7 +42,7 @@
 use anyhow::Result;
 use log::{info, trace};
 use parsec_service::utils::{ServiceBuilder, ServiceConfig};
-use signal_hook::{flag, SIGHUP, SIGTERM};
+use signal_hook::{consts::SIGHUP, consts::SIGTERM, flag};
 use std::io::{Error, ErrorKind};
 use std::sync::{
     atomic::{AtomicBool, Ordering},

--- a/src/providers/tpm/mod.rs
+++ b/src/providers/tpm/mod.rs
@@ -21,6 +21,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, RwLock};
 use tss_esapi::constants::algorithm::{Cipher, HashingAlgorithm};
+use tss_esapi::interface_types::resource_handles::Hierarchy;
 use tss_esapi::Tcti;
 use uuid::Uuid;
 use zeroize::Zeroize;
@@ -331,7 +332,7 @@ impl ProviderBuilder {
                 .with_root_key_size(ROOT_KEY_SIZE)
                 .with_root_key_auth_size(ROOT_KEY_AUTH_SIZE)
                 .with_hierarchy_auth(hierarchy_auth)
-                .with_hierarchy(tss_esapi::utils::Hierarchy::Owner)
+                .with_hierarchy(Hierarchy::Owner)
                 .with_session_hash_alg(HashingAlgorithm::Sha256)
                 .with_default_context_cipher(default_cipher)
                 .build()


### PR DESCRIPTION
This commit changes the dependency to the latest TSS crate published -
and also to the latest interface and PSA crates to be compatible with
the tss-esapi.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>