### PR TITLE
Update docker registry for TPM2 images

### DIFF
--- a/e2e_tests/provider_cfg/all/Dockerfile
+++ b/e2e_tests/provider_cfg/all/Dockerfile
@@ -1,4 +1,4 @@
-FROM tpm2software/tpm2-tss:ubuntu-18.04
+FROM ghcr.io/tpm2-software/ubuntu-18.04:latest
 
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 

--- a/e2e_tests/provider_cfg/tpm/Dockerfile
+++ b/e2e_tests/provider_cfg/tpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM tpm2software/tpm2-tss:ubuntu-18.04
+FROM ghcr.io/tpm2-software/ubuntu-18.04:latest
 
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
 


### PR DESCRIPTION
This commit updates the tpm2-software Docker images that we use, as
described in a recent email [1].

[1]
https://lists.01.org/hyperkitty/list/tpm2@lists.01.org/thread/MJLXGAQ3RYXE7IDPYR5KKUDVBYTVT4GR/

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>