### PR TITLE
Import newest versions of cryptoki and tss-esapi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   all-providers:
@@ -43,6 +43,34 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run the container to execute the test script
         run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh trusted-service
+
+  cross-compilation:
+    # Currently only the Mbed Crypto and PKCS 11 providers are tested as the other ones need to cross-compile other libraries.
+    name: Cross-compile Parsec to various targets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: armv7-unknown-linux-gnueabihf
+        run: |
+          rustup target add armv7-unknown-linux-gnueabihf
+          sudo apt install -y gcc-multilib
+          sudo apt install -y gcc-arm-linux-gnueabihf
+          cargo build --features "pkcs11-provider, mbed-crypto-provider, all-authenticators" --target armv7-unknown-linux-gnueabihf
+      - name: aarch64-unknown-linux-gnu
+        run: |
+          rustup target add aarch64-unknown-linux-gnu
+          sudo apt install -y gcc-aarch64-linux-gnu
+          cargo build --features "pkcs11-provider, mbed-crypto-provider, all-authenticators" --target aarch64-unknown-linux-gnu
+      - name: i686-unknown-linux-gnu
+        run: |
+          sudo apt install -y gcc-multilib libc6-dev-i386
+          rustup target add i686-unknown-linux-gnu
+          cargo build --features "pkcs11-provider, mbed-crypto-provider, all-authenticators" --target i686-unknown-linux-gnu
 
   links:
     name: Check links

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,8 @@ dependencies = [
 
 [[package]]
 name = "cryptoki"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee26477a11a3a0af4c733799495a2399c9fd864f454b4c37f58c7b4d2842d87"
+version = "0.1.1"
+source = "git+https://github.com/parallaxsecond/rust-cryptoki?rev=850b826b631df354553bf62757f35cd394b3dfff#850b826b631df354553bf62757f35cd394b3dfff"
 dependencies = [
  "cryptoki-sys",
  "derivative",
@@ -220,11 +219,11 @@ dependencies = [
 
 [[package]]
 name = "cryptoki-sys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712c566c87e4c7ef3af69411026dd107f931787c2d3f790b7e6c1f981d6e916"
+version = "0.1.1"
+source = "git+https://github.com/parallaxsecond/rust-cryptoki?rev=850b826b631df354553bf62757f35cd394b3dfff#850b826b631df354553bf62757f35cd394b3dfff"
 dependencies = [
  "libloading",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1102,6 +1101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,8 +1179,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi"
 version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60838db8f40fb2e4f99dd6cfe5b3176c75b08dcbb169b2e51b8282be99e7e56a"
+source = "git+https://github.com/parallaxsecond/rust-tss-esapi?rev=2e0ba0aa2c5aa928d960b26458778acde448981a#2e0ba0aa2c5aa928d960b26458778acde448981a"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -1193,10 +1197,10 @@ dependencies = [
 [[package]]
 name = "tss-esapi-sys"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8797d73bf711621fbf42432a67088b4d4eb5630bfb374b0a3611f4e2437279"
+source = "git+https://github.com/parallaxsecond/rust-tss-esapi?rev=2e0ba0aa2c5aa928d960b26458778acde448981a#2e0ba0aa2c5aa928d960b26458778acde448981a"
 dependencies = [
  "pkg-config",
+ "target-lexicon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ toml = "0.5.8"
 serde = { version = "1.0.123", features = ["derive"] }
 env_logger = "0.8.3"
 log = { version = "0.4.14", features = ["serde"] }
-cryptoki = { version = "0.1.0", optional = true, features = ["psa-crypto-conversions"] }
+cryptoki = { git = "https://github.com/parallaxsecond/rust-cryptoki", rev = "850b826b631df354553bf62757f35cd394b3dfff", optional = true, features = ["psa-crypto-conversions"] }
 picky-asn1-der = { version = "0.2.4", optional = true }
 picky-asn1 = { version = "0.3.1", optional = true }
-tss-esapi = { version = "5.0.0", optional = true }
+tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi", rev = "2e0ba0aa2c5aa928d960b26458778acde448981a", optional = true }
 bincode = "1.3.1"
 structopt = "0.3.21"
 derivative = "2.2.0"

--- a/ci.sh
+++ b/ci.sh
@@ -219,13 +219,6 @@ fi
 echo "Build test"
 RUST_BACKTRACE=1 cargo build $FEATURES
 
-echo "Cross-compilation test"
-# Make sure the the provider install the correct targets via rustup in its Dockerfile.
-if [ "$PROVIDER_NAME" = "pkcs11" ] || [ "$PROVIDER_NAME" = "mbed-crypto" ]; then
-	RUST_BACKTRACE=1 cargo build $FEATURES --target armv7-unknown-linux-gnueabihf
-	RUST_BACKTRACE=1 cargo build $FEATURES --target aarch64-unknown-linux-gnu
-fi
-
 echo "Static checks"
 # On native target clippy or fmt might not be available.
 if rustup component list | grep -q fmt; then

--- a/e2e_tests/docker_image/Dockerfile
+++ b/e2e_tests/docker_image/Dockerfile
@@ -6,9 +6,6 @@ RUN apt update
 RUN apt install -y autoconf-archive libcmocka0 libcmocka-dev procps
 RUN apt install -y iproute2 build-essential git pkg-config gcc libtool automake libssl-dev uthash-dev doxygen libjson-c-dev
 RUN apt install -y --fix-missing wget python3 cmake clang
-RUN apt install -y gcc-multilib
-RUN apt install -y gcc-arm-linux-gnueabihf
-RUN apt install -y gcc-aarch64-linux-gnu
 RUN apt install -y libini-config-dev libcurl4-openssl-dev tpm2-tools curl libgcc1
 RUN apt install -y python3-distutils libclang-dev protobuf-compiler python3-pip
 
@@ -101,10 +98,6 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Install the wrappers for the Rust binaries installed earlier
 COPY _exec_wrapper /usr/local/bin/
 RUN ls /opt/rust/bin | xargs -n1 -I% ln -s /usr/local/bin/_exec_wrapper /usr/local/bin/$(basename %)
-
-# Adding the targets for the cross-compilation tests
-RUN rustup target add armv7-unknown-linux-gnueabihf
-RUN rustup target add aarch64-unknown-linux-gnu
 
 # Add users for multitenancy tests
 RUN useradd -m parsec-client-1


### PR DESCRIPTION
Imported as git dependencies to test cross-compilation of other targets.
The `Dockerfile` has been updated and changed to be built just to be tested on this CI. We can update the Docker image if that works.