### PR TITLE
#417 Added additional error logging to front end handle_request function.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,3 +16,4 @@ This file aims to acknowledge the specific contributors referred to in the "Cont
 * Patrick Uiterwijk (@puiterwijk)
 * Nicolas Stalder (@nickray)
 * Edmund Grimley Evans (@egrimley-arm)
+* Matt Davis (@MattDavis00)

--- a/src/front/front_end.rs
+++ b/src/front/front_end.rs
@@ -38,8 +38,8 @@ impl FrontEndHandler {
     /// Unmarshalls a request from the stream, passes it to the dispatcher and marshalls
     /// the response back onto the stream.
     ///
-    /// If an error occurs during (un)marshalling, no operation will be performed and the
-    /// method will return.
+    /// If an error occurs during (un)marshalling; no operation will be performed, an error will be logged
+    /// and the method will return.
     pub fn handle_request(&self, mut connection: Connection) {
         trace!("handle_request ingress");
         // Read bytes from stream
@@ -50,6 +50,9 @@ impl FrontEndHandler {
                 format_error!("Failed to read request", status);
 
                 let response = Response::from_status(status);
+                if response.header.status != ResponseStatus::Success {
+                 format_error!("Sending back an error", response.header.status);
+                }
                 if let Err(status) = response.write_to_stream(&mut connection.stream) {
                     format_error!("Failed to write response", status);
                 }

--- a/src/front/front_end.rs
+++ b/src/front/front_end.rs
@@ -51,7 +51,7 @@ impl FrontEndHandler {
 
                 let response = Response::from_status(status);
                 if response.header.status != ResponseStatus::Success {
-                 format_error!("Sending back an error", response.header.status);
+                    format_error!("Sending back an error", response.header.status);
                 }
                 if let Err(status) = response.write_to_stream(&mut connection.stream) {
                     format_error!("Failed to write response", status);


### PR DESCRIPTION
An ERROR will now be logged before the error response is sent to the
client. Issue #417.

Signed-off-by: Matt Davis <matt.davis@arm.com>