### PR TITLE
Update the TS revision used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
         run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh trusted-service
-      # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh trusted-service
+        # When running the container built on the CI
+        # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh trusted-service
 
   cryptoauthlib-provider:
     name: Integration tests using CryptoAuthentication Library provider

--- a/build.rs
+++ b/build.rs
@@ -6,16 +6,22 @@ use std::path::{Path, PathBuf};
 
 #[cfg(feature = "trusted-service-provider")]
 fn generate_ts_bindings(ts_include_dir: String) -> Result<()> {
-    let header = ts_include_dir.clone() + "/service/locator/interface/service_locator.h";
+    let header = ts_include_dir.clone() + "/components/service/locator/interface/service_locator.h";
+    let encoding_header = ts_include_dir.clone() + "/protocols/rpc/common/packed-c/encoding.h";
 
     println!("cargo:rerun-if-changed={}", header);
 
     let bindings = bindgen::Builder::default()
-        .clang_arg(format!("-I{}", ts_include_dir + "/rpc/common/interface"))
+        .clang_arg(format!(
+            "-I{}",
+            ts_include_dir + "/components/rpc/common/interface"
+        ))
         .rustfmt_bindings(true)
         .header(header)
+        .header(encoding_header)
         .generate_comments(false)
         .size_t_is_usize(true)
+        .derive_default(true)
         .generate()
         .map_err(|_| {
             Error::new(
@@ -71,7 +77,7 @@ fn generate_proto_sources(contract_dir: String) -> Result<()> {
 fn main() -> Result<()> {
     {
         generate_proto_sources(String::from("trusted-services-vendor/protocols"))?;
-        generate_ts_bindings(String::from("trusted-services-vendor/components"))?;
+        generate_ts_bindings(String::from("trusted-services-vendor"))?;
     }
 
     Ok(())

--- a/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
+++ b/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
@@ -94,9 +94,9 @@ RUN cd nanopb-0.4.4-linux-x86 \
 RUN rm -rf nanopb-0.4.4-linux-x86 nanopb-0.4.4-linux-x86.tar.gz
 
 # Install mock Trusted Services
-RUN git clone https://git.trustedfirmware.org/TS/trusted-services.git --branch integration \
+RUN git clone https://git.trustedfirmware.org/TS/trusted-services.git --branch main \
 	&& cd trusted-services \
-	&& git reset --hard 840696b9ac1ba6aa9ccd024ca9dc3b4be12bf837
+	&& git reset --hard 2fc7e10c7c21e4dafbf63dc9d00dfc2a7a7fddad
 # Install correct python dependencies
 RUN pip3 install -r trusted-services/requirements.txt
 RUN cd trusted-services/deployments/libts/linux-pc/ \

--- a/src/providers/trusted_service/context/mod.rs
+++ b/src/providers/trusted_service/context/mod.rs
@@ -100,7 +100,9 @@ impl Context {
 
         info!("Starting crypto Trusted Service context");
         let mut rpc_caller = null_mut();
-        let rpc_session_handle = unsafe { service_context_open(service_context, &mut rpc_caller) };
+        let rpc_session_handle = unsafe {
+            service_context_open(service_context, TS_RPC_ENCODING_PROTOBUF, &mut rpc_caller)
+        };
         if rpc_caller.is_null() || rpc_session_handle.is_null() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,


### PR DESCRIPTION
This commit updates the revision we use from the Trusted Services repo.
We switch to using the `main` branch and a recent commit, and fix the
build and FFI wrapper to handle the small changes introduced.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>