### PR TITLE
[DONT MERGE] Test Parsec with Mbed TLS 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Build the container
+        run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
+      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
 
   pkcs11-provider:
     name: Integration tests using PKCS 11 provider

--- a/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
+++ b/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
@@ -71,7 +71,7 @@ RUN rm -rf SoftHSMv2
 # Download and install Mbed Crypto from Mbed TLS
 RUN git clone https://github.com/ARMmbed/mbedtls.git \
 	&& cd mbedtls \
-	&& git reset --hard mbedtls-2.25.0
+	&& git checkout v3.0.0
 RUN cd mbedtls \
 	&& ./scripts/config.py crypto \
 	&& SHARED=1 make \


### PR DESCRIPTION
Try if Parsec work when Mbed TLS is dynamically link with version 3.0.0.

See https://github.com/parallaxsecond/rust-psa-crypto/issues/85 for context.