### PR TITLE
Enable coverage testing for TS provider

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,11 @@ on:
     # Every night at midnight
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      rev:
+        description: "Revision hash to run against"
+        required: false
+        default: ""
 
 jobs:
   dependencies:
@@ -12,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Check out the correct revision
+        run: [ ! -z "${{ github.event.inputs.rev }}" ] && git fetch origin ${{ github.event.inputs.rev }} && git checkout FETCH_HEAD
       - name: Install latest Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -26,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Check out the correct revision
+        run: [ ! -z "${{ github.event.inputs.rev }}" ] && git fetch origin ${{ github.event.inputs.rev }} && git checkout FETCH_HEAD
       - name: Install latest Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -40,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Check out the correct revision
+        run: [ ! -z "${{ github.event.inputs.rev }}" ] && git fetch origin ${{ github.event.inputs.rev }} && git checkout FETCH_HEAD
       - name: Run the container to execute the coverage script
         run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec --security-opt seccomp=unconfined ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh coverage
       - name: Collect coverage results

--- a/ci.sh
+++ b/ci.sh
@@ -157,7 +157,7 @@ if [ "$PROVIDER_NAME" = "trusted-service" ] || [ "$PROVIDER_NAME" = "coverage" ]
 fi
 
 if [ "$PROVIDER_NAME" = "coverage" ]; then
-    PROVIDERS="mbed-crypto tpm pkcs11" # trusted-service not supported because of a segfault when the service stops; see: https://github.com/parallaxsecond/parsec/issues/349
+    PROVIDERS="mbed-crypto tpm pkcs11 trusted-service" # trusted-service not supported because of a segfault when the service stops; see: https://github.com/parallaxsecond/parsec/issues/349
     EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/providers/trusted_service/*"
     # Install tarpaulin
     cargo install cargo-tarpaulin


### PR DESCRIPTION
This commit enables collection of code coverage results for the TS
provider, since current changes in the way testing is done means there
is no service restarting, which was triggering the problems before.
The nightly run manual toggle also has an added field, allowing the
tests to be run against specific revision numbers.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>