### PR TITLE
Modify the git submodule command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,5 +8,5 @@ jobs:
     steps:
       - checkout
       - run: |
-          git submodule init
+          git submodule update --init --recursive
           cargo build --features=all-providers,all-authenticators


### PR DESCRIPTION
Last build on Circle CI [failed](https://app.circleci.com/pipelines/github/parallaxsecond/parsec/51/workflows/2d2ad5fd-6d15-485f-b42c-5ae4f5e1eab5/jobs/52) with "No such file or directory" in the service build script. I believe this is because the trusted-services-vendor submodule has not been populated.
Try with a new command.