### PR TITLE
Randomly select the shutdown signal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,6 @@ e2e_tests/docker_image/   @parallaxsecond/admin
 # The way tests are executed should be only modified carefully to not remove
 # regression or breaking changes detection.
 ci.sh   @parallaxsecond/admin
+# The main function file contains interactions with the operating system which must
+# stay stable.
+src/bin/main.rs   @parallaxsecond/admin

--- a/ci.sh
+++ b/ci.sh
@@ -62,7 +62,13 @@ wait_for_service() {
 }
 
 stop_service() {
-    pkill parsec || true
+    # Randomly signals with SIGINT or SIGTERM to test that both can be used to
+    # gracefully shutdowm Parsec.
+    if ! (($RANDOM % 2)); then
+        pkill -SIGINT parsec || true
+    else
+        pkill -SIGTERM parsec || true
+    fi
 
     while [ -n "$(pgrep parsec)" ]; do
         sleep 1
@@ -320,9 +326,7 @@ else
 
     if [ -z "$NO_STRESS_TEST" ]; then
         echo "Shutdown Parsec"
-        pkill parsec
-        # Sleep time needed to make sure Parsec is killed.
-        sleep 2
+        stop_service
 
         echo "Start Parsec for stress tests"
         # Change the log level for the stress tests because logging is limited on the

--- a/src/authenticators/direct_authenticator/mod.rs
+++ b/src/authenticators/direct_authenticator/mod.rs
@@ -95,7 +95,7 @@ mod test {
             .expect("Failed to authenticate");
 
         assert_eq!(app.get_name(), &ApplicationName::from_name(app_name));
-        assert_eq!(app.is_admin, false);
+        assert!(!app.is_admin);
     }
 
     #[test]
@@ -141,7 +141,7 @@ mod test {
             .expect("Failed to authenticate");
 
         assert_eq!(auth_name.get_name(), &ApplicationName::from_name(app_name));
-        assert_eq!(auth_name.is_admin, false);
+        assert!(!auth_name.is_admin);
 
         let req_auth = RequestAuth::new(admin_name.clone().into_bytes());
         let auth_name = authenticator
@@ -152,6 +152,6 @@ mod test {
             auth_name.get_name(),
             &ApplicationName::from_name(admin_name)
         );
-        assert_eq!(auth_name.is_admin, true);
+        assert!(auth_name.is_admin);
     }
 }

--- a/src/authenticators/unix_peer_credentials_authenticator/mod.rs
+++ b/src/authenticators/unix_peer_credentials_authenticator/mod.rs
@@ -142,7 +142,7 @@ mod test {
             auth_name.get_name(),
             &ApplicationName::from_name(get_current_uid().to_string())
         );
-        assert_eq!(auth_name.is_admin, false);
+        assert!(!auth_name.is_admin);
     }
 
     #[test]
@@ -249,7 +249,7 @@ mod test {
             auth_name.get_name(),
             &ApplicationName::from_name(get_current_uid().to_string())
         );
-        assert_eq!(auth_name.is_admin, true);
+        assert!(auth_name.is_admin);
     }
 
     #[test]

--- a/src/providers/cryptoauthlib/key_slot.rs
+++ b/src/providers/cryptoauthlib/key_slot.rs
@@ -365,19 +365,19 @@ mod tests {
         };
         // KeyType::P256EccKey
         // Type::EccKeyPair => NOK
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), false);
+        assert!(!key_slot.is_key_type_ok(0, &attributes));
         // private key attrs => OK
         key_slot.config.key_type = rust_cryptoauthlib::KeyType::P256EccKey;
         key_slot.config.write_config = rust_cryptoauthlib::WriteConfig::Encrypt;
         key_slot.config.is_secret = true;
         key_slot.config.ecc_key_attr.is_private = true;
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), true);
+        assert!(key_slot.is_key_type_ok(0, &attributes));
         // Type::Aes => NOK
         attributes.key_type = Type::Aes;
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), false);
+        assert!(!key_slot.is_key_type_ok(0, &attributes));
         // Type::RawData => NOK
         attributes.key_type = Type::RawData;
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), false);
+        assert!(!key_slot.is_key_type_ok(0, &attributes));
 
         // KeyType::Aes
         // Type::EccKeyPair => NOK
@@ -385,13 +385,13 @@ mod tests {
         attributes.key_type = Type::EccKeyPair {
             curve_family: EccFamily::SecpR1,
         };
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), false);
+        assert!(!key_slot.is_key_type_ok(0, &attributes));
         // Type::Aes => OK
         attributes.key_type = Type::Aes;
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), true);
+        assert!(key_slot.is_key_type_ok(0, &attributes));
         // Type::RawData => NOK
         attributes.key_type = Type::RawData;
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), false);
+        assert!(!key_slot.is_key_type_ok(0, &attributes));
 
         // KeyType::ShaOrText
         // Type::EccKeyPair => NOK
