### PR TITLE
Isolate config logic and add e2e config tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The content of the config.rs file should not change in a breaking way.
+# See https://github.com/parallaxsecond/parsec/issues/393 for details.
+src/utils/config.rs   @parallaxsecond/admin

--- a/ci.sh
+++ b/ci.sh
@@ -82,6 +82,10 @@ run_key_mappings_tests() {
     RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml key_mappings
 }
 
+# During end-to-end tests, Parsec is configured with the socket in /tmp/
+# Individual tests might change that, but set the default after.
+export PARSEC_SERVICE_ENDPOINT="unix:/tmp/parsec.sock"
+
 # Parse arguments
 NO_CARGO_CLEAN=
 NO_STRESS_TEST=

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -23,13 +23,8 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
     Attributes, EccFamily, Lifetime, Policy, Type, UsageFlags,
 };
 use parsec_client::core::interface::requests::{Opcode, ProviderId, ResponseStatus, Result};
-use parsec_client::core::ipc_handler::unix_socket;
 use parsec_client::error::Error;
 use std::collections::HashSet;
-use std::time::Duration;
-
-const TEST_SOCKET_PATH: &str = "/tmp/parsec.sock";
-const TEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Client structure automatically choosing a provider and high-level operation functions.
 #[derive(Debug)]
@@ -58,20 +53,8 @@ impl TestClient {
             env_logger::try_init();
         }
 
-        let mut basic_client = BasicClient::new_naked();
-
-        let ipc_handler =
-            unix_socket::Handler::new(TEST_SOCKET_PATH.into(), Some(TEST_TIMEOUT)).unwrap();
-        basic_client.set_ipc_handler(Box::from(ipc_handler));
-        basic_client.set_timeout(Some(Duration::from_secs(10)));
-
-        basic_client.set_default_provider().unwrap();
-        basic_client
-            .set_default_auth(Some(String::from("root")))
-            .unwrap();
-
         TestClient {
-            basic_client,
+            basic_client: BasicClient::new(Some(String::from("root"))).unwrap(),
             created_keys: Some(HashSet::new()),
         }
     }

--- a/e2e_tests/tests/all_providers/config/tomls/various_field_check.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/various_field_check.toml
@@ -1,0 +1,28 @@
+[core_settings]
+allow_root = true
+thread_pool_size = 2
+idle_listener_sleep_duration = 12
+log_level = "trace"
+log_timestamp = true
+# 1 KiB max for requests
+body_len_limit = 1024
+log_error_details = true
+# 1 KiB max for responses
+buffer_size_limit = 1024
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 202
+socket_path = "/tmp/toto.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "I-want-to-speak-to-the-manager"
+manager_type = "OnDisk"
+store_path = "/tmp/the-mappings"
+
+[[provider]]
+provider_type = "MbedCrypto"
+key_info_manager = "I-want-to-speak-to-the-manager"

--- a/src/authenticators/direct_authenticator/mod.rs
+++ b/src/authenticators/direct_authenticator/mod.rs
@@ -8,8 +8,9 @@
 //! This authenticator does not offer any security value and should only be used in environments
 //! where all the clients and the service are mutually trustworthy.
 
-use super::{Admin, AdminList, Application, Authenticate};
+use super::{AdminList, Application, Authenticate};
 use crate::front::listener::ConnectionMetadata;
+use crate::utils::config::Admin;
 use log::error;
 use parsec_interface::operations::list_authenticators;
 use parsec_interface::requests::request::RequestAuth;
