### PR TITLE
Execute e2e tests with an old version of client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,11 @@ src/utils/config.rs   @parallaxsecond/admin
 # The content of the cli.rs file should not change in a breaking way.
 # See https://github.com/parallaxsecond/parsec/issues/392 for details.
 src/utils/cli.rs      @parallaxsecond/admin
+# The Docker container is also used to check that there are no breaking
+# changes in buildtime dependencies.
+# See https://github.com/parallaxsecond/parsec/issues/397
+# See https://github.com/parallaxsecond/parsec/issues/408
+e2e_tests/docker_image/   @parallaxsecond/admin
+# The way tests are executed should be only modified carefully to not remove
+# regression or breaking changes detection.
+ci.sh   @parallaxsecond/admin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ prost-build = { version = "0.7.0", optional = true }
 [package.metadata.docs.rs]
 features = ["pkcs11-provider", "tpm-provider", "mbed-crypto-provider", "cryptoauthlib-provider", "direct-authenticator"]
 
+# The features should not be modified in a breaking way.
+# See https://github.com/parallaxsecond/parsec/issues/408 for details.
 [features]
 default = ["unix-peer-credentials-authenticator"]
 

--- a/e2e_tests/docker_image/generate-keys.sh
+++ b/e2e_tests/docker_image/generate-keys.sh
@@ -31,7 +31,6 @@ cd ../
 # We use the Parsec Tool to create one RSA and one ECC key per provider,
 # when it is possible.
 cargo install parsec-tool
-export PARSEC_SERVICE_ENDPOINT="unix:/tmp/parsec.sock"
 parsec-tool -p 1 create-rsa-key -k rsa
 parsec-tool -p 1 create-ecc-key -k ecc
 parsec-tool -p 2 create-rsa-key -k rsa

--- a/e2e_tests/docker_image/import-old-e2e-tests.sh
+++ b/e2e_tests/docker_image/import-old-e2e-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+# These commands are made to import the oldest version of the end-to-end tests to check that they
+# still work with the current version of the Parsec service.
+
+set -xeuf -o pipefail
+
+git clone https://github.com/parallaxsecond/parsec.git
+cd parsec
+# This commit is the oldest one which still works with current Parsec version.
+# It works with the Rust client version 0.6.0
+git checkout 2fee72fc64871472edf141906bf7f55bd59a2f8d
+mv e2e_tests /tmp/old_e2e_tests
+cd ..
+rm -rf parsec
+# Compiling the tests so that it's faster on the CI
+RUST_BACKTRACE=1 cargo test --no-run --manifest-path /tmp/old_e2e_tests/Cargo.toml

--- a/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
@@ -201,3 +201,39 @@ fn wrong_permitted_algorithm() {
 
     assert_eq!(status, ResponseStatus::PsaErrorNotPermitted);
 }
+
+#[test]
+#[cfg(not(feature = "cryptoauthlib-provider"))]
+fn no_usage_flag_set() {
+    let mut client = TestClient::new();
+    let key_name = String::from("no_usage_flag_set");
+    let key_type = Type::RsaKeyPair;
+    let permitted_algorithm =
+        Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
+            hash_alg: Hash::Sha512.into(),
+        });
+    let key_attributes = Attributes {
+        lifetime: Lifetime::Persistent,
+        key_type,
+        bits: 1024,
+        policy: Policy {
+            usage_flags: UsageFlags {
+                sign_hash: false,
+                verify_hash: false,
+                sign_message: false,
+                verify_message: false,
+                export: false,
+                encrypt: false,
+                decrypt: false,
+                cache: false,
+                copy: false,
+                derive: false,
+            },
+            permitted_algorithms: permitted_algorithm,
+        },
+    };
+
+    client
+        .generate_key(key_name.clone(), key_attributes)
+        .unwrap();
+}


### PR DESCRIPTION
This is to ensure that the Parsec service does not break for old
clients.
This commit also specifies an exact version of libclang and Mbed Crypto.
Adds build tests for specific versions of the Rust compiler.

See #397 #408 