### PR TITLE
Do not login if no user pin was entered

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -121,8 +121,8 @@ key_info_manager = "on-disk-manager"
 #library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 # (Required) PKCS 11 slot that will be used by Parsec.
 #slot_number = 123456789
-# (Optional) User pin for authentication with the specific slot. If not set, no authentication will
-# be used.
+# (Optional) User pin for authentication with the specific slot. If not set, the sessions will not
+# be logged in. It might prevent some operations to execute successfully on some tokens.
 #user_pin = "123456"
 # (Optional) Control whether missing public key operation (such as verifying signatures or asymmetric
 # encryption) are fully performed in software. 

--- a/e2e_tests/tests/all_providers/config/mod.rs
+++ b/e2e_tests/tests/all_providers/config/mod.rs
@@ -299,3 +299,13 @@ fn ts_pkcs11_cross() {
         signature.clone(),
     );
 }
+
+#[test]
+fn no_user_pin() {
+    set_config("no_user_pin.toml");
+    // The service should still start, without the user pin.
+    reload_service();
+
+    let mut client = TestClient::new();
+    let _ = client.ping().unwrap();
+}

--- a/e2e_tests/tests/all_providers/config/tomls/no_user_pin.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_user_pin.toml
@@ -1,0 +1,32 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
+[listener]
+listener_type = "DomainSocket"
+# The timeout needs to be smaller than the test client timeout (five seconds) as it is testing
+# that the service does not hang for very big values of body or authentication length.
+timeout = 3000 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+provider_type = "Pkcs11"
+key_info_manager = "on-disk-manager"
+library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
+# The service should start without the user pin
+#user_pin = "123456"
+# The slot_number mandatory field is going to replace the following line with a valid number
+# slot_number

--- a/src/providers/pkcs11/utils.rs
+++ b/src/providers/pkcs11/utils.rs
@@ -38,7 +38,7 @@ pub fn to_response_status(error: Error) -> ResponseStatus {
         Error::TryFromSlice(e) => ResponseStatus::from(e),
         Error::NulError(e) => ResponseStatus::from(e),
         error => {
-            error!("Conversion of {} to PsaErrorCommunicationFailure", error);
+            format_error!("Conversion of error to PsaErrorCommunicationFailure", error);
             ResponseStatus::PsaErrorCommunicationFailure
         }
     }


### PR DESCRIPTION
Fixes a bug where the service would still login even though no user pin
was given in the configuration file.