### PR TITLE
Update dependency on Trusted Services

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ mbed-crypto-provider = ["psa-crypto"]
 pkcs11-provider = ["cryptoki", "picky-asn1-der", "picky-asn1", "picky-asn1-x509", "psa-crypto", "rand"]
 tpm-provider = ["tss-esapi", "picky-asn1-der", "picky-asn1", "picky-asn1-x509", "hex"]
 cryptoauthlib-provider = ["rust-cryptoauthlib"]
-trusted-service-provider = ["mbed-crypto-provider", "bindgen", "prost-build", "prost"]
+trusted-service-provider = ["psa-crypto", "bindgen", "prost-build", "prost"]
 all-providers = ["tpm-provider", "pkcs11-provider", "mbed-crypto-provider", "cryptoauthlib-provider"]
 
 # Authenticators

--- a/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
+++ b/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
@@ -94,15 +94,18 @@ RUN cd nanopb-0.4.4-linux-x86 \
 RUN rm -rf nanopb-0.4.4-linux-x86 nanopb-0.4.4-linux-x86.tar.gz
 
 # Install mock Trusted Services
-RUN git clone https://git.trustedfirmware.org/TS/trusted-services.git --branch main \
+# Setup git config for patching dependencies
+RUN git config --global user.email "some@email.com"
+RUN git config --global user.name "Parsec Team"
+RUN git clone https://git.trustedfirmware.org/TS/trusted-services.git --branch integration \
 	&& cd trusted-services \
-	&& git reset --hard 2fc7e10c7c21e4dafbf63dc9d00dfc2a7a7fddad
+	&& git reset --hard c1cf9120e4ab0b359a27176b079769b9a7e6bb87
 # Install correct python dependencies
 RUN pip3 install -r trusted-services/requirements.txt
 RUN cd trusted-services/deployments/libts/linux-pc/ \
 	&& cmake . \
 	&& make \
-	&& cp libts.so nanopb_install/lib/libprotobuf-nanopb.a mbedcrypto_install/lib/libmbedcrypto.a /usr/local/lib/
+	&& cp libts.so nanopb_install/lib/libprotobuf-nanopb.a mbedtls_install/lib/libmbedcrypto.a /usr/local/lib/
 RUN rm -rf trusted-services
 
 # Create a new token in a new slot. The slot number assigned will be random

--- a/src/providers/trusted_service/context/asym_sign.rs
+++ b/src/providers/trusted_service/context/asym_sign.rs
@@ -17,11 +17,11 @@ impl Context {
     ) -> Result<Vec<u8>, Error> {
         info!("Handling SignHash request");
         let proto_req = SignHashIn {
-            handle: 0,
+            id: key_id,
             hash,
             alg: algorithm.try_into()?,
         };
-        let SignHashOut { signature } = self.send_request_with_key(proto_req, key_id)?;
+        let SignHashOut { signature } = self.send_request(&proto_req)?;
 
         Ok(signature)
     }
@@ -36,12 +36,12 @@ impl Context {
     ) -> Result<(), Error> {
         info!("Handling VerifyHash request");
         let proto_req = VerifyHashIn {
-            handle: 0,
+            id: key_id,
             hash,
             signature,
             alg: algorithm.try_into()?,
         };
-        self.send_request_with_key(proto_req, key_id)?;
+        self.send_request(&proto_req)?;
 
         Ok(())
     }

--- a/src/providers/trusted_service/context/mod.rs
+++ b/src/providers/trusted_service/context/mod.rs
@@ -10,7 +10,7 @@ use std::ptr::null_mut;
 use std::slice;
 use std::sync::Mutex;
 use ts_binding::*;
-use ts_protobuf::{CloseKeyIn, GetOpcode, OpenKeyIn, OpenKeyOut, SetHandle};
+use ts_protobuf::GetOpcode;
 
 #[allow(
     non_snake_case,
@@ -175,27 +175,6 @@ impl Context {
         unsafe { rpc_caller_end(self.rpc_caller, call_handle) };
 
         Ok(resp)
-    }
-
-    // Send a request that requires a key, given the key's ID.
-    // This function is responsible for opening the key, for sending the
-    // request with `send_request` and for closing the key afterwards.
-    fn send_request_with_key<T: Message + Default>(
-        &self,
-        mut req: impl Message + GetOpcode + SetHandle,
-        key_id: u32,
-    ) -> Result<T, Error> {
-        let open_req = OpenKeyIn { id: key_id };
-        let OpenKeyOut { handle } = self.send_request(&open_req)?;
-
-        req.set_handle(handle);
-        let res = self.send_request(&req);
-        let close_req = CloseKeyIn { handle };
-
-        let res_close = self.send_request(&close_req);
-        let res = res?;
-        res_close?;
-        Ok(res)
     }
 }
 

