### PR TITLE
Parsec PsaHashCompare operation implementation for CryptoAuthLib provider

### DIFF
--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -74,6 +74,7 @@ fn list_opcodes() {
 
     // Not that much to be tested ATM
     let _ = crypto_providers_cal.insert(Opcode::PsaHashCompute);
+    let _ = crypto_providers_cal.insert(Opcode::PsaHashCompare);
     let _ = crypto_providers_cal.insert(Opcode::PsaGenerateRandom);
 
     assert_eq!(

--- a/src/providers/cryptoauthlib/hash.rs
+++ b/src/providers/cryptoauthlib/hash.rs
@@ -39,7 +39,6 @@ impl Provider {
         &self,
         op: psa_hash_compare::Operation,
     ) -> Result<psa_hash_compare::Result> {
-        let op_hash = op.hash.to_vec();
         let alg_len = op.alg.hash_length();
         // calculate input hash
         let op_compute = psa_hash_compute::Operation {
@@ -49,13 +48,13 @@ impl Provider {
         match self.psa_hash_compute_internal(op_compute) {
             Ok(psa_hash_compute::Result { hash }) => {
                 // compare hashes length
-                if op_hash.len() != alg_len || hash.as_slice().len() != alg_len {
+                if op.hash.len() != alg_len || hash.len() != alg_len {
                     let error = ResponseStatus::PsaErrorInvalidArgument;
                     format_error!("Hash length comparison failed: ", error);
                     return Err(error);
                 }
                 // compare hashes
-                if op_hash != hash.as_slice() {
+                if op.hash != hash {
                     let error = ResponseStatus::PsaErrorInvalidSignature;
                     format_error!("Hash comparison failed: ", error);
                     return Err(error);
@@ -63,11 +62,7 @@ impl Provider {
                 // return result
                 Ok(psa_hash_compare::Result)
             }
-            _ => {
-                let error = ResponseStatus::PsaErrorGenericError;
-                format_error!("Hash computation failed ", error);
-                Err(error)
-            }
+            Err(error) => Err(error),
         }
     }
 }

--- a/src/providers/cryptoauthlib/hash.rs
+++ b/src/providers/cryptoauthlib/hash.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
 use parsec_interface::operations::psa_algorithm::Hash;
+use parsec_interface::operations::psa_hash_compare;
 use parsec_interface::operations::psa_hash_compute;
 use parsec_interface::requests::{ResponseStatus, Result};
 
@@ -29,6 +30,42 @@ impl Provider {
             _ => {
                 let error = ResponseStatus::PsaErrorNotSupported;
                 format_error!("Unsupported hash algorithm ", error);
+                Err(error)
+            }
+        }
+    }
+
+    pub(super) fn psa_hash_compare_internal(
+        &self,
+        op: psa_hash_compare::Operation,
+    ) -> Result<psa_hash_compare::Result> {
+        let op_hash = op.hash.to_vec();
+        let alg_len = op.alg.hash_length();
+        // calculate input hash
+        let op_compute = psa_hash_compute::Operation {
+            alg: op.alg,
+            input: op.input,
+        };
+        match self.psa_hash_compute_internal(op_compute) {
+            Ok(psa_hash_compute::Result { hash }) => {
+                // compare hashes length
+                if op_hash.len() != alg_len || hash.as_slice().len() != alg_len {
+                    let error = ResponseStatus::PsaErrorInvalidArgument;
+                    format_error!("Hash length comparison failed: ", error);
+                    return Err(error);
+                }
+                // compare hashes
+                if op_hash != hash.as_slice() {
+                    let error = ResponseStatus::PsaErrorInvalidSignature;
+                    format_error!("Hash comparison failed: ", error);
+                    return Err(error);
+                }
+                // return result
+                Ok(psa_hash_compare::Result)
+            }
+            _ => {
+                let error = ResponseStatus::PsaErrorGenericError;
+                format_error!("Hash computation failed ", error);
                 Err(error)
             }
         }

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -18,12 +18,16 @@ use std::io::{Error, ErrorKind};
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
-use parsec_interface::operations::{psa_generate_random, psa_hash_compute};
+use parsec_interface::operations::{psa_generate_random, psa_hash_compare, psa_hash_compute};
 
 mod generate_random;
 mod hash;
 
-const SUPPORTED_OPCODES: [Opcode; 2] = [Opcode::PsaHashCompute, Opcode::PsaGenerateRandom];
+const SUPPORTED_OPCODES: [Opcode; 3] = [
+    Opcode::PsaHashCompute,
+    Opcode::PsaHashCompare,
+    Opcode::PsaGenerateRandom,
+];
 
 /// CryptoAuthLib provider structure
 #[derive(Derivative)]
@@ -86,6 +90,14 @@ impl Provide for Provider {
     ) -> Result<psa_hash_compute::Result> {
         trace!("psa_hash_compute ingress");
         self.psa_hash_compute_internal(op)
+    }
+
+    fn psa_hash_compare(
+        &self,
+        op: psa_hash_compare::Operation,
+    ) -> Result<psa_hash_compare::Result> {
+        trace!("psa_hash_compare ingress");
+        self.psa_hash_compare_internal(op)
     }
 
     fn psa_generate_random(


### PR DESCRIPTION
An implementation of a psa_hash_compare callback inside a cryptoauthlibrary-provider responsible for PsaHashCompare operation/opcode using CryptoAuthentication Library API calls.