@@ -399,10 +399,10 @@ mod tests {
         attributes.key_type = Type::EccKeyPair {
             curve_family: EccFamily::SecpR1,
         };
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), false);
+        assert!(!key_slot.is_key_type_ok(0, &attributes));
         // Type::Aes => NOK
         attributes.key_type = Type::Aes;
-        assert_eq!(key_slot.is_key_type_ok(0, &attributes), false);
+        assert!(!key_slot.is_key_type_ok(0, &attributes));
     }
 
     #[test]
@@ -468,30 +468,30 @@ mod tests {
         };
         // Type::EccKeyPair
         // && export && copy == true => OK
-        assert_eq!(key_slot.is_usage_flags_ok(&attributes), true);
+        assert!(key_slot.is_usage_flags_ok(&attributes));
         // && pub_info == false => OK
         key_slot.config.pub_info = false;
-        assert_eq!(key_slot.is_usage_flags_ok(&attributes), false);
+        assert!(!key_slot.is_usage_flags_ok(&attributes));
         // && pub_info == false => NOK
         key_slot.config.pub_info = false;
-        assert_eq!(key_slot.is_usage_flags_ok(&attributes), false);
+        assert!(!key_slot.is_usage_flags_ok(&attributes));
         // && is_private == false => NOK
         key_slot.config.ecc_key_attr.is_private = false;
-        assert_eq!(key_slot.is_usage_flags_ok(&attributes), true);
+        assert!(key_slot.is_usage_flags_ok(&attributes));
         // && export && copy == false => OK
         attributes.policy.usage_flags.export = false;
         attributes.policy.usage_flags.copy = false;
-        assert_eq!(key_slot.is_usage_flags_ok(&attributes), true);
+        assert!(key_slot.is_usage_flags_ok(&attributes));
 
         // KeyType::Aes => NOK
         attributes.policy.usage_flags.export = true;
         attributes.policy.usage_flags.copy = true;
         key_slot.config.key_type = rust_cryptoauthlib::KeyType::Aes;
-        assert_eq!(key_slot.is_usage_flags_ok(&attributes), false);
+        assert!(!key_slot.is_usage_flags_ok(&attributes));
         // && sign_hash && sign_message == false => OK
         attributes.policy.usage_flags.sign_hash = false;
         attributes.policy.usage_flags.sign_message = false;
-        assert_eq!(key_slot.is_usage_flags_ok(&attributes), false);
+        assert!(!key_slot.is_usage_flags_ok(&attributes));
     }
 
     #[test]
@@ -559,37 +559,31 @@ mod tests {
 
         // KeyType::P256EccKey
         // && AsymmetricSignature::Ecdsa => OK
-        assert_eq!(key_slot.is_permitted_algorithms_ok(&attributes, None), true);
+        assert!(key_slot.is_permitted_algorithms_ok(&attributes, None));
         // && FullLengthMac::Hmac => NOK
         attributes.policy.permitted_algorithms = Mac::FullLength(FullLengthMac::Hmac {
             hash_alg: Hash::Sha256,
         })
         .into();
-        assert_eq!(
-            key_slot.is_permitted_algorithms_ok(&attributes, None),
-            false
-        );
+        assert!(!key_slot.is_permitted_algorithms_ok(&attributes, None));
         // && AsymmetricSignature::DeterministicEcdsa => NOK
         attributes.policy.permitted_algorithms = AsymmetricSignature::DeterministicEcdsa {
             hash_alg: Hash::Sha256.into(),
         }
         .into();
-        assert_eq!(
-            key_slot.is_permitted_algorithms_ok(&attributes, None),
-            false
-        );
+        assert!(!key_slot.is_permitted_algorithms_ok(&attributes, None));
         // && RawKeyAgreement::Ecdh => OK
         attributes.policy.permitted_algorithms = KeyAgreement::Raw(RawKeyAgreement::Ecdh).into();
-        assert_eq!(key_slot.is_permitted_algorithms_ok(&attributes, None), true);
+        assert!(key_slot.is_permitted_algorithms_ok(&attributes, None));
 
         // KeyType::Aes
         // && Aead::AeadWithDefaultLengthTag => OK
         attributes.policy.permitted_algorithms =
             Aead::AeadWithDefaultLengthTag(AeadWithDefaultLengthTag::Ccm).into();
         key_slot.config.key_type = rust_cryptoauthlib::KeyType::Aes;
-        assert_eq!(key_slot.is_permitted_algorithms_ok(&attributes, None), true);
+        assert!(key_slot.is_permitted_algorithms_ok(&attributes, None));
         // && Cipher(Cipher::CbcPkcs7) => OK
         attributes.policy.permitted_algorithms = Algorithm::Cipher(Cipher::CbcPkcs7);
-        assert_eq!(key_slot.is_permitted_algorithms_ok(&attributes, None), true);
+        assert!(key_slot.is_permitted_algorithms_ok(&attributes, None));
     }
 }


### PR DESCRIPTION
This is to test that both signals work in the future. Also adds the main
function to the CODEOWNERS to make sure that the OS interactions stay
stable.