--- a/src/providers/trusted_service/context/ts_protobuf.rs
+++ b/src/providers/trusted_service/context/ts_protobuf.rs
@@ -48,37 +48,12 @@ macro_rules! opcode_impl {
     };
 }
 
-opcode_impl!(OpenKeyIn, OpenKeyOut, OpenKey);
-opcode_impl!(CloseKeyIn, CloseKey);
 opcode_impl!(GenerateKeyIn, GenerateKeyOut, GenerateKey);
 opcode_impl!(DestroyKeyIn, DestroyKeyOut, DestroyKey);
 opcode_impl!(SignHashIn, SignHashOut, SignHash);
 opcode_impl!(VerifyHashIn, VerifyHashOut, VerifyHash);
 opcode_impl!(ImportKeyIn, ImportKeyOut, ImportKey);
 opcode_impl!(ExportPublicKeyIn, ExportPublicKeyOut, ExportPublicKey);
-
-/// Trait allowing the handle of opened-key-dependent operations
-/// to be set in a generic way.
-pub trait SetHandle {
-    fn set_handle(&mut self, handle: u32);
-}
-
-macro_rules! set_handle_impl {
-    ($type:ty) => {
-        impl SetHandle for $type {
-            fn set_handle(&mut self, handle: u32) {
-                self.handle = handle;
-            }
-        }
-    };
-}
-
-set_handle_impl!(DestroyKeyIn);
-set_handle_impl!(SignHashIn);
-set_handle_impl!(VerifyHashIn);
-set_handle_impl!(AsymmetricEncryptIn);
-set_handle_impl!(AsymmetricDecryptIn);
-set_handle_impl!(ExportPublicKeyIn);
 
 impl Drop for ImportKeyIn {
     fn drop(&mut self) {

--- a/src/providers/trusted_service/key_management.rs
+++ b/src/providers/trusted_service/key_management.rs
@@ -3,13 +3,29 @@
 use super::Provider;
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::KeyTriple;
-use crate::providers::mbed_crypto::key_management::create_key_id;
 use log::error;
 use parsec_interface::operations::{
     psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
 };
 use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
+use psa_crypto::types::key::PSA_KEY_ID_USER_MAX;
+use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
+
+/// Creates a new PSA Key ID
+pub fn create_key_id(max_current_id: &AtomicU32) -> Result<u32> {
+    // fetch_add adds 1 to the old value and returns the old value, so add 1 to local value for new ID
+    let new_key_id = max_current_id.fetch_add(1, Relaxed) + 1;
+    if new_key_id > PSA_KEY_ID_USER_MAX {
+        // If storing key failed and no other keys were created in the mean time, it is safe to
+        // decrement the key counter.
+        let _ = max_current_id.store(PSA_KEY_ID_USER_MAX, Relaxed);
+        error!("PSA max key ID limit of {} reached", PSA_KEY_ID_USER_MAX);
+        return Err(ResponseStatus::PsaErrorInsufficientMemory);
+    }
+
+    Ok(new_key_id)
+}
 
 impl Provider {
     pub(super) fn psa_generate_key_internal(

--- a/src/providers/trusted_service/mod.rs
+++ b/src/providers/trusted_service/mod.rs
@@ -19,7 +19,6 @@ use psa_crypto::types::key;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU32, Ordering};
 use uuid::Uuid;
-
 mod asym_sign;
 mod context;
 mod error;
@@ -80,12 +79,8 @@ impl Provider {
                             }
                         };
 
-                        if ts_provider.context.check_key_exists(key_id)? {
-                            if key_id > max_key_id {
-                                max_key_id = key_id;
-                            }
-                        } else {
-                            to_remove.push(key_triple.clone());
+                        if key_id > max_key_id {
+                            max_key_id = key_id;
                         }
                     }
                 }


### PR DESCRIPTION
This commit updates our dependency on the upstream Trusted Services repo
to include recent commits. The changes include major updates to the
crypto interface, including a move to PSA Crypto v1, meaning a very
different approach to managing keys is needed. Calls to OpenKey and
CloseKey have been scrapped.
