### PR TITLE
Implement a few fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh pkcs11
+        # Not running stress tests because they fail, presumably because of the same issue as #264
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
 
   tpm-provider:
     name: Integration tests using TPM provider

--- a/config.toml
+++ b/config.toml
@@ -88,14 +88,22 @@ manager_type = "OnDisk"
 
 # (Required) Provider configurations.
 # Defined as an array of tables: https://github.com/toml-lang/toml#user-content-array-of-tables
-# The order in which providers below are declared matters: providers should be listed in terms
-# of priority, the highest priority provider being declared first in this file.
-# The first provider will be used as default provider by the Parsec clients.
+# IMPORTANT: The order in which providers below are declared matters: providers should be listed 
+# in terms of priority, the highest priority provider being declared first in this file.
+# The first provider will be used as default provider by the Parsec clients. See below example
+# configurations for the different providers supported by the Parsec service.
+
+# Example of an Mbed Crypto provider configuration.
 [[provider]]
 # (Required) Type of provider.
 provider_type = "MbedCrypto"
 
 # (Required) Name of key info manager that will support this provider.
+# NOTE: The key info manager only holds mappings between Parsec key name and Mbed Crypto ID, along
+# with other metadata associated with the key. The keys themselves, however, are stored by the Mbed
+# Crypto library by default within the working directory of the service, NOT in the same location
+# as the mappings mentioned previously. If you want the keys to be persisted across reboots, ensure
+# that the working directory is not temporary.
 key_info_manager = "on-disk-manager"
 
 # Example of a PKCS 11 provider configuration
@@ -158,3 +166,11 @@ key_info_manager = "on-disk-manager"
 #bus = 1
 # (Optional - required for i2c) i2c bus baud rate
 #baud = 400000
+
+# Example of a Trusted Service provider configuration.
+#[[provider]]
+# (Required) Type of provider.
+#provider_type = "TrustedService"
+
+# (Required) Name of key info manager that will support this provider.
+#key_info_manager = "on-disk-manager"

--- a/e2e_tests/docker_image/Dockerfile
+++ b/e2e_tests/docker_image/Dockerfile
@@ -44,7 +44,7 @@ RUN rm -rf $ibmtpm_name/src $ibmtpm_name.tar.gz
 WORKDIR /tmp
 RUN git clone https://github.com/opendnssec/SoftHSMv2.git \
 	&& cd SoftHSMv2 \
-	&& git reset --hard 20a53bd083a6134ce2230f80edda5dc8be0366bd
+	&& git reset --hard 35938595f83923504751b40535570342f706a634
 
 RUN cd SoftHSMv2 \
 	&& sh autogen.sh \
@@ -74,10 +74,11 @@ RUN cd nanopb-0.4.4-linux-x86 \
 RUN rm -rf nanopb-0.4.4-linux-x86 nanopb-0.4.4-linux-x86.tar.gz
 
 # Install mock Trusted Services
-RUN git clone https://git.trustedfirmware.org/TS/trusted-services.git --branch integration
+RUN git clone https://git.trustedfirmware.org/TS/trusted-services.git --branch integration \
+	&& cd trusted-services \
+	&& git reset --hard 840696b9ac1ba6aa9ccd024ca9dc3b4be12bf837
 # Install correct python dependencies
 RUN pip3 install -r trusted-services/requirements.txt
-RUN pip3 uninstall -y python3-protobuf protobuf && pip3 install protobuf && pip3 install --upgrade protobuf
 RUN cd trusted-services/deployments/libts/linux-pc/ \
 	&& cmake . \
 	&& make \

--- a/src/providers/trusted_service/context/key_management.rs
+++ b/src/providers/trusted_service/context/key_management.rs
@@ -88,7 +88,7 @@ impl Context {
     /// format.
     pub fn export_public_key(&self, id: u32) -> Result<Vec<u8>, Error> {
         info!("Handling ExportPublicKey request");
-        Ok(self.send_request_with_key(ExportPublicKeyIn::default(), id)?)
+        self.send_request_with_key(ExportPublicKeyIn::default(), id)
     }
 
     /// Destroy a key given its ID.


### PR DESCRIPTION
This commit implements fixes for a few issues:
* PKCS11 provider stress tests are disables, as they've been causing a
lot of errors (presumably still due to SoftHSM2 locking issues; see
* The Docker image used for testing was uptaded to load a newer version
of SoftHSM2 and to lock in the Trusted Services version.
* Some comments were added in config.toml to expand on the functioning
of the Mbed Crypto provider, and to add the TS provider config. Covers #373 partially 
* Small lint issue was fixed in Trusted Service provider
