### PR TITLE
Add a way to allow providers to fail instantiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi"
 version = "5.0.1"
-source = "git+https://github.com/parallaxsecond/rust-tss-esapi?rev=56c487a101dc85e17560416d71f0fc2eb81739a6#56c487a101dc85e17560416d71f0fc2eb81739a6"
+source = "git+https://github.com/parallaxsecond/rust-tss-esapi?rev=1f68655e278b0319c080b9804a7bf3f6e11ff721#1f68655e278b0319c080b9804a7bf3f6e11ff721"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -1967,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "tss-esapi-sys"
 version = "0.1.1"
-source = "git+https://github.com/parallaxsecond/rust-tss-esapi?rev=56c487a101dc85e17560416d71f0fc2eb81739a6#56c487a101dc85e17560416d71f0fc2eb81739a6"
+source = "git+https://github.com/parallaxsecond/rust-tss-esapi?rev=1f68655e278b0319c080b9804a7bf3f6e11ff721#1f68655e278b0319c080b9804a7bf3f6e11ff721"
 dependencies = [
  "pkg-config",
  "target-lexicon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.14", features = ["serde"] }
 cryptoki = { git = "https://github.com/parallaxsecond/rust-cryptoki", rev = "916f9bbb208ba8a671c593a36313f09c60cd0255", optional = true, features = ["psa-crypto-conversions"] }
 picky-asn1-der = { version = "<=0.2.4", optional = true }
 picky-asn1 = { version = ">=0.3.1, <=0.3.1", optional = true }
-tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi", rev = "56c487a101dc85e17560416d71f0fc2eb81739a6", optional = true }
+tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi", rev = "1f68655e278b0319c080b9804a7bf3f6e11ff721", optional = true }
 bincode = "1.3.1"
 structopt = "0.3.21"
 derivative = "2.2.0"

--- a/config.toml
+++ b/config.toml
@@ -149,6 +149,8 @@ key_info_manager = "on-disk-manager"
 # e.g. "str:password", or to represent a string version of a hex value, e.g. "hex:1a2b3c". If no prefix is
 # provided, the value is considered to be a string.
 #owner_hierarchy_auth = "password"
+# (Optional) Allows the service to still start without this provider if there is no TPM on the system. The priority list of providers will be as if this provider was commented out.
+#skip_if_no_tpm = false
 
 # Example of a CryptoAuthLib provider configuration
 # All below parameters depend on what devices, interfaces or parameters are required or supported by

--- a/e2e_tests/tests/all_providers/config/mod.rs
+++ b/e2e_tests/tests/all_providers/config/mod.rs
@@ -159,6 +159,25 @@ fn pkcs11_encrypt_software() {
 }
 
 #[test]
+fn no_tpm_support() {
+    set_config("no_tpm_support.toml");
+    // The service should still start, without the TPM provider.
+    reload_service();
+
+    let mut client = TestClient::new();
+    let providers = client.list_providers().unwrap();
+    let uuids: Vec<Uuid> = providers.iter().map(|p| p.uuid).collect();
+    assert_eq!(
+        uuids,
+        vec![
+            Uuid::parse_str("1c1139dc-ad7c-47dc-ad6b-db6fdb466552").unwrap(), // Mbed crypto provider
+            Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap(), // Pkcs11 provider
+            Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
+        ]
+    );
+}
+
+#[test]
 fn various_fields() {
     set_config("various_field_check.toml");
     reload_service();

--- a/e2e_tests/tests/all_providers/config/tomls/no_tpm_support.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_tpm_support.toml
@@ -1,0 +1,37 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+provider_type = "MbedCrypto"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+provider_type = "Tpm"
+key_info_manager = "on-disk-manager"
+# There shoudn't be a real TPM available on the CI
+tcti = "device"
+owner_hierarchy_auth = ""
+skip_if_no_tpm = true
+
+[[provider]]
+provider_type = "Pkcs11"
+key_info_manager = "on-disk-manager"
+library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
+user_pin = "123456"
+# The slot_number mandatory field is going to replace the following line with a valid number
+# slot_number

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -132,6 +132,9 @@ pub enum ProviderConfig {
         tcti: String,
         /// Owner Hierarchy Authentication
         owner_hierarchy_auth: String,
+        /// Allows the service to still start without this provider if there is no TPM on the
+        /// system. The priority list of providers will be as if this provider was commented out.
+        skip_if_no_tpm: Option<bool>,
     },
     /// Microchip CryptoAuthentication Library provider configuration
     CryptoAuthLib {


### PR DESCRIPTION
A new optional flag is added to set if a provider can fail to start.

Fix #401

Note that a shortcut is taken here, from #401

> A careful definition of "cannot be instantiated" is also needed, because it is important to be able to distinguish between an optional provider and a badly-configured one, or one that fails unexpectedly due to some platform or environment error.

Here we allow all kind of failures and do not differentiate, mainly for simplicity.