### PR TITLE
Split out the all-providers cargo check into its own CI job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,19 @@ jobs:
       # When running the container built on the CI
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh all
 
+  build-all-providers:
+    name: Cargo check all-providers (current Rust stable & old compiler)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Use the following step when updating the `parsec-service-test-all` image
+      # - name: Build the container
+      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Run the container to execute the test script
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cargo-check
+      # When running the container built on the CI
+      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cargo-check
+
   mbed-crypto-provider:
     name: Integration tests using Mbed Crypto provider
     runs-on: ubuntu-latest

--- a/ci.sh
+++ b/ci.sh
@@ -117,13 +117,18 @@ while [ "$#" -gt 0 ]; do
         --no-stress-test )
             NO_STRESS_TEST="True"
         ;;
-        mbed-crypto | pkcs11 | tpm | trusted-service | cryptoauthlib | all)
+        mbed-crypto | pkcs11 | tpm | trusted-service | cryptoauthlib | all | cargo-check)
             if [ -n "$PROVIDER_NAME" ]; then
                 error_msg "Only one provider name must be given"
             fi
             PROVIDER_NAME=$1
-            cp $(pwd)/e2e_tests/provider_cfg/$1/config.toml $CONFIG_PATH
-            if [ "$PROVIDER_NAME" = "all" ]; then
+
+            # If running anything but cargo-check, copy config
+            if [ "$PROVIDER_NAME" != "cargo-check" ]; then
+                cp $(pwd)/e2e_tests/provider_cfg/$1/config.toml $CONFIG_PATH
+            fi
+
+            if [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "cargo-check" ]; then
                 FEATURES="--features=all-providers,all-authenticators"
                 TEST_FEATURES="--features=all-providers"
             else
@@ -245,7 +250,7 @@ fi
 
 echo "Build test"
 
-if [ "$PROVIDER_NAME" = "all" ]; then
+if [ "$PROVIDER_NAME" = "cargo-check" ]; then
     # We test that everything in the service still builds with the current Rust stable
     # and an old Rust compiler.
     # The old Rust compiler version is found by manually checking the oldest Rust version of all
@@ -278,6 +283,8 @@ if [ "$PROVIDER_NAME" = "all" ]; then
     RUST_BACKTRACE=1 cargo check --features="unix-peer-credentials-authenticator"
     RUST_BACKTRACE=1 cargo check --features="jwt-svid-authenticator"
     RUST_BACKTRACE=1 cargo check --features="all-authenticators"
+
+    exit 0
 fi
 
 RUST_BACKTRACE=1 cargo build $FEATURES


### PR DESCRIPTION
The cargo check using the latest version of rust, and an old version, is no longer included in the `Various tests targeting a Parsec image with all providers included` job. It now has it's own dedicated GitHub Actions job.

Closes #447 

Signed-off-by: Matt Davis <matt.davis@arm.com>