### PR TITLE
Move CLI log into its own file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 # The content of the config.rs file should not change in a breaking way.
 # See https://github.com/parallaxsecond/parsec/issues/393 for details.
 src/utils/config.rs   @parallaxsecond/admin
+# The content of the cli.rs file should not change in a breaking way.
+# See https://github.com/parallaxsecond/parsec/issues/392 for details.
+src/utils/cli.rs      @parallaxsecond/admin

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -41,6 +41,7 @@
 
 use anyhow::Result;
 use log::{info, trace};
+use parsec_service::utils::cli::Opts;
 use parsec_service::utils::{config::ServiceConfig, ServiceBuilder};
 use signal_hook::{consts::SIGHUP, consts::SIGINT, consts::SIGTERM, flag};
 use std::io::{Error, ErrorKind};
@@ -51,22 +52,6 @@ use std::sync::{
 use std::time::Duration;
 use structopt::StructOpt;
 use users::get_current_uid;
-
-/// Parsec is the Platform AbstRaction for SECurity, a new open-source initiative to provide a
-/// common API to secure services in a platform-agnostic way.
-///
-/// Parsec documentation is available at:
-/// https://parallaxsecond.github.io/parsec-book/index.html
-///
-/// Most of Parsec configuration comes from its configuration file.
-/// Please check the documentation to find more about configuration:
-/// https://parallaxsecond.github.io/parsec-book/user_guides/configuration.html
-#[derive(StructOpt)]
-struct Opts {
-    /// Sets the configuration file path
-    #[structopt(short, long, default_value = "config.toml")]
-    config: String,
-}
 
 const MAIN_LOOP_DEFAULT_SLEEP: u64 = 10;
 

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -1,0 +1,25 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! Command Line Interface configuration
+
+// WARNING: This file should be only updated in a non-breaking way. CLI flags should not be
+// removed, new flags should be tested.
+// See https://github.com/parallaxsecond/parsec/issues/392 for details.
+
+use structopt::StructOpt;
+
+/// Parsec is the Platform AbstRaction for SECurity, a new open-source initiative to provide a
+/// common API to secure services in a platform-agnostic way.
+///
+/// Parsec documentation is available at:
+/// https://parallaxsecond.github.io/parsec-book/index.html
+///
+/// Most of Parsec configuration comes from its configuration file.
+/// Please check the documentation to find more about configuration:
+/// https://parallaxsecond.github.io/parsec-book/user_guides/configuration.html
+#[derive(StructOpt, Debug)]
+pub struct Opts {
+    /// Sets the configuration file path
+    #[structopt(short, long, default_value = "config.toml")]
+    pub config: String,
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! Service utilities
+pub mod cli;
 pub mod config;
 mod global_config;
 mod service_builder;


### PR DESCRIPTION
That is to prevent breaking updates to the CLI options. The file is also
added to the GitHub code owners.