### PR TITLE
Add a allow_export flag to restrict exporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh tpm
 
   trusted-service-provider:
-    name: Integration tests using Cypto Trusted Service provider
+    name: Integration tests using Crypto Trusted Service provider
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/config.toml
+++ b/config.toml
@@ -127,6 +127,10 @@ key_info_manager = "on-disk-manager"
 # (Optional) Control whether missing public key operation (such as verifying signatures or asymmetric
 # encryption) are fully performed in software. 
 #software_public_operations = false
+# (Optional) Control whether it is allowed for a key to be exportable. On some platforms creating a
+# key that can be exported will fail with an obscure error. If this flag is set to false, creating
+# a key with its export usage flag set to true will return a PsaErrorNotPermitted error.
+#allow_export = true
 
 # Example of a TPM provider configuration
 #[[provider]]

--- a/e2e_tests/tests/all_providers/config/tomls/allow_export.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/allow_export.toml
@@ -1,0 +1,26 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+provider_type = "Pkcs11"
+key_info_manager = "on-disk-manager"
+library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
+user_pin = "123456"
+# The slot_number mandatory field is going to replace the following line with a valid number
+# slot_number
+allow_export = false

--- a/src/providers/pkcs11/key_management.rs
+++ b/src/providers/pkcs11/key_management.rs
@@ -178,8 +178,13 @@ impl Provider {
     ) -> Result<psa_import_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, key_name);
 
+        if key_attributes.policy.usage_flags.export && !self.allow_export {
+            error!("The configuration of this provider does not allow it to generate keys that can be exported.");
+            return Err(ResponseStatus::PsaErrorNotPermitted);
+        }
+
+        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, key_name);
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let session = self.new_session()?;

--- a/src/providers/pkcs11/key_management.rs
+++ b/src/providers/pkcs11/key_management.rs
@@ -95,6 +95,11 @@ impl Provider {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
 
+        if key_attributes.policy.usage_flags.export && !self.allow_export {
+            error!("The configuration of this provider does not allow it to generate keys that can be exported.");
+            return Err(ResponseStatus::PsaErrorNotPermitted);
+        }
+
         let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, key_name);
         self.key_info_store.does_not_exist(&key_triple)?;
 

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -64,6 +64,7 @@ pub struct Provider {
     backend: Pkcs11,
     slot_number: Slot,
     software_public_operations: bool,
+    allow_export: bool,
 }
 
 impl Provider {
@@ -77,6 +78,7 @@ impl Provider {
         slot_number: Slot,
         user_pin: Option<SecretString>,
         software_public_operations: bool,
+        allow_export: bool,
     ) -> Option<Provider> {
         if let Some(pin) = user_pin {
             backend.set_pin(slot_number, pin.expose_secret()).ok()?;
@@ -89,6 +91,7 @@ impl Provider {
             backend,
             slot_number,
             software_public_operations,
+            allow_export,
         };
         {
             let mut local_ids_handle = pkcs11_provider
@@ -341,6 +344,7 @@ pub struct ProviderBuilder {
     slot_number: Option<u64>,
     user_pin: Option<SecretString>,
     software_public_operations: Option<bool>,
+    allow_export: Option<bool>,
 }
 
 impl ProviderBuilder {
@@ -352,6 +356,7 @@ impl ProviderBuilder {
             slot_number: None,
             user_pin: None,
             software_public_operations: None,
+            allow_export: None,
         }
     }
 
@@ -398,6 +403,13 @@ impl ProviderBuilder {
         self
     }
 
+    /// Specify the `allow_export` flag
+    pub fn with_allow_export(mut self, allow_export: Option<bool>) -> ProviderBuilder {
+        self.allow_export = allow_export;
+
+        self
+    }
+
     /// Attempt to build a PKCS11 provider
     pub fn build(self) -> std::io::Result<Provider> {
         let library_path = self
@@ -436,6 +448,7 @@ impl ProviderBuilder {
             slot,
             self.user_pin,
             self.software_public_operations.unwrap_or(false),
+            self.allow_export.unwrap_or(true),
         )
         .ok_or_else(|| Error::new(ErrorKind::InvalidData, "PKCS 11 initialization failed"))?)
     }

--- a/src/providers/pkcs11/utils.rs
+++ b/src/providers/pkcs11/utils.rs
@@ -94,7 +94,7 @@ pub fn key_pair_usage_flags_to_pkcs11_attributes(
     priv_template.push(Attribute::Decrypt((usage_flags.decrypt).into()));
     priv_template.push(Attribute::Derive((usage_flags.derive).into()));
     priv_template.push(Attribute::Extractable((usage_flags.export).into()));
-    priv_template.push(Attribute::Sensitive((usage_flags.export).into()));
+    priv_template.push(Attribute::Sensitive((!usage_flags.export).into()));
     priv_template.push(Attribute::Copyable((usage_flags.copy).into()));
     pub_template.push(Attribute::Copyable((usage_flags.copy).into()));
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -123,6 +123,8 @@ pub enum ProviderConfig {
         user_pin: Option<String>,
         /// Control whether public key operations are performed in software
         software_public_operations: Option<bool>,
+        /// Control whether it is allowed for a key to be exportable
+        allow_export: Option<bool>,
     },
     /// TPM provider configuration
     Tpm {

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -289,6 +289,7 @@ unsafe fn get_provider(
             slot_number,
             user_pin,
             software_public_operations,
+            allow_export,
             ..
         } => {
             use std::convert::TryInto;
@@ -301,6 +302,7 @@ unsafe fn get_provider(
                     .with_slot_number((*slot_number).try_into()?)
                     .with_user_pin(user_pin.clone())
                     .with_software_public_operations(*software_public_operations)
+                    .with_allow_export(*allow_export)
                     .build()?,
             )))
         }


### PR DESCRIPTION
On some PKCS11 implementations, it is not allowed to create a key that
can be exported. For that reason, prevent creating exportable keys from
the configuration file so that clients can have a better return value.

This probably should be written in the book as well, as a new possible return value for generate key.

Fix #462 