### PR TITLE
Add the Class attribute when generating key pairs

### DIFF
--- a/src/providers/pkcs11/key_management.rs
+++ b/src/providers/pkcs11/key_management.rs
@@ -117,6 +117,8 @@ impl Provider {
             .mechanism_type()]),
         ];
         let mut priv_template = pub_template.clone();
+        priv_template.push(Attribute::Class(ObjectClass::PRIVATE_KEY));
+        pub_template.push(Attribute::Class(ObjectClass::PUBLIC_KEY));
         pub_template.push(Attribute::Private(false.into()));
 
         utils::key_pair_usage_flags_to_pkcs11_attributes(


### PR DESCRIPTION
As per the specs this is not mandatory but could help with some PKCS11
implementations.