### PR TITLE
Enable code coverage for PKCS11, disable for TS

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -174,8 +174,8 @@ if [ "$PROVIDER_NAME" = "trusted-service" ] || [ "$PROVIDER_NAME" = "coverage" ]
 fi
 
 if [ "$PROVIDER_NAME" = "coverage" ]; then
-    PROVIDERS="mbed-crypto tpm trusted-service" # pkcs11 not supported because of a segfault when the service stops; see: https://github.com/parallaxsecond/parsec/issues/349
-    EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/providers/pkcs11/*"
+    PROVIDERS="mbed-crypto tpm pkcs11" # pkcs11 not supported because of a segfault when the service stops; see: https://github.com/parallaxsecond/parsec/issues/349
+    EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/providers/trusted_service/*"
 
     # Install tarpaulin
     cargo install cargo-tarpaulin


### PR DESCRIPTION
This commit enables PKCS11 provider code coverage generation and
disables TS provider coverage generation.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>