### PR TITLE
Added missing ingress logs to providers. #416

### DIFF
--- a/src/back/backend_handler.rs
+++ b/src/back/backend_handler.rs
@@ -154,7 +154,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result =
                     unwrap_or_else_return!(self.provider.psa_export_key(app.into(), op_export_key));
-                trace!("psa_export_public_key egress");
+                trace!("psa_export_key egress");
                 self.result_to_response(NativeResult::PsaExportKey(result), header)
             }
             NativeOperation::PsaDestroyKey(op_destroy_key) => {
@@ -185,7 +185,7 @@ impl BackEndHandler {
                 let result = unwrap_or_else_return!(self
                     .provider
                     .psa_asymmetric_encrypt(app.into(), op_asymmetric_encrypt));
-                trace!("psa_asymmetric_encrypt_egress");
+                trace!("psa_asymmetric_encrypt egress");
                 self.result_to_response(NativeResult::PsaAsymmetricEncrypt(result), header)
             }
             NativeOperation::PsaAsymmetricDecrypt(op_asymmetric_decrypt) => {
@@ -193,7 +193,7 @@ impl BackEndHandler {
                 let result = unwrap_or_else_return!(self
                     .provider
                     .psa_asymmetric_decrypt(app.into(), op_asymmetric_decrypt));
-                trace!("psa_asymmetric_decrypt_egress");
+                trace!("psa_asymmetric_decrypt egress");
                 self.result_to_response(NativeResult::PsaAsymmetricDecrypt(result), header)
             }
             NativeOperation::PsaAeadEncrypt(op_aead_encrypt) => {
@@ -201,7 +201,7 @@ impl BackEndHandler {
                 let result = unwrap_or_else_return!(self
                     .provider
                     .psa_aead_encrypt(app.into(), op_aead_encrypt));
-                trace!("psa_aead_encrypt_egress");
+                trace!("psa_aead_encrypt egress");
                 self.result_to_response(NativeResult::PsaAeadEncrypt(result), header)
             }
             NativeOperation::PsaAeadDecrypt(op_aead_decrypt) => {
@@ -209,7 +209,7 @@ impl BackEndHandler {
                 let result = unwrap_or_else_return!(self
                     .provider
                     .psa_aead_decrypt(app.into(), op_aead_decrypt));
-                trace!("psa_aead_decrypt_egress");
+                trace!("psa_aead_decrypt egress");
                 self.result_to_response(NativeResult::PsaAeadDecrypt(result), header)
             }
             NativeOperation::ListAuthenticators(op_list_authenticators) => {
@@ -239,13 +239,13 @@ impl BackEndHandler {
             NativeOperation::PsaHashCompute(op_hash_compute) => {
                 let result =
                     unwrap_or_else_return!(self.provider.psa_hash_compute(op_hash_compute));
-                trace!("psa_hash_compute_egress");
+                trace!("psa_hash_compute egress");
                 self.result_to_response(NativeResult::PsaHashCompute(result), header)
             }
             NativeOperation::PsaHashCompare(op_hash_compare) => {
                 let result =
                     unwrap_or_else_return!(self.provider.psa_hash_compare(op_hash_compare));
-                trace!("psa_hash_compare_egress");
+                trace!("psa_hash_compare egress");
                 self.result_to_response(NativeResult::PsaHashCompare(result), header)
             }
             NativeOperation::PsaRawKeyAgreement(op_raw_key_agreement) => {
@@ -253,13 +253,13 @@ impl BackEndHandler {
                 let result = unwrap_or_else_return!(self
                     .provider
                     .psa_raw_key_agreement(app.into(), op_raw_key_agreement));
-                trace!("psa_raw_key_agreement_egress");
+                trace!("psa_raw_key_agreement egress");
                 self.result_to_response(NativeResult::PsaRawKeyAgreement(result), header)
             }
             NativeOperation::PsaGenerateRandom(op_generate_random) => {
                 let result =
                     unwrap_or_else_return!(self.provider.psa_generate_random(op_generate_random));
-                trace!("psa_generate_random_egress");
+                trace!("psa_generate_random egress");
                 self.result_to_response(NativeResult::PsaGenerateRandom(result), header)
             }
             NativeOperation::PsaSignMessage(op_sign_message) => {

--- a/src/providers/core/mod.rs
+++ b/src/providers/core/mod.rs
@@ -178,6 +178,7 @@ impl Provide for Provider {
     }
 
     fn describe(&self) -> Result<(ProviderInfo, HashSet<Opcode>)> {
+        trace!("describe ingress");
         unreachable!()
     }
 }

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -164,12 +164,14 @@ impl Provide for Provider {
         app_name: ApplicationName,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
+        trace!("list_keys ingress");
         Ok(list_keys::Result {
             keys: self.key_info_store.list_keys(&app_name)?,
         })
     }
 
     fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
+        trace!("list_clients ingress");
         Ok(list_clients::Result {
             clients: self
                 .key_info_store
@@ -212,7 +214,7 @@ impl Provide for Provider {
         app_name: ApplicationName,
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
-        trace!("psa_export_public_key ingress");
+        trace!("psa_export_key ingress");
         self.psa_export_key_internal(app_name, op)
     }
 
@@ -300,7 +302,7 @@ impl Provide for Provider {
         app_name: ApplicationName,
         op: psa_raw_key_agreement::Operation,
     ) -> Result<psa_raw_key_agreement::Result> {
-        trace!("psa_raw_key_agreement");
+        trace!("psa_raw_key_agreement ingress");
         self.psa_raw_key_agreement(app_name, op)
     }
 

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -226,12 +226,14 @@ impl Provide for Provider {
         app_name: ApplicationName,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
+        trace!("list_keys ingress");
         Ok(list_keys::Result {
             keys: self.key_info_store.list_keys(&app_name)?,
         })
     }
 
     fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
+        trace!("list_clients ingress");
         Ok(list_clients::Result {
             clients: self
                 .key_info_store

--- a/src/providers/tpm/mod.rs
+++ b/src/providers/tpm/mod.rs
@@ -99,12 +99,14 @@ impl Provide for Provider {
         app_name: ApplicationName,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
+        trace!("list_keys ingress");
         Ok(list_keys::Result {
             keys: self.key_info_store.list_keys(&app_name)?,
         })
     }
 
     fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
+        trace!("list_clients ingress");
         Ok(list_clients::Result {
             clients: self
                 .key_info_store

--- a/src/providers/trusted_service/mod.rs
+++ b/src/providers/trusted_service/mod.rs
@@ -107,6 +107,7 @@ impl Provider {
 
 impl Provide for Provider {
     fn describe(&self) -> Result<(ProviderInfo, HashSet<Opcode>)> {
+        trace!("describe ingress");
         Ok((ProviderInfo {
             // Assigned UUID for this provider: 71129441-508a-4da6-b6e8-7b98a777e4c0
             uuid: Uuid::parse_str("71129441-508a-4da6-b6e8-7b98a777e4c0")?,
@@ -124,12 +125,14 @@ impl Provide for Provider {
         app_name: ApplicationName,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
+        trace!("list_keys ingress");
         Ok(list_keys::Result {
             keys: self.key_info_store.list_keys(&app_name)?,
         })
     }
 
     fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result> {
+        trace!("list_clients ingress");
         Ok(list_clients::Result {
             clients: self
                 .key_info_store


### PR DESCRIPTION
Added to core, mbed_crypto, pkcs11, tpm, and trusted_service providers.
Fixed psa_export_key function being referenced as psa_export_public_key.
Changed some egress logs from `psa_aead_encrypt_egress` format to
`psa_aead_encrypt egress` format.

Closes #416

Signed-off-by: Matt Davis <matt.davis@arm.com>