### PR TITLE
Add consistency in key creation/deletion

### DIFF
--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -146,60 +146,82 @@ pub trait ManageKeyInfo {
     fn exists(&self, key_triple: &KeyTriple) -> Result<bool, String>;
 }
 
-/// Returns a Vec of the KeyInfo objects corresponding to the given application name and
-/// provider ID.
-///
-/// # Errors
-///
-/// Returns an error as a String if there was a problem accessing the Key Info Manager.
-pub fn list_keys(
-    manager: &dyn ManageKeyInfo,
-    app_name: &ApplicationName,
-    provider_id: ProviderID,
-) -> Result<Vec<parsec_interface::operations::list_keys::KeyInfo>, String> {
-    use parsec_interface::operations::list_keys::KeyInfo;
+// "+ Send + Sync" is needed for things like:
+// ```
+// let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
+// let _ = store_handle.list_keys(&app_name, ProviderID::Pkcs11)?;
+// ```
+// to work because `store_handle` is a RWLockReadGuard of (dyn ManageKeyInfo + Send + Sync +
+// 'static). Did not work with only `impl dyn ManageKeyInfo` below. Maybe there is a way to
+// implement automagically the same methods on (dyn ManageKeyInfo + Send + Sync + 'static)
+// if they are implemented on dyn ManageKeyInfo but not sure.
+impl dyn ManageKeyInfo + Send + Sync {
+    /// Returns a Vec of the KeyInfo objects corresponding to the given application name and
+    /// provider ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error as a String if there was a problem accessing the Key Info Manager.
+    pub fn list_keys(
+        &self,
+        app_name: &ApplicationName,
+        provider_id: ProviderID,
+    ) -> Result<Vec<parsec_interface::operations::list_keys::KeyInfo>, String> {
+        use parsec_interface::operations::list_keys::KeyInfo;
 
-    let mut keys: Vec<KeyInfo> = Vec::new();
-    let key_triples = manager.get_all(provider_id)?;
+        let mut keys: Vec<KeyInfo> = Vec::new();
+        let key_triples = self.get_all(provider_id)?;
 
-    for key_triple in key_triples {
-        if key_triple.app_name() != app_name {
-            continue;
+        for key_triple in key_triples {
+            if key_triple.app_name() != app_name {
+                continue;
+            }
+
+            let key_info = self.get(key_triple)?;
+            let key_info = match key_info {
+                Some(key_info) => key_info,
+                _ => continue,
+            };
+
+            keys.push(KeyInfo {
+                provider_id: key_triple.provider_id,
+                name: key_triple.key_name().to_string(),
+                attributes: key_info.attributes,
+            });
         }
 
-        let key_info = manager.get(key_triple)?;
-        let key_info = match key_info {
-            Some(key_info) => key_info,
-            _ => continue,
-        };
-
-        keys.push(KeyInfo {
-            provider_id: key_triple.provider_id,
-            name: key_triple.key_name().to_string(),
-            attributes: key_info.attributes,
-        });
+        Ok(keys)
     }
 
-    Ok(keys)
-}
+    /// Returns a Vec of ApplicationName of clients having keys in the provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error as a String if there was a problem accessing the Key Info Manager.
+    pub fn list_clients(&self, provider_id: ProviderID) -> Result<Vec<ApplicationName>, String> {
+        let key_triples = self.get_all(provider_id)?;
+        let mut clients = Vec::new();
 
-/// Returns a Vec of ApplicationName of clients having keys in the provider.
-///
-/// # Errors
-///
-/// Returns an error as a String if there was a problem accessing the Key Info Manager.
-pub fn list_clients(
-    manager: &dyn ManageKeyInfo,
-    provider_id: ProviderID,
-) -> Result<Vec<ApplicationName>, String> {
-    let key_triples = manager.get_all(provider_id)?;
-    let mut clients = Vec::new();
+        for key_triple in key_triples {
+            if !clients.contains(key_triple.app_name()) {
+                let _ = clients.push(key_triple.app_name().clone());
+            }
+        }
 
-    for key_triple in key_triples {
-        if !clients.contains(key_triple.app_name()) {
-            let _ = clients.push(key_triple.app_name().clone());
+        Ok(clients)
+    }
+
+    /// Check if a key triple exists in the Key Info Manager and return a ResponseStatus
+    ///
+    /// # Errors
+    ///
+    /// Returns PsaErrorAlreadyExists if the key triple already exists or KeyInfoManagerError for
+    /// another error.
+    pub fn already_exists(&self, key_triple: &KeyTriple) -> Result<(), ResponseStatus> {
+        if self.exists(key_triple).map_err(to_response_status)? {
+            Err(ResponseStatus::PsaErrorAlreadyExists)
+        } else {
+            Ok(())
         }
     }
-
-    Ok(clients)
 }

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -217,7 +217,7 @@ impl dyn ManageKeyInfo + Send + Sync {
     ///
     /// Returns PsaErrorAlreadyExists if the key triple already exists or KeyInfoManagerError for
     /// another error.
-    pub fn already_exists(&self, key_triple: &KeyTriple) -> Result<(), ResponseStatus> {
+    pub fn does_not_exist(&self, key_triple: &KeyTriple) -> Result<(), ResponseStatus> {
         if self.exists(key_triple).map_err(to_response_status)? {
             Err(ResponseStatus::PsaErrorAlreadyExists)
         } else {

--- a/src/providers/core/mod.rs
+++ b/src/providers/core/mod.rs
@@ -87,10 +87,15 @@ impl Provide for Provider {
 
         let mut keys: Vec<KeyInfo> = Vec::new();
         for provider in &self.prov_list {
+            let id = if let Ok((provider_info, _)) = provider.describe() {
+                provider_info.id.to_string()
+            } else {
+                "unknown".to_string()
+            };
             let mut result = provider
                 .list_keys(app_name.clone(), _op)
                 .unwrap_or_else(|e| {
-                    error!("list_keys failed on provider with {}", e);
+                    error!("list_keys failed on provider {} with {}", id, e);
                     list_keys::Result { keys: Vec::new() }
                 });
             keys.append(&mut result.keys);
@@ -105,7 +110,12 @@ impl Provide for Provider {
         let mut clients: Vec<String> = Vec::new();
         for provider in &self.prov_list {
             let mut result = provider.list_clients(_op).unwrap_or_else(|e| {
-                error!("list_clients failed on provider with {}", e);
+                let id = if let Ok((provider_info, _)) = provider.describe() {
+                    provider_info.id.to_string()
+                } else {
+                    "unknown".to_string()
+                };
+                error!("list_clients failed on provider {} with {}", id, e);
                 list_clients::Result {
                     clients: Vec::new(),
                 }
@@ -124,6 +134,11 @@ impl Provide for Provider {
         let client = op.client;
 
         for provider in &self.prov_list {
+            let id = if let Ok((provider_info, _)) = provider.describe() {
+                provider_info.id.to_string()
+            } else {
+                "unknown".to_string()
+            };
             // Currently Parsec only stores keys, we delete all of them.
             let keys = provider
                 .list_keys(
@@ -131,7 +146,7 @@ impl Provide for Provider {
                     list_keys::Operation {},
                 )
                 .unwrap_or_else(|e| {
-                    error!("list_keys failed on provider with {}", e);
+                    error!("list_keys failed on provider {} with {}", id, e);
                     list_keys::Result { keys: Vec::new() }
                 })
                 .keys;
@@ -143,7 +158,7 @@ impl Provide for Provider {
                         psa_destroy_key::Operation { key_name },
                     )
                     .unwrap_or_else(|e| {
-                        error!("psa_destroy_key failed on provider with {}", e);
+                        error!("psa_destroy_key failed on provider {} with {}", id, e);
                         psa_destroy_key::Result {}
                     });
             }

--- a/src/providers/core/mod.rs
+++ b/src/providers/core/mod.rs
@@ -8,7 +8,7 @@
 use super::Provide;
 use crate::authenticators::ApplicationName;
 use derivative::Derivative;
-use log::trace;
+use log::{error, trace};
 use parsec_interface::operations::{
     delete_client, list_authenticators, list_clients, list_keys, list_opcodes, list_providers,
     ping, psa_destroy_key,
@@ -87,7 +87,12 @@ impl Provide for Provider {
 
         let mut keys: Vec<KeyInfo> = Vec::new();
         for provider in &self.prov_list {
-            let mut result = provider.list_keys(app_name.clone(), _op)?;
+            let mut result = provider
+                .list_keys(app_name.clone(), _op)
+                .unwrap_or_else(|e| {
+                    error!("list_keys failed on provider with {}", e);
+                    list_keys::Result { keys: Vec::new() }
+                });
             keys.append(&mut result.keys);
         }
 
@@ -99,7 +104,12 @@ impl Provide for Provider {
 
         let mut clients: Vec<String> = Vec::new();
         for provider in &self.prov_list {
-            let mut result = provider.list_clients(_op)?;
+            let mut result = provider.list_clients(_op).unwrap_or_else(|e| {
+                error!("list_clients failed on provider with {}", e);
+                list_clients::Result {
+                    clients: Vec::new(),
+                }
+            });
             clients.append(&mut result.clients);
         }
         clients.sort();
@@ -119,14 +129,23 @@ impl Provide for Provider {
                 .list_keys(
                     ApplicationName::from_name(client.clone()),
                     list_keys::Operation {},
-                )?
+                )
+                .unwrap_or_else(|e| {
+                    error!("list_keys failed on provider with {}", e);
+                    list_keys::Result { keys: Vec::new() }
+                })
                 .keys;
             for key in keys {
                 let key_name = key.name;
-                let _ = provider.psa_destroy_key(
-                    ApplicationName::from_name(client.clone()),
-                    psa_destroy_key::Operation { key_name },
-                )?;
+                let _ = provider
+                    .psa_destroy_key(
+                        ApplicationName::from_name(client.clone()),
+                        psa_destroy_key::Operation { key_name },
+                    )
+                    .unwrap_or_else(|e| {
+                        error!("psa_destroy_key failed on provider with {}", e);
+                        psa_destroy_key::Result {}
+                    });
             }
         }
 

--- a/src/providers/mbed_crypto/key_management.rs
+++ b/src/providers/mbed_crypto/key_management.rs
@@ -41,13 +41,30 @@ pub fn get_key_id(
     }
 }
 
-/// Creates a new PSA Key ID and stores it in the Key Info Manager.
-fn create_key_id(
+/// Stores a key ID it in the Key Info Manager.
+fn insert_key_id(
     key_triple: KeyTriple,
     key_attributes: Attributes,
     store_handle: &mut dyn ManageKeyInfo,
-    max_current_id: &AtomicU32,
-) -> Result<key::psa_key_id_t> {
+    new_key_id: key::psa_key_id_t,
+) -> Result<()> {
+    let key_info = KeyInfo {
+        id: new_key_id.to_ne_bytes().to_vec(),
+        attributes: key_attributes,
+    };
+    match store_handle.insert(key_triple.clone(), key_info) {
+        Ok(insert_option) => {
+            if insert_option.is_some() {
+                warn!("Overwriting Key triple mapping ({})", key_triple);
+            }
+            Ok(())
+        }
+        Err(string) => Err(key_info_managers::to_response_status(string)),
+    }
+}
+
+/// Creates a new PSA Key ID
+fn create_key_id(max_current_id: &AtomicU32) -> Result<key::psa_key_id_t> {
     // fetch_add adds 1 to the old value and returns the old value, so add 1 to local value for new ID
     let new_key_id = max_current_id.fetch_add(1, Relaxed) + 1;
     if new_key_id > key::PSA_KEY_ID_USER_MAX {
@@ -61,19 +78,7 @@ fn create_key_id(
         return Err(ResponseStatus::PsaErrorInsufficientMemory);
     }
 
-    let key_info = KeyInfo {
-        id: new_key_id.to_ne_bytes().to_vec(),
-        attributes: key_attributes,
-    };
-    match store_handle.insert(key_triple.clone(), key_info) {
-        Ok(insert_option) => {
-            if insert_option.is_some() {
-                warn!("Overwriting Key triple mapping ({})", key_triple);
-            }
-            Ok(new_key_id)
-        }
-        Err(string) => Err(key_info_managers::to_response_status(string)),
-    }
+    Ok(new_key_id)
 }
 
 fn remove_key_id(key_triple: &KeyTriple, store_handle: &mut dyn ManageKeyInfo) -> Result<()> {
@@ -82,12 +87,6 @@ fn remove_key_id(key_triple: &KeyTriple, store_handle: &mut dyn ManageKeyInfo) -
         Ok(_) => Ok(()),
         Err(string) => Err(key_info_managers::to_response_status(string)),
     }
-}
-
-pub fn key_info_exists(key_triple: &KeyTriple, store_handle: &dyn ManageKeyInfo) -> Result<bool> {
-    store_handle
-        .exists(key_triple)
-        .map_err(key_info_managers::to_response_status)
 }
 
 impl Provider {
@@ -99,19 +98,15 @@ impl Provider {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_triple = KeyTriple::new(app_name, ProviderID::MbedCrypto, key_name);
+
         let mut store_handle = self
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
-        if key_info_exists(&key_triple, &*store_handle)? {
-            return Err(ResponseStatus::PsaErrorAlreadyExists);
-        }
-        let key_id = create_key_id(
-            key_triple.clone(),
-            key_attributes,
-            &mut *store_handle,
-            &self.id_counter,
-        )?;
+
+        store_handle.already_exists(&key_triple)?;
+
+        let key_id = create_key_id(&self.id_counter)?;
 
         let _guard = self
             .key_handle_mutex
@@ -119,9 +114,13 @@ impl Provider {
             .expect("Grabbing key handle mutex failed");
 
         match psa_crypto_key_management::generate(key_attributes, Some(key_id)) {
-            Ok(_) => Ok(psa_generate_key::Result {}),
+            Ok(_) => {
+                // If this fails, then we will have a zombie key in the Mbed Crypto backend. This
+                // is probably not a big problem apart from memory consumption.
+                insert_key_id(key_triple, key_attributes, &mut *store_handle, key_id)?;
+                Ok(psa_generate_key::Result {})
+            }
             Err(error) => {
-                remove_key_id(&key_triple, &mut *store_handle)?;
                 let error = ResponseStatus::from(error);
                 format_error!("Generate key status: ", error);
                 Err(error)
@@ -142,15 +141,9 @@ impl Provider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
-        if key_info_exists(&key_triple, &*store_handle)? {
-            return Err(ResponseStatus::PsaErrorAlreadyExists);
-        }
-        let key_id = create_key_id(
-            key_triple.clone(),
-            key_attributes,
-            &mut *store_handle,
-            &self.id_counter,
-        )?;
+        store_handle.already_exists(&key_triple)?;
+
+        let key_id = create_key_id(&self.id_counter)?;
 
         let _guard = self
             .key_handle_mutex
@@ -162,9 +155,11 @@ impl Provider {
             Some(key_id),
             key_data.expose_secret(),
         ) {
-            Ok(_) => Ok(psa_import_key::Result {}),
+            Ok(_) => {
+                insert_key_id(key_triple, key_attributes, &mut *store_handle, key_id)?;
+                Ok(psa_import_key::Result {})
+            }
             Err(error) => {
-                remove_key_id(&key_triple, &mut *store_handle)?;
                 let error = ResponseStatus::from(error);
                 format_error!("Import key status: ", error);
                 Err(error)
@@ -239,7 +234,9 @@ impl Provider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
+
         let key_id = get_key_id(&key_triple, &*store_handle)?;
+        remove_key_id(&key_triple, &mut *store_handle)?;
 
         let _guard = self
             .key_handle_mutex
@@ -257,11 +254,10 @@ impl Provider {
         }
 
         match destroy_key_status {
-            Ok(()) => {
-                remove_key_id(&key_triple, &mut *store_handle)?;
-                Ok(psa_destroy_key::Result {})
-            }
+            Ok(()) => Ok(psa_destroy_key::Result {}),
             Err(error) => {
+                // In that case we would have a zombie key in the Mbed Crypto backend. The key is
+                // maybe still there but can not be accessible from Parsec anymore.
                 let error = ResponseStatus::from(error);
                 format_error!("Destroy key status: ", error);
                 Err(error)

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -5,7 +5,7 @@
 //! This provider is a software based implementation of PSA Crypto, Mbed Crypto.
 use super::Provide;
 use crate::authenticators::ApplicationName;
-use crate::key_info_managers::{self, KeyTriple, ManageKeyInfo};
+use crate::key_info_managers::{KeyTriple, ManageKeyInfo};
 use derivative::Derivative;
 use log::{error, trace};
 use parsec_interface::operations::{list_clients, list_keys, list_providers::ProviderInfo};
@@ -19,7 +19,6 @@ use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use psa_crypto::types::{key, status};
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
-use std::ops::Deref;
 use std::sync::{
     atomic::{AtomicU32, Ordering::Relaxed},
     Arc, Mutex, RwLock,
@@ -169,22 +168,20 @@ impl Provide for Provider {
     ) -> Result<list_keys::Result> {
         let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
         Ok(list_keys::Result {
-            keys: key_info_managers::list_keys(
-                store_handle.deref(),
-                &app_name,
-                ProviderID::MbedCrypto,
-            )
-            .map_err(|e| {
-                format_error!("Error occurred when fetching key information", e);
-                ResponseStatus::KeyInfoManagerError
-            })?,
+            keys: store_handle
+                .list_keys(&app_name, ProviderID::MbedCrypto)
+                .map_err(|e| {
+                    format_error!("Error occurred when fetching key information", e);
+                    ResponseStatus::KeyInfoManagerError
+                })?,
         })
     }
 
     fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
         let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
         Ok(list_clients::Result {
-            clients: key_info_managers::list_clients(store_handle.deref(), ProviderID::MbedCrypto)
+            clients: store_handle
+                .list_clients(ProviderID::MbedCrypto)
                 .map_err(|e| {
                     format_error!("Error occurred when fetching key information", e);
                     ResponseStatus::KeyInfoManagerError

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -187,7 +187,17 @@ pub trait Provide {
         Err(ResponseStatus::PsaErrorNotSupported)
     }
 
-    /// Execute a CreateKey operation.
+    /// Execute a GenerateKey operation.
+    ///
+    /// Providers should try, in a best-effort way, to handle failures in a way that it is possible
+    /// to create a key with the same name later on.
+    ///
+    /// For providers using a Key Info Manager to map a key name with a provider-specific key
+    /// identification, the following algorithm can be followed:
+    /// 1. generate unique key ID
+    /// 2. try key creation with it. If successfull go to 3 else return an error.
+    /// 3. store the mappings between key name and key ID. If successfull return success, else go to 4.
+    /// 4. try to delete the key created. If failed, log it and return the error from 3.
     fn psa_generate_key(
         &self,
         _app_name: ApplicationName,
@@ -198,6 +208,16 @@ pub trait Provide {
     }
 
     /// Execute an ImportKey operation.
+    ///
+    /// Providers should try, in a best-effort way, to handle failures in a way that it is possible
+    /// to import a key with the same name later on.
+    ///
+    /// For providers using a Key Info Manager to map a key name with a provider-specific key
+    /// identification, the following algorithm can be followed:
+    /// 1. generate unique key ID
+    /// 2. try key import with it. If successfull go to 3 else return an error.
+    /// 3. store the mappings between key name and key ID. If successfull return success, else go to 4.
+    /// 4. try to delete the key imported. If failed, log it and return the error from 3.
     fn psa_import_key(
         &self,
         _app_name: ApplicationName,
@@ -228,6 +248,15 @@ pub trait Provide {
     }
 
     /// Execute a DestroyKey operation.
+    ///
+    /// Providers should try, in a best-effort way, to handle failures in a way that it is possible
+    /// to generate or create a key with the same name than the one destroyed later on.
+    ///
+    /// For providers using a Key Info Manager to map a key name with a provider-specific key
+    /// identification, the following algorithm can be followed:
+    /// 1. get the key ID from the key name using the KIM
+    /// 2. destroy the key mappings
+    /// 3. try to destroy the key
     fn psa_destroy_key(
         &self,
         _app_name: ApplicationName,

--- a/src/providers/pkcs11/key_management.rs
+++ b/src/providers/pkcs11/key_management.rs
@@ -463,12 +463,8 @@ impl Provider {
             }
         };
 
-        if let Err(e) = first_res {
-            Err(e)
-        } else if let Err(e) = second_res {
-            Err(e)
-        } else {
-            Ok(psa_destroy_key::Result {})
-        }
+        first_res?;
+        second_res?;
+        Ok(psa_destroy_key::Result {})
     }
 }

--- a/src/providers/pkcs11/key_metadata.rs
+++ b/src/providers/pkcs11/key_metadata.rs
@@ -96,9 +96,9 @@ impl Provider {
         }
     }
 
-    pub(super) fn key_info_exists(&self, key_triple: &KeyTriple) -> Result<()> {
+    pub(super) fn key_info_does_not_exist(&self, key_triple: &KeyTriple) -> Result<()> {
         let locks = self.get_ordered_locks();
         let store_handle = locks.0.read().expect("Key store lock poisoned");
-        store_handle.already_exists(key_triple)
+        store_handle.does_not_exist(key_triple)
     }
 }

--- a/src/providers/pkcs11/key_metadata.rs
+++ b/src/providers/pkcs11/key_metadata.rs
@@ -42,22 +42,31 @@ impl Provider {
         }
     }
 
-    pub(super) fn create_key_id(
-        &self,
-        key_triple: KeyTriple,
-        key_attributes: Attributes,
-    ) -> Result<[u8; 4]> {
+    pub(super) fn create_key_id(&self) -> [u8; 4] {
         let locks = self.get_ordered_locks();
-        let mut store_handle = locks.0.write().expect("Key store lock poisoned");
         let mut local_ids_handle = locks.1.write().expect("Local ID lock poisoned");
         let mut key_id = rand::random::<[u8; 4]>();
         while local_ids_handle.contains(&key_id) {
             key_id = rand::random::<[u8; 4]>();
         }
+        let _ = local_ids_handle.insert(key_id);
+        key_id
+    }
+
+    pub(super) fn insert_key_id(
+        &self,
+        key_triple: KeyTriple,
+        key_attributes: Attributes,
+        key_id: [u8; 4],
+    ) -> Result<()> {
+        let locks = self.get_ordered_locks();
+        let mut store_handle = locks.0.write().expect("Key store lock poisoned");
+
         let key_info = KeyInfo {
             id: key_id.to_vec(),
             attributes: key_attributes,
         };
+
         match store_handle.insert(key_triple.clone(), key_info) {
             Ok(insert_option) => {
                 if insert_option.is_some() {
@@ -67,29 +76,18 @@ impl Provider {
                         warn!("Overwriting Key triple mapping");
                     }
                 }
-                let _ = local_ids_handle.insert(key_id);
-                Ok(key_id)
+                Ok(())
             }
             Err(string) => Err(key_info_managers::to_response_status(string)),
         }
     }
 
-    pub(super) fn remove_key_id(&self, key_triple: &KeyTriple) -> Result<[u8; 4]> {
+    pub(super) fn remove_key_id(&self, key_triple: &KeyTriple) -> Result<()> {
+        // We don't remove the key ID from the local IDs set as there are a lot of possible values.
         let locks = self.get_ordered_locks();
         let mut store_handle = locks.0.write().expect("Key store lock poisoned");
-        let mut local_ids_handle = locks.1.write().expect("Local ID lock poisoned");
         match store_handle.remove(key_triple) {
-            Ok(Some(key_info)) => {
-                let mut key_id = [0; 4];
-                if key_info.id.len() == 4 {
-                    key_id.copy_from_slice(&key_info.id);
-                } else {
-                    error!("Key info contained invalid key ID");
-                    return Err(ResponseStatus::PsaErrorDataCorrupt);
-                };
-                let _ = local_ids_handle.remove(&key_id);
-                Ok(key_id)
-            }
+            Ok(Some(_key_info)) => Ok(()),
             Ok(None) => {
                 error!("Did not find expected key info.");
                 Err(ResponseStatus::PsaErrorDoesNotExist)
@@ -98,12 +96,9 @@ impl Provider {
         }
     }
 
-    pub(super) fn key_info_exists(&self, key_triple: &KeyTriple) -> Result<bool> {
+    pub(super) fn key_info_exists(&self, key_triple: &KeyTriple) -> Result<()> {
         let locks = self.get_ordered_locks();
         let store_handle = locks.0.read().expect("Key store lock poisoned");
-        match store_handle.exists(key_triple) {
-            Ok(val) => Ok(val),
-            Err(string) => Err(key_info_managers::to_response_status(string)),
-        }
+        store_handle.already_exists(key_triple)
     }
 }

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -6,7 +6,7 @@
 //! through the Parsec interface.
 use super::Provide;
 use crate::authenticators::ApplicationName;
-use crate::key_info_managers::{self, KeyInfo, KeyTriple, ManageKeyInfo};
+use crate::key_info_managers::{KeyInfo, KeyTriple, ManageKeyInfo};
 use derivative::Derivative;
 use log::{error, info, trace, warn};
 use parsec_interface::operations::{list_clients, list_keys, list_providers::ProviderInfo};
@@ -20,7 +20,6 @@ use pkcs11::types::{CKF_OS_LOCKING_OK, CK_C_INITIALIZE_ARGS, CK_SLOT_ID};
 use pkcs11::Ctx;
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
-use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, RwLock};
 use utils::{KeyPairType, ReadWriteSession, Session};
@@ -217,7 +216,8 @@ impl Provide for Provider {
     ) -> Result<list_keys::Result> {
         let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
         Ok(list_keys::Result {
-            keys: key_info_managers::list_keys(store_handle.deref(), &app_name, ProviderID::Pkcs11)
+            keys: store_handle
+                .list_keys(&app_name, ProviderID::Pkcs11)
                 .map_err(|e| {
                     format_error!("Error occurred when fetching key information", e);
                     ResponseStatus::KeyInfoManagerError
@@ -228,7 +228,8 @@ impl Provide for Provider {
     fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
         let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
         Ok(list_clients::Result {
-            clients: key_info_managers::list_clients(store_handle.deref(), ProviderID::Pkcs11)
+            clients: store_handle
+                .list_clients(ProviderID::Pkcs11)
                 .map_err(|e| {
                     format_error!("Error occurred when fetching key information", e);
                     ResponseStatus::KeyInfoManagerError

--- a/src/providers/tpm/key_management.rs
+++ b/src/providers/tpm/key_management.rs
@@ -86,6 +86,9 @@ impl Provider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
+
+        store_handle.already_exists(&key_triple)?;
+
         let mut esapi_context = self
             .esapi_context
             .lock()
@@ -155,6 +158,7 @@ impl Provider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
+        store_handle.already_exists(&key_triple)?;
         let mut esapi_context = self
             .esapi_context
             .lock()
@@ -212,6 +216,7 @@ impl Provider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
+        store_handle.already_exists(&key_triple)?;
         let mut esapi_context = self
             .esapi_context
             .lock()

--- a/src/providers/tpm/key_management.rs
+++ b/src/providers/tpm/key_management.rs
@@ -87,7 +87,7 @@ impl Provider {
             .write()
             .expect("Key store lock poisoned");
 
-        store_handle.already_exists(&key_triple)?;
+        store_handle.does_not_exist(&key_triple)?;
 
         let mut esapi_context = self
             .esapi_context
@@ -158,7 +158,7 @@ impl Provider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
-        store_handle.already_exists(&key_triple)?;
+        store_handle.does_not_exist(&key_triple)?;
         let mut esapi_context = self
             .esapi_context
             .lock()
@@ -216,7 +216,7 @@ impl Provider {
             .key_info_store
             .write()
             .expect("Key store lock poisoned");
-        store_handle.already_exists(&key_triple)?;
+        store_handle.does_not_exist(&key_triple)?;
         let mut esapi_context = self
             .esapi_context
             .lock()

--- a/src/providers/tpm/mod.rs
+++ b/src/providers/tpm/mod.rs
@@ -6,7 +6,7 @@
 //! for their Parsec operations.
 use super::Provide;
 use crate::authenticators::ApplicationName;
-use crate::key_info_managers::{self, ManageKeyInfo};
+use crate::key_info_managers::ManageKeyInfo;
 use derivative::Derivative;
 use log::{info, trace};
 use parsec_interface::operations::{list_clients, list_keys, list_providers::ProviderInfo};
@@ -17,7 +17,6 @@ use parsec_interface::operations::{
 use parsec_interface::requests::{Opcode, ProviderID, ResponseStatus, Result};
 use std::collections::HashSet;
 use std::io::ErrorKind;
-use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, RwLock};
 use tss_esapi::constants::algorithm::{Cipher, HashingAlgorithm};
@@ -101,7 +100,8 @@ impl Provide for Provider {
     ) -> Result<list_keys::Result> {
         let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
         Ok(list_keys::Result {
-            keys: key_info_managers::list_keys(store_handle.deref(), &app_name, ProviderID::Tpm)
+            keys: store_handle
+                .list_keys(&app_name, ProviderID::Tpm)
                 .map_err(|e| {
                     format_error!("Error occurred when fetching key information", e);
                     ResponseStatus::KeyInfoManagerError
@@ -112,7 +112,8 @@ impl Provide for Provider {
     fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
         let store_handle = self.key_info_store.read().expect("Key store lock poisoned");
         Ok(list_clients::Result {
-            clients: key_info_managers::list_clients(store_handle.deref(), ProviderID::Tpm)
+            clients: store_handle
+                .list_clients(ProviderID::Tpm)
                 .map_err(|e| {
                     format_error!("Error occurred when fetching key information", e);
                     ResponseStatus::KeyInfoManagerError


### PR DESCRIPTION
on all providers.
Also make the core operations looping on all providers "best-effort" by
being infallible.

This is mainly for initial review/CI testing. This makes the assumption that [this comment](https://github.com/parallaxsecond/parsec/issues/323#issuecomment-764854039) is agreed but I can change later on.

Fix #323 
Fix #319 
Fix #149 
