### PR TITLE
Fix ownership of ibmtpm folder

### DIFF
--- a/e2e_tests/docker_image/Dockerfile
+++ b/e2e_tests/docker_image/Dockerfile
@@ -19,23 +19,21 @@ RUN cd tpm2-tss \
 	&& make -j$(nproc) \
 	&& make install \
 	&& ldconfig
-
 RUN rm -rf tpm2-tss
 
-ARG ibmtpm_name=ibmtpm1637
-
 # Download and install software TPM
+ARG ibmtpm_name=ibmtpm1637
 RUN wget -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
 RUN sha256sum $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327
 RUN mkdir -p $ibmtpm_name \
-	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
+	&& tar -xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
+	&& chown -R root:root $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
 RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
 RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
-RUN rm -rf $ibmtpm_name/src $ibmtpm_name.tar.gz
-
+RUN rm -rf $ibmtpm_name/src $ibmtpm_name
 
 # Download and install SoftHSMv2
 WORKDIR /tmp


### PR DESCRIPTION
CircleCI build is failing because the ibmtpm folder ends up with weird ownership values (user and group IDs are 300k+)