### PR TITLE
Update tss-esapi dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "parsec-service"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -1172,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dbef1777dd54deb1b10f60188733014a99297a54fbe9af7205a1532bbc6c52"
+checksum = "60838db8f40fb2e4f99dd6cfe5b3176c75b08dcbb169b2e51b8282be99e7e56a"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -1191,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi-sys"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472310244a6e6d234b32af2cc0ce3cd8e7d761a474647d85309d7892ce225c94"
+checksum = "1a8797d73bf711621fbf42432a67088b4d4eb5630bfb374b0a3611f4e2437279"
 dependencies = [
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-service"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Parsec Project Contributors"]
 description = "A language-agnostic API to secure services in a platform-agnostic way"
 license = "Apache-2.0"


### PR DESCRIPTION
This is to make `tss-esapi` build on docs.rs

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>