@@ -73,7 +74,7 @@ impl Authenticate for DirectAuthenticator {
 
 #[cfg(test)]
 mod test {
-    use super::super::{Admin, Authenticate};
+    use super::super::Authenticate;
     use super::DirectAuthenticator;
     use crate::authenticators::ApplicationName;
     use parsec_interface::requests::request::RequestAuth;
@@ -126,11 +127,9 @@ mod test {
     #[test]
     fn admin_check() {
         let admin_name = String::from("admin_name");
+        let admin = toml::from_str(&format!("name = '{}'", admin_name)).unwrap();
         let authenticator = DirectAuthenticator {
-            admins: vec![Admin {
-                name: admin_name.clone(),
-            }]
-            .into(),
+            admins: vec![admin].into(),
         };
 
         let app_name = "app_name".to_string();

--- a/src/authenticators/mod.rs
+++ b/src/authenticators/mod.rs
@@ -22,12 +22,11 @@ pub mod direct_authenticator;
 pub mod unix_peer_credentials_authenticator;
 
 use crate::front::listener::ConnectionMetadata;
+use crate::utils::config::Admin;
 use parsec_interface::operations::list_authenticators;
 use parsec_interface::requests::request::RequestAuth;
 use parsec_interface::requests::Result;
-use serde::Deserialize;
 use std::ops::Deref;
-use zeroize::Zeroize;
 
 /// String wrapper for app names
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -111,36 +110,6 @@ impl From<Application> for ApplicationName {
 impl std::fmt::Display for ApplicationName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
-    }
-}
-
-/// Authenticator configuration structure
-#[derive(Deserialize, Debug, Zeroize)]
-#[zeroize(drop)]
-#[serde(tag = "auth_type")]
-pub enum AuthenticatorConfig {
-    /// Direct authentication
-    Direct {
-        /// List of service admins
-        admins: Option<Vec<Admin>>,
-    },
-    /// Unix Peer Credentials authentication
-    UnixPeerCredentials {
-        /// List of service admins
-        admins: Option<Vec<Admin>>,
-    },
-}
-
-/// Structure defining the properties of a service admin
-#[derive(Deserialize, Debug, Zeroize, Clone)]
-#[zeroize(drop)]
-pub struct Admin {
-    name: String,
-}
-
-impl Admin {
-    fn name(&self) -> &str {
-        &self.name
     }
 }
 

--- a/src/authenticators/unix_peer_credentials_authenticator/mod.rs
+++ b/src/authenticators/unix_peer_credentials_authenticator/mod.rs
@@ -9,8 +9,9 @@
 //!
 //! Currently, the stringified UID is used as the application name.
 
-use super::{Admin, AdminList, Application, Authenticate};
+use super::{AdminList, Application, Authenticate};
 use crate::front::listener::ConnectionMetadata;
+use crate::utils::config::Admin;
 use log::error;
 use parsec_interface::operations::list_authenticators;
 use parsec_interface::requests::request::RequestAuth;
@@ -98,7 +99,7 @@ impl Authenticate for UnixPeerCredentialsAuthenticator {
 
 #[cfg(test)]
 mod test {
-    use super::super::{Admin, Authenticate};
+    use super::super::Authenticate;
     use super::UnixPeerCredentialsAuthenticator;
     use crate::authenticators::ApplicationName;
     use crate::front::domain_socket::peer_credentials;
@@ -227,11 +228,9 @@ mod test {
             peer_credentials::peer_cred(&_sock_b).unwrap(),
         );
 
+        let admin = toml::from_str(&format!("name = '{}'", get_current_uid())).unwrap();
         let authenticator = UnixPeerCredentialsAuthenticator {
-            admins: vec![Admin {
-                name: get_current_uid().to_string(),
-            }]
-            .into(),
+            admins: vec![admin].into(),
         };
 
         let req_auth_data = cred_a.uid.to_le_bytes().to_vec();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -41,7 +41,7 @@
 
 use anyhow::Result;
 use log::{info, trace};
-use parsec_service::utils::{ServiceBuilder, ServiceConfig};
+use parsec_service::utils::{config::ServiceConfig, ServiceBuilder};
 use signal_hook::{consts::SIGHUP, consts::SIGINT, consts::SIGTERM, flag};
 use std::io::{Error, ErrorKind};
 use std::sync::{

--- a/src/front/listener.rs
+++ b/src/front/listener.rs
@@ -6,7 +6,6 @@
 //! trait acts as an interface for the operations that must be supported by any implementation
 //! of the IPC mechanism used as a Parsec front.
 use derivative::Derivative;
-use serde::Deserialize;
 use std::time::Duration;
 
 /// This trait is created to allow the iterator returned by incoming to iterate over a trait object
@@ -14,24 +13,6 @@ use std::time::Duration;
 pub trait ReadWrite: std::io::Read + std::io::Write {}
 // Automatically implements ReadWrite for all types that implement Read and Write.
 impl<T: std::io::Read + std::io::Write> ReadWrite for T {}
-
-/// Type of the Listener used
-#[derive(Copy, Clone, Deserialize, Debug)]
-pub enum ListenerType {
-    /// Listener using Unix Domain Socket
-    DomainSocket,
-}
-
-/// Configuration of the Listener
-#[derive(Clone, Deserialize, Debug)]
-pub struct ListenerConfig {
-    /// Type of the Listener
-    pub listener_type: ListenerType,
-    /// Timeout of the Listener before the connection errors out (in milliseconds)
-    pub timeout: u64,
-    /// Path of the Unix Domain socket
-    pub socket_path: Option<String>,
-}
 
 /// Specifies metadata associated with a connection, if any.
 #[derive(Copy, Clone, Debug)]

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -8,6 +8,7 @@
 //! means but it has to be persistent.
 
 use crate::authenticators::ApplicationName;
+use crate::utils::config::{KeyInfoManagerConfig, KeyInfoManagerType};
 use anyhow::Result;
 use derivative::Derivative;
 use parsec_interface::operations::psa_key_attributes::Attributes;
@@ -19,24 +20,6 @@ use std::sync::{Arc, RwLock};
 use zeroize::Zeroize;
 
 pub mod on_disk_manager;
-
-/// Type of the KeyInfoManager
-#[derive(Copy, Clone, Deserialize, Debug)]
-pub enum KeyInfoManagerType {
-    /// KeyInfoManager storing the mappings on disk
-    OnDisk,
-}
-
-/// KeyInfoManager configuration
-#[derive(Deserialize, Debug)]
-pub struct KeyInfoManagerConfig {
-    /// Name of the KeyInfoManager
-    pub name: String,
-    /// Type of the KeyInfoManager
-    pub manager_type: KeyInfoManagerType,
-    /// Path used to store the mappings
-    pub store_path: Option<String>,
-}
 
 /// This structure corresponds to a unique identifier of the key. It is used internally by the Key
 /// ID manager to refer to a key.

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -7,10 +7,8 @@
 //! functionality in the underlying hardware which allows the PSA Crypto operations to be
 //! backed by a hardware root of trust.
 use log::trace;
-use parsec_interface::requests::{Opcode, ProviderId};
-use serde::Deserialize;
+use parsec_interface::requests::Opcode;
 use std::collections::HashSet;
-use zeroize::Zeroize;
 
 pub mod core;
 
@@ -30,106 +28,6 @@ pub mod cryptoauthlib;
 
 #[cfg(feature = "trusted-service-provider")]
 pub mod trusted_service;
-
-/// Provider configuration structure
-/// For providers configs in Parsec config.toml we use a format similar
-/// to the one described in the Internally Tagged Enum representation
-/// where "provider_type" is the tag field. For details see:
-/// https://serde.rs/enum-representations.html
-#[derive(Deserialize, Debug, Zeroize)]
-#[zeroize(drop)]
-#[serde(tag = "provider_type")]
-pub enum ProviderConfig {
-    /// Mbed Crypto provider configuration
-    MbedCrypto {
-        /// Name of the Key Info Manager to use
-        key_info_manager: String,
-    },
-    /// PKCS 11 provider configuration
-    Pkcs11 {
-        /// Name of the Key Info Manager to use
-        key_info_manager: String,
-        /// Path of the PKCS 11 library
-        library_path: String,
-        /// Slot number to use
-        slot_number: usize,
-        /// User Pin
-        user_pin: Option<String>,
-        /// Control whether public key operations are performed in software
-        software_public_operations: Option<bool>,
-    },
-    /// TPM provider configuration
-    Tpm {
-        /// Name of the Key Info Manager to use
-        key_info_manager: String,
-        /// TCTI to use with the provider
-        tcti: String,
-        /// Owner Hierarchy Authentication
-        owner_hierarchy_auth: String,
-    },
-    /// Microchip CryptoAuthentication Library provider configuration
-    CryptoAuthLib {
-        /// Name of the Key Info Manager to use
-        key_info_manager: String,
-        /// ATECC Device type
-        device_type: String,
-        /// Interface type
-        iface_type: String,
-        /// Wake delay
-        wake_delay: Option<u16>,
-        /// Number of rx retries
-        rx_retries: Option<i32>,
-        /// I2C slave address
-        slave_address: Option<u8>,
-        /// I2C bus
-        bus: Option<u8>,
-        /// I2C baud rate
-        baud: Option<u32>,
-    },
-    /// Trusted Service provider configuration
-    TrustedService {
-        /// Name of Key Info Manager to use
-        key_info_manager: String,
-    },
-}
-
-impl ProviderConfig {
-    /// Get the name of the Key Info Manager in the provider configuration
-    pub fn key_info_manager(&self) -> &String {
-        match *self {
-            ProviderConfig::MbedCrypto {
-                ref key_info_manager,
-                ..
-            } => key_info_manager,
-            ProviderConfig::Pkcs11 {
-                ref key_info_manager,
-                ..
-            } => key_info_manager,
-            ProviderConfig::Tpm {
-                ref key_info_manager,
-                ..
-            } => key_info_manager,
-            ProviderConfig::CryptoAuthLib {
-                ref key_info_manager,
-                ..
-            } => key_info_manager,
-            ProviderConfig::TrustedService {
-                ref key_info_manager,
-                ..
-            } => key_info_manager,
-        }
-    }
-    /// Get the Provider ID of the provider
-    pub fn provider_id(&self) -> ProviderId {
-        match *self {
-            ProviderConfig::MbedCrypto { .. } => ProviderId::MbedCrypto,
-            ProviderConfig::Pkcs11 { .. } => ProviderId::Pkcs11,
-            ProviderConfig::Tpm { .. } => ProviderId::Tpm,
-            ProviderConfig::CryptoAuthLib { .. } => ProviderId::CryptoAuthLib,
-            ProviderConfig::TrustedService { .. } => ProviderId::TrustedService,
-        }
-    }
-}
 
 use crate::authenticators::ApplicationName;
 use parsec_interface::operations::{

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1,0 +1,204 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! Structures for the Parsec configuration file
+
+use log::LevelFilter;
+use parsec_interface::requests::ProviderId;
+use serde::Deserialize;
+use zeroize::Zeroize;
+
+/// Core settings
+///
+/// See the config.toml file for a description of each field.
+#[derive(Copy, Clone, Deserialize, Debug)]
+#[allow(missing_docs)]
+pub struct CoreSettings {
+    pub thread_pool_size: Option<usize>,
+    pub idle_listener_sleep_duration: Option<u64>,
+    pub log_level: Option<LevelFilter>,
+    pub log_timestamp: Option<bool>,
+    pub body_len_limit: Option<usize>,
+    pub log_error_details: Option<bool>,
+    pub allow_root: Option<bool>,
+    pub buffer_size_limit: Option<usize>,
+}
+
+/// Type of the Listener used
+#[derive(Copy, Clone, Deserialize, Debug)]
+pub enum ListenerType {
+    /// Listener using Unix Domain Socket
+    DomainSocket,
+}
+
+/// Configuration of the Listener
+#[derive(Clone, Deserialize, Debug)]
+pub struct ListenerConfig {
+    /// Type of the Listener
+    pub listener_type: ListenerType,
+    /// Timeout of the Listener before the connection errors out (in milliseconds)
+    pub timeout: u64,
+    /// Path of the Unix Domain socket
+    pub socket_path: Option<String>,
+}
+
+/// Authenticator configuration structure
+#[derive(Deserialize, Debug, Zeroize)]
+#[zeroize(drop)]
+#[serde(tag = "auth_type")]
+pub enum AuthenticatorConfig {
+    /// Direct authentication
+    Direct {
+        /// List of service admins
+        admins: Option<Vec<Admin>>,
+    },
+    /// Unix Peer Credentials authentication
+    UnixPeerCredentials {
+        /// List of service admins
+        admins: Option<Vec<Admin>>,
+    },
+}
+
+/// Structure defining the properties of a service admin
+#[derive(Deserialize, Debug, Zeroize, Clone)]
+#[zeroize(drop)]
+pub struct Admin {
+    name: String,
+}
+
+impl Admin {
+    /// Give the application name of the admin
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Type of the KeyInfoManager
+#[derive(Copy, Clone, Deserialize, Debug)]
+pub enum KeyInfoManagerType {
+    /// KeyInfoManager storing the mappings on disk
+    OnDisk,
+}
+
+/// KeyInfoManager configuration
+#[derive(Deserialize, Debug)]
+pub struct KeyInfoManagerConfig {
+    /// Name of the KeyInfoManager
+    pub name: String,
+    /// Type of the KeyInfoManager
+    pub manager_type: KeyInfoManagerType,
+    /// Path used to store the mappings
+    pub store_path: Option<String>,
+}
+
+/// Provider configuration structure
+/// For providers configs in Parsec config.toml we use a format similar
+/// to the one described in the Internally Tagged Enum representation
+/// where "provider_type" is the tag field. For details see:
+/// https://serde.rs/enum-representations.html
+#[derive(Deserialize, Debug, Zeroize)]
+#[zeroize(drop)]
+#[serde(tag = "provider_type")]
+pub enum ProviderConfig {
+    /// Mbed Crypto provider configuration
+    MbedCrypto {
+        /// Name of the Key Info Manager to use
+        key_info_manager: String,
+    },
+    /// PKCS 11 provider configuration
+    Pkcs11 {
+        /// Name of the Key Info Manager to use
+        key_info_manager: String,
+        /// Path of the PKCS 11 library
+        library_path: String,
+        /// Slot number to use
+        slot_number: usize,
+        /// User Pin
+        user_pin: Option<String>,
+        /// Control whether public key operations are performed in software
+        software_public_operations: Option<bool>,
+    },
+    /// TPM provider configuration
+    Tpm {
+        /// Name of the Key Info Manager to use
+        key_info_manager: String,
+        /// TCTI to use with the provider
+        tcti: String,
+        /// Owner Hierarchy Authentication
+        owner_hierarchy_auth: String,
+    },
+    /// Microchip CryptoAuthentication Library provider configuration
+    CryptoAuthLib {
+        /// Name of the Key Info Manager to use
+        key_info_manager: String,
+        /// ATECC Device type
+        device_type: String,
+        /// Interface type
+        iface_type: String,
+        /// Wake delay
+        wake_delay: Option<u16>,
+        /// Number of rx retries
+        rx_retries: Option<i32>,
+        /// I2C slave address
+        slave_address: Option<u8>,
+        /// I2C bus
+        bus: Option<u8>,
+        /// I2C baud rate
+        baud: Option<u32>,
+    },
+    /// Trusted Service provider configuration
+    TrustedService {
+        /// Name of Key Info Manager to use
+        key_info_manager: String,
+    },
+}
+
+impl ProviderConfig {
+    /// Get the name of the Key Info Manager in the provider configuration
+    pub fn key_info_manager(&self) -> &String {
+        match *self {
+            ProviderConfig::MbedCrypto {
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
+            ProviderConfig::Pkcs11 {
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
+            ProviderConfig::Tpm {
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
+            ProviderConfig::CryptoAuthLib {
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
+            ProviderConfig::TrustedService {
+                ref key_info_manager,
+                ..
+            } => key_info_manager,
+        }
+    }
+    /// Get the Provider ID of the provider
+    pub fn provider_id(&self) -> ProviderId {
+        match *self {
+            ProviderConfig::MbedCrypto { .. } => ProviderId::MbedCrypto,
+            ProviderConfig::Pkcs11 { .. } => ProviderId::Pkcs11,
+            ProviderConfig::Tpm { .. } => ProviderId::Tpm,
+            ProviderConfig::CryptoAuthLib { .. } => ProviderId::CryptoAuthLib,
+            ProviderConfig::TrustedService { .. } => ProviderId::TrustedService,
+        }
+    }
+}
+
+/// Configuration of Parsec
+///
+/// See the config.toml file for a description of each field.
+#[derive(Deserialize, Debug)]
+#[allow(missing_docs)]
+pub struct ServiceConfig {
+    pub core_settings: CoreSettings,
+    pub listener: ListenerConfig,
+    pub authenticator: AuthenticatorConfig,
+    pub key_manager: Option<Vec<KeyInfoManagerConfig>>,
+    pub provider: Option<Vec<ProviderConfig>>,
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,8 +1,9 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! Service utilities
+pub mod config;
 mod global_config;
 mod service_builder;
 
 pub use global_config::GlobalConfig;
-pub use service_builder::{CoreSettings, ServiceBuilder, ServiceConfig};
+pub use service_builder::ServiceBuilder;

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -5,24 +5,26 @@
 //! The service builder is required to bootstrap all the components based on a
 //! provided configuration.
 use super::global_config::GlobalConfigBuilder;
-use crate::authenticators::{Authenticate, AuthenticatorConfig};
+use crate::authenticators::Authenticate;
 use crate::back::{
     backend_handler::{BackEndHandler, BackEndHandlerBuilder},
     dispatcher::DispatcherBuilder,
 };
-use crate::front::listener::{ListenerConfig, ListenerType};
 use crate::front::{
     domain_socket::DomainSocketListenerBuilder, front_end::FrontEndHandler,
     front_end::FrontEndHandlerBuilder, listener::Listen,
 };
-use crate::key_info_managers::{KeyInfoManagerConfig, KeyInfoManagerFactory};
-use crate::providers::{core::ProviderBuilder as CoreProviderBuilder, Provide, ProviderConfig};
+use crate::key_info_managers::KeyInfoManagerFactory;
+use crate::providers::{core::ProviderBuilder as CoreProviderBuilder, Provide};
+use crate::utils::config::{
+    AuthenticatorConfig, KeyInfoManagerConfig, ListenerConfig, ListenerType, ProviderConfig,
+    ServiceConfig,
+};
 use anyhow::Result;
-use log::{error, warn, LevelFilter};
+use log::{error, warn};
 use parsec_interface::operations_protobuf::ProtobufConverter;
 use parsec_interface::requests::AuthType;
 use parsec_interface::requests::{BodyType, ProviderId};
-use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::sync::Arc;
@@ -65,35 +67,6 @@ pub const DEFAULT_BUFFER_SIZE_LIMIT: usize = 1 << 20;
 
 type Provider = Arc<dyn Provide + Send + Sync>;
 type Authenticator = Box<dyn Authenticate + Send + Sync>;
-
-/// Core settings
-///
-/// See the config.toml file for a description of each field.
-#[derive(Copy, Clone, Deserialize, Debug)]
-#[allow(missing_docs)]
-pub struct CoreSettings {
-    pub thread_pool_size: Option<usize>,
-    pub idle_listener_sleep_duration: Option<u64>,
-    pub log_level: Option<LevelFilter>,
-    pub log_timestamp: Option<bool>,
-    pub body_len_limit: Option<usize>,
-    pub log_error_details: Option<bool>,
-    pub allow_root: Option<bool>,
-    pub buffer_size_limit: Option<usize>,
-}
-
-/// Configuration of Parsec
-///
-/// See the config.toml file for a description of each field.
-#[derive(Deserialize, Debug)]
-#[allow(missing_docs)]
-pub struct ServiceConfig {
-    pub core_settings: CoreSettings,
-    pub listener: ListenerConfig,
-    pub authenticator: AuthenticatorConfig,
-    pub key_manager: Option<Vec<KeyInfoManagerConfig>>,
-    pub provider: Option<Vec<ProviderConfig>>,
-}
 
 /// Service component builder and assembler
 ///


### PR DESCRIPTION
This commit puts the serialised version of the config file into one
single Rust file. This file is put under a CODEOWNERS rule so that it is
carefully check for breaking changes.

It also adds one end-to-end config test checking the behaviour of
various fields.

See #393 for details