### PR TITLE
Add some cross-compilation tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Cargo seems to expect the -gcc variant instead of -ld
+
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/ci.sh
+++ b/ci.sh
@@ -218,6 +218,13 @@ fi
 echo "Build test"
 RUST_BACKTRACE=1 cargo build $FEATURES
 
+echo "Cross-compilation test"
+# Make sure the the provider install the correct targets via rustup in its Dockerfile.
+if [ "$PROVIDER_NAME" = "pkcs11" ] || [ "$PROVIDER_NAME" = "mbed-crypto" ]; then
+	RUST_BACKTRACE=1 cargo build $FEATURES --target armv7-unknown-linux-gnueabihf
+	RUST_BACKTRACE=1 cargo build $FEATURES --target aarch64-unknown-linux-gnu
+fi
+
 echo "Static checks"
 # On native target clippy or fmt might not be available.
 if rustup component list | grep -q fmt; then

--- a/e2e_tests/provider_cfg/mbed-crypto/Dockerfile
+++ b/e2e_tests/provider_cfg/mbed-crypto/Dockerfile
@@ -7,8 +7,16 @@ RUN apt-get update && \
 	# Needed for Open SSL
 	apt-get install -y pkg-config libssl-dev
 
+RUN apt -y install gcc-multilib
+RUN apt -y install gcc-arm-linux-gnueabihf
+RUN apt -y install gcc-aarch64-linux-gnu
+
 WORKDIR /tmp
 
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Adding the targets for the cross-compilation test
+RUN rustup target add armv7-unknown-linux-gnueabihf
+RUN rustup target add aarch64-unknown-linux-gnu

--- a/e2e_tests/provider_cfg/pkcs11/Dockerfile
+++ b/e2e_tests/provider_cfg/pkcs11/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update && \
 	# Needed for Open SSL
 	apt-get install -y pkg-config libssl-dev
 
+RUN apt -y install gcc-multilib
+RUN apt -y install gcc-arm-linux-gnueabihf
+RUN apt -y install gcc-aarch64-linux-gnu
+
 WORKDIR /tmp
 RUN git clone https://github.com/opendnssec/SoftHSMv2.git \
 	&& cd SoftHSMv2 \
@@ -27,6 +31,10 @@ RUN cd SoftHSMv2 \
 # Install Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Adding the targets for the cross-compilation test
+RUN rustup target add armv7-unknown-linux-gnueabihf
+RUN rustup target add aarch64-unknown-linux-gnu
 
 # Create a new token in a new slot. The slot number assigned will be random
 # and is found with the find_slot_number script.


### PR DESCRIPTION
Currently this is just focusing on the Mbed Crypto and PKCS11 provider
and with Armv8-A, Armv7-A on Linux.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>