### PR TITLE
Added KeyIdentity to replace KeyTriple

### DIFF
--- a/src/authenticators/jwt_svid_authenticator/mod.rs
+++ b/src/authenticators/jwt_svid_authenticator/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! JWT SVID authenticator
 
-use super::{Admin, AdminList, Application, Authenticate};
+use super::{Admin, AdminList, Application, ApplicationIdentity, Authenticate};
 use crate::front::listener::ConnectionMetadata;
 use log::error;
 use parsec_interface::operations::list_authenticators;
@@ -72,6 +72,12 @@ impl Authenticate for JwtSvidAuthenticator {
             })?;
         let app_name = spiffe_id.to_string();
         let is_admin = self.admins.is_admin(&app_name);
-        Ok(Application::new(app_name, is_admin))
+        Ok(Application {
+            identity: ApplicationIdentity {
+                name: app_name,
+                authenticator_id: AuthType::JwtSvid,
+            },
+            is_admin,
+        })
     }
 }

--- a/src/back/backend_handler.rs
+++ b/src/back/backend_handler.rs
@@ -103,7 +103,7 @@ impl BackEndHandler {
             if !app.is_admin() {
                 warn!(
                     "Application name \"{}\" tried to perform an admin operation ({:?}).",
-                    app.get_name(),
+                    app.identity().name(),
                     opcode
                 );
                 return Response::from_request_header(header, ResponseStatus::AdminOperation);
@@ -131,14 +131,15 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_generate_key(app.into(), op_generate_key));
+                    .psa_generate_key(app.identity(), op_generate_key));
                 trace!("psa_generate_key egress");
                 self.result_to_response(NativeResult::PsaGenerateKey(result), header)
             }
             NativeOperation::PsaImportKey(op_import_key) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
-                let result =
-                    unwrap_or_else_return!(self.provider.psa_import_key(app.into(), op_import_key));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .psa_import_key(app.identity(), op_import_key));
                 trace!("psa_import_key egress");
                 self.result_to_response(NativeResult::PsaImportKey(result), header)
             }
@@ -146,14 +147,15 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_export_public_key(app.into(), op_export_public_key));
+                    .psa_export_public_key(app.identity(), op_export_public_key));
                 trace!("psa_export_public_key egress");
                 self.result_to_response(NativeResult::PsaExportPublicKey(result), header)
             }
             NativeOperation::PsaExportKey(op_export_key) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
-                let result =
-                    unwrap_or_else_return!(self.provider.psa_export_key(app.into(), op_export_key));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .psa_export_key(app.identity(), op_export_key));
                 trace!("psa_export_key egress");
                 self.result_to_response(NativeResult::PsaExportKey(result), header)
             }
@@ -161,14 +163,15 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_destroy_key(app.into(), op_destroy_key));
+                    .psa_destroy_key(app.identity(), op_destroy_key));
                 trace!("psa_destroy_key egress");
                 self.result_to_response(NativeResult::PsaDestroyKey(result), header)
             }
             NativeOperation::PsaSignHash(op_sign_hash) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
-                let result =
-                    unwrap_or_else_return!(self.provider.psa_sign_hash(app.into(), op_sign_hash));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .psa_sign_hash(app.identity(), op_sign_hash));
                 trace!("psa_sign_hash egress");
                 self.result_to_response(NativeResult::PsaSignHash(result), header)
             }
@@ -176,7 +179,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_verify_hash(app.into(), op_verify_hash));
+                    .psa_verify_hash(app.identity(), op_verify_hash));
                 trace!("psa_verify_hash egress");
                 self.result_to_response(NativeResult::PsaVerifyHash(result), header)
             }
@@ -184,7 +187,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_asymmetric_encrypt(app.into(), op_asymmetric_encrypt));
+                    .psa_asymmetric_encrypt(app.identity(), op_asymmetric_encrypt));
                 trace!("psa_asymmetric_encrypt egress");
                 self.result_to_response(NativeResult::PsaAsymmetricEncrypt(result), header)
             }
@@ -192,7 +195,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_asymmetric_decrypt(app.into(), op_asymmetric_decrypt));
+                    .psa_asymmetric_decrypt(app.identity(), op_asymmetric_decrypt));
                 trace!("psa_asymmetric_decrypt egress");
                 self.result_to_response(NativeResult::PsaAsymmetricDecrypt(result), header)
             }
@@ -200,7 +203,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_aead_encrypt(app.into(), op_aead_encrypt));
+                    .psa_aead_encrypt(app.identity(), op_aead_encrypt));
                 trace!("psa_aead_encrypt egress");
                 self.result_to_response(NativeResult::PsaAeadEncrypt(result), header)
             }
@@ -208,7 +211,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_aead_decrypt(app.into(), op_aead_decrypt));
+                    .psa_aead_decrypt(app.identity(), op_aead_decrypt));
                 trace!("psa_aead_decrypt egress");
                 self.result_to_response(NativeResult::PsaAeadDecrypt(result), header)
             }
@@ -222,7 +225,7 @@ impl BackEndHandler {
             NativeOperation::ListKeys(op_list_keys) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result =
-                    unwrap_or_else_return!(self.provider.list_keys(app.into(), op_list_keys));
+                    unwrap_or_else_return!(self.provider.list_keys(app.identity(), op_list_keys));
                 trace!("list_keys egress");
                 self.result_to_response(NativeResult::ListKeys(result), header)
             }
@@ -232,7 +235,10 @@ impl BackEndHandler {
                 self.result_to_response(NativeResult::ListClients(result), header)
             }
             NativeOperation::DeleteClient(op_delete_client) => {
-                let result = unwrap_or_else_return!(self.provider.delete_client(op_delete_client));
+                let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .delete_client(app.identity(), op_delete_client));
                 trace!("delete_client egress");
                 self.result_to_response(NativeResult::DeleteClient(result), header)
             }
@@ -252,7 +258,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_raw_key_agreement(app.into(), op_raw_key_agreement));
+                    .psa_raw_key_agreement(app.identity(), op_raw_key_agreement));
                 trace!("psa_raw_key_agreement egress");
                 self.result_to_response(NativeResult::PsaRawKeyAgreement(result), header)
             }
@@ -266,7 +272,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_sign_message(app.into(), op_sign_message));
+                    .psa_sign_message(app.identity(), op_sign_message));
                 trace!("psa_sign_message egress");
                 self.result_to_response(NativeResult::PsaSignMessage(result), header)
             }
@@ -274,7 +280,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_verify_message(app.into(), op_verify_message));
+                    .psa_verify_message(app.identity(), op_verify_message));
                 trace!("psa_verify_message egress");
                 self.result_to_response(NativeResult::PsaVerifyMessage(result), header)
             }

--- a/src/front/front_end.rs
+++ b/src/front/front_end.rs
@@ -92,7 +92,7 @@ impl FrontEndHandler {
                 if let Some(app) = &app.as_ref() {
                     info!(
                         "New request received from application name \"{}\"",
-                        app.get_name()
+                        app.identity().name()
                     )
                 } else {
                     info!("New request received without authentication")
@@ -111,7 +111,7 @@ impl FrontEndHandler {
                     if let Some(app) = app {
                         info!(
                             "Response for application name \"{}\" sent back",
-                            app.get_name()
+                            app.identity().name()
                         );
                     } else {
                         info!("Response sent back from request without authentication");

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -6,15 +6,18 @@
 //! trait to help providers to store in a persistent manner the mapping between the name and the
 //! information of the keys they manage. Different implementors might store this mapping using different
 //! means but it has to be persistent.
-
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
+#[allow(deprecated)]
+use crate::key_info_managers::on_disk_manager::KeyTriple;
+use crate::providers::ProviderIdentity;
 use crate::utils::config::{KeyInfoManagerConfig, KeyInfoManagerType};
 use anyhow::Result;
 use derivative::Derivative;
 use parsec_interface::operations::psa_key_attributes::Attributes;
-use parsec_interface::requests::{ProviderId, ResponseStatus};
+use parsec_interface::requests::{AuthType, ResponseStatus};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::fmt;
 use std::sync::{Arc, RwLock};
 use zeroize::Zeroize;
@@ -24,18 +27,21 @@ pub mod on_disk_manager;
 /// This structure corresponds to a unique identifier of the key. It is used internally by the Key
 /// ID manager to refer to a key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct KeyTriple {
-    app_name: ApplicationName,
-    provider_id: ProviderId,
+pub struct KeyIdentity {
+    /// The identity of the application that created the key.
+    application: ApplicationIdentity,
+    /// The identity of the provider where the key is stored.
+    provider: ProviderIdentity,
+    /// The key name
     key_name: String,
 }
 
-impl fmt::Display for KeyTriple {
+impl fmt::Display for KeyIdentity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Application Name: \"{}\", Provider ID: {}, Key Name: \"{}\"",
-            self.app_name, self.provider_id, self.key_name
+            "KeyIdentity: {{\n{},\n{},\nkey_name: \"{}\",\n}}",
+            self.application, self.provider, self.key_name
         )
     }
 }
@@ -50,29 +56,43 @@ struct KeyInfo {
     attributes: Attributes,
 }
 
-impl KeyTriple {
-    /// Creates a new instance of KeyTriple.
-    pub fn new(app_name: ApplicationName, provider_id: ProviderId, key_name: String) -> KeyTriple {
-        KeyTriple {
-            app_name,
-            provider_id,
+impl KeyIdentity {
+    /// Creates a new instance of KeyIdentity.
+    pub fn new(
+        application: ApplicationIdentity,
+        provider: ProviderIdentity,
+        key_name: String,
+    ) -> KeyIdentity {
+        KeyIdentity {
+            application,
+            provider,
             key_name,
         }
     }
 
     /// Checks if this key belongs to a specific provider.
-    pub fn belongs_to_provider(&self, provider_id: ProviderId) -> bool {
-        self.provider_id == provider_id
+    pub fn belongs_to_provider(&self, provider_name: String) -> bool {
+        *self.provider().name() == provider_name
     }
 
     /// Get the key name
-    pub fn key_name(&self) -> &str {
+    pub fn key_name(&self) -> &String {
         &self.key_name
     }
 
+    /// Get the application identity of the key
+    pub fn application(&self) -> &ApplicationIdentity {
+        &self.application
+    }
+
+    /// Get the application identity of the key
+    pub fn provider(&self) -> &ProviderIdentity {
+        &self.provider
+    }
+
     /// Get the app name
-    pub fn app_name(&self) -> &ApplicationName {
-        &self.app_name
+    pub fn app_name(&self) -> &String {
+        &self.application.name()
     }
 }
 
@@ -96,14 +116,14 @@ trait ManageKeyInfo {
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn get(&self, key_triple: &KeyTriple) -> Result<Option<&KeyInfo>, String>;
+    fn get(&self, key_identity: &KeyIdentity) -> Result<Option<&KeyInfo>, String>;
 
     /// Returns a Vec of reference to the key triples corresponding to this provider.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn get_all(&self, provider_id: ProviderId) -> Result<Vec<&KeyTriple>, String>;
+    fn get_all(&self, provider_identity: ProviderIdentity) -> Result<Vec<KeyIdentity>, String>;
 
     /// Inserts a new mapping between the key triple and the key info. If the triple already exists,
     /// overwrite the existing mapping and returns the old `KeyInfo`. Otherwise returns `None`.
@@ -113,7 +133,7 @@ trait ManageKeyInfo {
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn insert(
         &mut self,
-        key_triple: KeyTriple,
+        key_identity: KeyIdentity,
         key_info: KeyInfo,
     ) -> Result<Option<KeyInfo>, String>;
 
@@ -123,14 +143,14 @@ trait ManageKeyInfo {
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn remove(&mut self, key_triple: &KeyTriple) -> Result<Option<KeyInfo>, String>;
+    fn remove(&mut self, key_identity: &KeyIdentity) -> Result<Option<KeyInfo>, String>;
 
     /// Check if a key triple mapping exists.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn exists(&self, key_triple: &KeyTriple) -> Result<bool, String>;
+    fn exists(&self, key_identity: &KeyIdentity) -> Result<bool, String>;
 }
 
 /// KeyInfoManager client structure that bridges between the KIM and the providers that need
@@ -138,15 +158,19 @@ trait ManageKeyInfo {
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct KeyInfoManagerClient {
-    provider_id: ProviderId,
+    provider_identity: ProviderIdentity,
     #[derivative(Debug = "ignore")]
     key_info_manager_impl: Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>,
 }
 
 impl KeyInfoManagerClient {
     /// Get the KeyTriple representing a key.
-    pub fn get_key_triple(&self, app_name: ApplicationName, key_name: String) -> KeyTriple {
-        KeyTriple::new(app_name, self.provider_id, key_name)
+    pub fn get_key_triple(
+        &self,
+        application: ApplicationIdentity,
+        key_name: String,
+    ) -> KeyIdentity {
+        KeyIdentity::new(application, self.provider_identity.clone(), key_name)
     }
 
     /// Get the key ID for a given key triple
@@ -161,13 +185,13 @@ impl KeyInfoManagerClient {
     /// type fails, InvalidEncoding is returned.
     pub fn get_key_id<T: DeserializeOwned>(
         &self,
-        key_triple: &KeyTriple,
+        key_identity: &KeyIdentity,
     ) -> parsec_interface::requests::Result<T> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
-        let key_info = match key_info_manager_impl.get(key_triple) {
+        let key_info = match key_info_manager_impl.get(key_identity) {
             Ok(Some(key_info)) => key_info,
             Ok(None) => return Err(ResponseStatus::PsaErrorDoesNotExist),
             Err(string) => return Err(to_response_status(string)),
@@ -185,7 +209,7 @@ impl KeyInfoManagerClient {
     /// KeyInfoManagerError is returned.
     pub fn get_key_attributes(
         &self,
-        key_triple: &KeyTriple,
+        key_triple: &KeyIdentity,
     ) -> parsec_interface::requests::Result<Attributes> {
         let key_info_manager_impl = self
             .key_info_manager_impl
@@ -200,15 +224,15 @@ impl KeyInfoManagerClient {
     }
 
     /// Get all the key triples for the current provider
-    pub fn get_all(&self) -> parsec_interface::requests::Result<Vec<KeyTriple>> {
+    pub fn get_all(&self) -> parsec_interface::requests::Result<Vec<KeyIdentity>> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
 
         key_info_manager_impl
-            .get_all(self.provider_id)
-            .map(|vec| vec.into_iter().cloned().collect())
+            .get_all(self.provider_identity.clone())
+            // .map(|vec| vec.into_iter().cloned().collect())
             .map_err(to_response_status)
     }
 
@@ -220,7 +244,7 @@ impl KeyInfoManagerClient {
     /// KeyInfoManagerError is returned.
     pub fn remove_key_info(
         &self,
-        key_triple: &KeyTriple,
+        key_triple: &KeyIdentity,
     ) -> parsec_interface::requests::Result<()> {
         let mut key_info_manager_impl = self
             .key_info_manager_impl
@@ -241,7 +265,7 @@ impl KeyInfoManagerClient {
     /// any other error occurring in the KIM, KeyInfoManagerError is returned.
     pub fn insert_key_info<T: Serialize>(
         &self,
-        key_triple: KeyTriple,
+        key_triple: KeyIdentity,
         key_id: &T,
         attributes: Attributes,
     ) -> parsec_interface::requests::Result<()> {
@@ -261,24 +285,25 @@ impl KeyInfoManagerClient {
         }
     }
 
-    /// Returns a Vec of ApplicationName of clients having keys in the provider.
+    /// Returns a Vec of ApplicationIdentity of clients having keys in the provider.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    pub fn list_clients(&self) -> parsec_interface::requests::Result<Vec<ApplicationName>> {
+    pub fn list_clients(&self) -> parsec_interface::requests::Result<Vec<ApplicationIdentity>> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
-        let key_triples = key_info_manager_impl
-            .get_all(self.provider_id)
+        let key_identities = key_info_manager_impl
+            .get_all(self.provider_identity.clone())
             .map_err(to_response_status)?;
-        let mut clients = Vec::new();
 
-        for key_triple in key_triples {
-            if !clients.contains(key_triple.app_name()) {
-                let _ = clients.push(key_triple.app_name().clone());
+        let mut clients = Vec::new();
+        for key_identity in key_identities {
+            // TODO: Check this comparison
+            if !clients.contains(&key_identity.application) {
+                let _ = clients.push(key_identity.application.clone());
             }
         }
 
@@ -293,7 +318,7 @@ impl KeyInfoManagerClient {
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     pub fn list_keys(
         &self,
-        app_name: &ApplicationName,
+        application_identity: &ApplicationIdentity,
     ) -> parsec_interface::requests::Result<Vec<parsec_interface::operations::list_keys::KeyInfo>>
     {
         use parsec_interface::operations::list_keys::KeyInfo;
@@ -303,26 +328,33 @@ impl KeyInfoManagerClient {
             .expect("Key Info Manager lock poisoned");
 
         let mut keys: Vec<KeyInfo> = Vec::new();
-        let key_triples = key_info_manager_impl
-            .get_all(self.provider_id)
+        let key_identities = key_info_manager_impl
+            .get_all(self.provider_identity.clone())
             .map_err(to_response_status)?;
 
-        for key_triple in key_triples {
-            if key_triple.app_name() != app_name {
+        for key_identity in key_identities {
+            // TODO: Change this to also match on authenticator_id for SQLiteKeyInfoManager.
+            if key_identity.application.name() != application_identity.name() {
                 continue;
             }
 
             let key_info = key_info_manager_impl
-                .get(key_triple)
+                .get(&key_identity)
                 .map_err(to_response_status)?;
             let key_info = match key_info {
                 Some(key_info) => key_info,
                 _ => continue,
             };
 
+            // TODO: Fix this translation when SQLiteKeyInfoManager is added.
+            #[allow(deprecated)]
+            let key_triple =
+                KeyTriple::try_from(key_identity.clone()).map_err(to_response_status)?;
+
+            #[allow(deprecated)]
             keys.push(KeyInfo {
-                provider_id: key_triple.provider_id,
-                name: key_triple.key_name().to_string(),
+                provider_id: *key_triple.provider_id(),
+                name: key_identity.key_name().to_string(),
                 attributes: key_info.attributes,
             });
         }
@@ -336,7 +368,7 @@ impl KeyInfoManagerClient {
     ///
     /// Returns PsaErrorAlreadyExists if the key triple already exists or KeyInfoManagerError for
     /// another error.
-    pub fn does_not_exist(&self, key_triple: &KeyTriple) -> Result<(), ResponseStatus> {
+    pub fn does_not_exist(&self, key_triple: &KeyIdentity) -> Result<(), ResponseStatus> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
@@ -363,13 +395,14 @@ pub struct KeyInfoManagerFactory {
 
 impl KeyInfoManagerFactory {
     /// Create a KeyInfoManagerFactory
-    pub fn new(config: &KeyInfoManagerConfig) -> Result<Self> {
+    pub fn new(config: &KeyInfoManagerConfig, default_auth_type: AuthType) -> Result<Self> {
         let manager = match config.manager_type {
             KeyInfoManagerType::OnDisk => {
                 let mut builder = on_disk_manager::OnDiskKeyInfoManagerBuilder::new();
                 if let Some(store_path) = &config.store_path {
                     builder = builder.with_mappings_dir_path(store_path.into());
                 }
+                builder = builder.with_auth_type(default_auth_type);
                 builder.build()?
             }
         };
@@ -380,10 +413,10 @@ impl KeyInfoManagerFactory {
     }
 
     /// Build a KeyInfoManagerClient
-    pub fn build_client(&self, provider: ProviderId) -> KeyInfoManagerClient {
+    pub fn build_client(&self, provider_identity: ProviderIdentity) -> KeyInfoManagerClient {
         KeyInfoManagerClient {
             key_info_manager_impl: self.key_info_manager_impl.clone(),
-            provider_id: provider,
+            provider_identity,
         }
     }
 }

--- a/src/providers/core/mod.rs
+++ b/src/providers/core/mod.rs
@@ -6,7 +6,7 @@
 //! aiding clients in discovering the capabilities offered by their underlying
 //! platform.
 use super::Provide;
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use derivative::Derivative;
 use log::{error, trace};
 use parsec_interface::operations::{
@@ -49,6 +49,14 @@ pub struct Provider {
     prov_list: Vec<Arc<dyn Provide + Send + Sync>>,
 }
 
+impl Provider {
+    /// The default provider name for cryptoauthlib provider
+    pub const DEFAULT_PROVIDER_NAME: &'static str = "core-provider";
+
+    /// The UUID for this provider
+    pub const PROVIDER_UUID: &'static str = "47049873-2a43-4845-9d72-831eab668784";
+}
+
 impl Provide for Provider {
     fn list_opcodes(&self, op: list_opcodes::Operation) -> Result<list_opcodes::Result> {
         trace!("list_opcodes ingress");
@@ -80,7 +88,7 @@ impl Provide for Provider {
 
     fn list_keys(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
         trace!("list_keys ingress");
@@ -93,7 +101,7 @@ impl Provide for Provider {
                 "unknown".to_string()
             };
             let mut result = provider
-                .list_keys(app_name.clone(), _op)
+                .list_keys(application_identity, _op)
                 .unwrap_or_else(|e| {
                     error!("list_keys failed on provider {} with {}", id, e);
                     list_keys::Result { keys: Vec::new() }
@@ -128,7 +136,11 @@ impl Provide for Provider {
         Ok(list_clients::Result { clients })
     }
 
-    fn delete_client(&self, op: delete_client::Operation) -> Result<delete_client::Result> {
+    fn delete_client(
+        &self,
+        application_identity: &ApplicationIdentity,
+        op: delete_client::Operation,
+    ) -> Result<delete_client::Result> {
         trace!("delete_client ingress");
 
         let client = op.client;
@@ -142,7 +154,10 @@ impl Provide for Provider {
             // Currently Parsec only stores keys, we delete all of them.
             let keys = provider
                 .list_keys(
-                    ApplicationName::from_name(client.clone()),
+                    &ApplicationIdentity::new(
+                        client.clone(),
+                        *application_identity.authenticator_id(),
+                    ),
                     list_keys::Operation {},
                 )
                 .unwrap_or_else(|e| {
@@ -154,7 +169,11 @@ impl Provide for Provider {
                 let key_name = key.name;
                 let _ = provider
                     .psa_destroy_key(
-                        ApplicationName::from_name(client.clone()),
+                        // TODO: Check auth type. Will need passing down when SQLite KIM is implemented.
+                        &ApplicationIdentity::new(
+                            client.clone(),
+                            *application_identity.authenticator_id(),
+                        ),
                         psa_destroy_key::Operation { key_name },
                     )
                     .unwrap_or_else(|e| {

--- a/src/providers/cryptoauthlib/asym_sign.rs
+++ b/src/providers/cryptoauthlib/asym_sign.rs
@@ -1,15 +1,15 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use log::error;
 use parsec_interface::operations::psa_algorithm::{AsymmetricSignature, Hash, SignHash};
 use parsec_interface::operations::psa_key_attributes::{EccFamily, Type};
 use parsec_interface::operations::{
     psa_sign_hash, psa_sign_message, psa_verify_hash, psa_verify_message,
 };
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use rust_cryptoauthlib::AtcaStatus;
 
 impl Provider {
@@ -76,10 +76,14 @@ impl Provider {
 
     pub(super) fn psa_sign_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::CryptoAuthLib, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         op.validate(key_attributes)?;
@@ -100,12 +104,12 @@ impl Provider {
 
     pub(super) fn psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
         let key_triple = self
             .key_info_store
-            .get_key_triple(app_name, op.key_name.clone());
+            .get_key_triple(application_identity.clone(), op.key_name.clone());
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         op.validate(key_attributes)?;
@@ -127,12 +131,12 @@ impl Provider {
 
     pub(super) fn psa_sign_message_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_message::Operation,
     ) -> Result<psa_sign_message::Result> {
         let key_triple = self
             .key_info_store
-            .get_key_triple(app_name, op.key_name.clone());
+            .get_key_triple(application_identity.clone(), op.key_name.clone());
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         op.validate(key_attributes)?;
@@ -155,12 +159,12 @@ impl Provider {
 
     pub(super) fn psa_verify_message_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_message::Operation,
     ) -> Result<psa_verify_message::Result> {
         let key_triple = self
             .key_info_store
-            .get_key_triple(app_name, op.key_name.clone());
+            .get_key_triple(application_identity.clone(), op.key_name.clone());
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         op.validate(key_attributes)?;

--- a/src/providers/cryptoauthlib/key_management.rs
+++ b/src/providers/cryptoauthlib/key_management.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::key_slot::KeySlotStatus;
 use super::Provider;
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use log::{error, warn};
 use parsec_interface::operations::psa_key_attributes::{Attributes, EccFamily, Type};
 use parsec_interface::operations::{
@@ -15,11 +15,13 @@ use zeroize::Zeroizing;
 impl Provider {
     pub(super) fn psa_generate_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
-        let key_triple = self.key_info_store.get_key_triple(app_name, key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), key_name);
 
         self.key_info_store.does_not_exist(&key_triple)?;
 
@@ -75,11 +77,13 @@ impl Provider {
 
     pub(super) fn psa_destroy_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = self.key_info_store.get_key_triple(app_name, key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), key_name);
         let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
 
         match self.key_info_store.remove_key_info(&key_triple) {
@@ -104,11 +108,13 @@ impl Provider {
 
     pub(super) fn psa_import_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         let key_name = op.key_name;
-        let key_triple = self.key_info_store.get_key_triple(app_name, key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), key_name);
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let key_attributes = op.attributes;
@@ -172,10 +178,12 @@ impl Provider {
 
     pub(super) fn psa_export_public_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
-        let key_triple = self.key_info_store.get_key_triple(app_name, op.key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), op.key_name);
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         match key_attributes.key_type {
@@ -208,10 +216,12 @@ impl Provider {
 
     pub(super) fn psa_export_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
-        let key_triple = self.key_info_store.get_key_triple(app_name, op.key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), op.key_name);
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         if !key_attributes.is_exportable() {

--- a/src/providers/mbed_crypto/aead.rs
+++ b/src/providers/mbed_crypto/aead.rs
@@ -1,22 +1,26 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::{psa_aead_decrypt, psa_aead_encrypt};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use psa_crypto::operations::aead;
 use psa_crypto::types::key;
 
 impl Provider {
     pub(super) fn psa_aead_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_aead_encrypt::Operation,
     ) -> Result<psa_aead_encrypt::Result> {
         let key_name = op.key_name.clone();
 
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let _guard = self
             .key_handle_mutex
@@ -54,10 +58,14 @@ impl Provider {
 
     pub(super) fn psa_aead_decrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_aead_decrypt::Operation,
     ) -> Result<psa_aead_decrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         let _guard = self

--- a/src/providers/mbed_crypto/asym_encryption.rs
+++ b/src/providers/mbed_crypto/asym_encryption.rs
@@ -1,22 +1,26 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use psa_crypto::operations::asym_encryption;
 use psa_crypto::types::key;
 
 impl Provider {
     pub(super) fn psa_asymmetric_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
         let key_name = op.key_name.clone();
 
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let _guard = self
             .key_handle_mutex
@@ -48,10 +52,14 @@ impl Provider {
 
     pub(super) fn psa_asymmetric_decrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         let _guard = self

--- a/src/providers/mbed_crypto/key_agreement.rs
+++ b/src/providers/mbed_crypto/key_agreement.rs
@@ -1,10 +1,10 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::psa_raw_key_agreement;
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use parsec_interface::secrecy::Secret;
 use psa_crypto::operations::key_agreement;
 use psa_crypto::types::key;
@@ -12,12 +12,16 @@ use psa_crypto::types::key;
 impl Provider {
     pub(super) fn psa_raw_key_agreement(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_raw_key_agreement::Operation,
     ) -> Result<psa_raw_key_agreement::Result> {
         let key_name = op.private_key_name.clone();
 
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let _guard = self
             .key_handle_mutex

--- a/src/providers/pkcs11/asym_encryption.rs
+++ b/src/providers/pkcs11/asym_encryption.rs
@@ -3,22 +3,26 @@
 use super::utils::to_response_status;
 use super::KeyPairType;
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use cryptoki::types::mechanism::Mechanism;
 use log::{info, trace};
 use parsec_interface::operations::psa_algorithm::Algorithm;
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use std::convert::TryFrom;
 
 impl Provider {
     pub(super) fn psa_asymmetric_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
@@ -42,10 +46,14 @@ impl Provider {
 
     pub(super) fn psa_asymmetric_decrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
@@ -69,10 +77,14 @@ impl Provider {
 
     pub(super) fn software_psa_asymmetric_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         op.validate(key_attributes)?;

--- a/src/providers/pkcs11/asym_sign.rs
+++ b/src/providers/pkcs11/asym_sign.rs
@@ -3,23 +3,27 @@
 use super::utils::to_response_status;
 use super::Provider;
 use super::{utils, KeyPairType};
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use cryptoki::types::mechanism::Mechanism;
 use log::{info, trace};
 use parsec_interface::operations::psa_algorithm::Algorithm;
 use parsec_interface::operations::psa_key_attributes::Type;
 use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use std::convert::TryFrom;
 
 impl Provider {
     pub(super) fn psa_sign_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
@@ -52,10 +56,14 @@ impl Provider {
 
     pub(super) fn psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
@@ -87,10 +95,14 @@ impl Provider {
 
     pub(super) fn software_psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         op.validate(key_attributes)?;

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -5,8 +5,9 @@
 //! This provider allows clients to access any PKCS 11 compliant device
 //! through the Parsec interface.
 use super::Provide;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::{KeyInfoManagerClient, KeyTriple};
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::{KeyIdentity, KeyInfoManagerClient};
+use crate::providers::ProviderIdentity;
 use cryptoki::types::locking::CInitializeArgs;
 use cryptoki::types::session::{Session, UserType};
 use cryptoki::types::slot_token::Slot;
@@ -58,8 +59,8 @@ const SUPPORTED_OPCODES: [Opcode; 8] = [
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Provider {
-    // The name of the provider set in the config.
-    provider_name: String,
+    // The identity of the provider including uuid & name.
+    provider_identity: ProviderIdentity,
     #[derivative(Debug = "ignore")]
     key_info_store: KeyInfoManagerClient,
     local_ids: RwLock<LocalIdStore>,
@@ -101,7 +102,10 @@ impl Provider {
 
         #[allow(clippy::mutex_atomic)]
         let pkcs11_provider = Provider {
-            provider_name,
+            provider_identity: ProviderIdentity {
+                name: provider_name,
+                uuid: String::from(Self::PROVIDER_UUID),
+            },
             key_info_store,
             local_ids: RwLock::new(HashSet::new()),
             backend,
@@ -115,7 +119,7 @@ impl Provider {
                 .local_ids
                 .write()
                 .expect("Local ID lock poisoned");
-            let mut to_remove: Vec<KeyTriple> = Vec::new();
+            let mut to_remove: Vec<KeyIdentity> = Vec::new();
             // Go through all PKCS 11 key triple to key info mappings and check if they are still
             // present.
             // Delete those who are not present and add to the local_store the ones present.
@@ -245,12 +249,12 @@ impl Provide for Provider {
 
     fn list_keys(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
         trace!("list_keys ingress");
         Ok(list_keys::Result {
-            keys: self.key_info_store.list_keys(&app_name)?,
+            keys: self.key_info_store.list_keys(application_identity)?,
         })
     }
 
@@ -261,91 +265,91 @@ impl Provide for Provider {
                 .key_info_store
                 .list_clients()?
                 .into_iter()
-                .map(|app_name| app_name.to_string())
+                .map(|application_identity| application_identity.name().clone())
                 .collect(),
         })
     }
 
     fn psa_generate_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         trace!("psa_generate_key ingress");
-        self.psa_generate_key_internal(app_name, op)
+        self.psa_generate_key_internal(application_identity, op)
     }
 
     fn psa_import_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         trace!("psa_import_key ingress");
-        self.psa_import_key_internal(app_name, op)
+        self.psa_import_key_internal(application_identity, op)
     }
 
     fn psa_export_public_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         trace!("psa_export_public_key ingress");
-        self.psa_export_public_key_internal(app_name, op)
+        self.psa_export_public_key_internal(application_identity, op)
     }
 
     fn psa_destroy_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         trace!("psa_destroy_key ingress");
-        self.psa_destroy_key_internal(app_name, op)
+        self.psa_destroy_key_internal(application_identity, op)
     }
 
     fn psa_sign_hash(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
         trace!("psa_sign_hash ingress");
-        self.psa_sign_hash_internal(app_name, op)
+        self.psa_sign_hash_internal(application_identity, op)
     }
 
     fn psa_verify_hash(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
         if self.software_public_operations {
             trace!("software_psa_verify_hash ingress");
-            self.software_psa_verify_hash_internal(app_name, op)
+            self.software_psa_verify_hash_internal(application_identity, op)
         } else {
             trace!("pkcs11_psa_verify_hash ingress");
-            self.psa_verify_hash_internal(app_name, op)
+            self.psa_verify_hash_internal(application_identity, op)
         }
     }
 
     fn psa_asymmetric_encrypt(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
         if self.software_public_operations {
             trace!("software_psa_asymmetric_encrypt ingress");
-            self.software_psa_asymmetric_encrypt_internal(app_name, op)
+            self.software_psa_asymmetric_encrypt_internal(application_identity, op)
         } else {
             trace!("psa_asymmetric_encrypt ingress");
-            self.psa_asymmetric_encrypt_internal(app_name, op)
+            self.psa_asymmetric_encrypt_internal(application_identity, op)
         }
     }
 
     fn psa_asymmetric_decrypt(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
         trace!("psa_asymmetric_decrypt ingress");
-        self.psa_asymmetric_decrypt_internal(app_name, op)
+        self.psa_asymmetric_decrypt_internal(application_identity, op)
     }
 }
 

--- a/src/providers/tpm/asym_encryption.rs
+++ b/src/providers/tpm/asym_encryption.rs
@@ -4,20 +4,24 @@ use super::{
     utils::{self, PasswordContext},
     Provider,
 };
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
-use parsec_interface::requests::{ProviderId, Result};
+use parsec_interface::requests::Result;
 use std::convert::TryInto;
 use std::ops::Deref;
 
 impl Provider {
     pub(super) fn psa_asymmetric_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let mut esapi_context = self
             .esapi_context
@@ -66,10 +70,14 @@ impl Provider {
 
     pub(super) fn psa_asymmetric_decrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let mut esapi_context = self
             .esapi_context

--- a/src/providers/tpm/asym_sign.rs
+++ b/src/providers/tpm/asym_sign.rs
@@ -4,22 +4,26 @@ use super::{
     utils::{self, PasswordContext},
     Provider,
 };
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use log::error;
 use parsec_interface::operations::psa_algorithm::*;
 use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use std::convert::TryFrom;
 use tss_esapi::structures::{Auth, Digest};
 
 impl Provider {
     pub(super) fn psa_sign_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let mut esapi_context = self
             .esapi_context
@@ -70,10 +74,14 @@ impl Provider {
 
     pub(super) fn psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let mut esapi_context = self
             .esapi_context

--- a/src/providers/trusted_service/asym_sign.rs
+++ b/src/providers/trusted_service/asym_sign.rs
@@ -1,18 +1,22 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
-use parsec_interface::requests::{ProviderId, Result};
+use parsec_interface::requests::Result;
 
 impl Provider {
     pub(super) fn psa_sign_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         Ok(psa_sign_hash::Result {
@@ -25,10 +29,14 @@ impl Provider {
 
     pub(super) fn psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         self.context

--- a/src/providers/trusted_service/key_management.rs
+++ b/src/providers/trusted_service/key_management.rs
@@ -1,13 +1,13 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use log::error;
 use parsec_interface::operations::{
     psa_destroy_key, psa_export_key, psa_export_public_key, psa_generate_key, psa_import_key,
 };
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
 use parsec_interface::secrecy::Secret;
 use psa_crypto::types::key::PSA_KEY_ID_USER_MAX;
@@ -31,12 +31,16 @@ pub fn create_key_id(max_current_id: &AtomicU32) -> Result<u32> {
 impl Provider {
     pub(super) fn psa_generate_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let key_id = create_key_id(&self.id_counter)?;
@@ -65,13 +69,17 @@ impl Provider {
 
     pub(super) fn psa_import_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_data = op.data;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let key_id = create_key_id(&self.id_counter)?;
@@ -102,11 +110,15 @@ impl Provider {
 
     pub(super) fn psa_export_public_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         match self.context.export_public_key(key_id) {
@@ -122,11 +134,15 @@ impl Provider {
 
     pub(super) fn psa_export_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         match self.context.export_key(key_id) {
@@ -142,11 +158,15 @@ impl Provider {
 
     pub(super) fn psa_destroy_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let _ = self.key_info_store.remove_key_info(&key_triple)?;
 

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -50,6 +50,26 @@ use crate::providers::tpm::ProviderBuilder as TpmProviderBuilder;
 #[cfg(feature = "trusted-service-provider")]
 use crate::providers::trusted_service::ProviderBuilder as TrustedServiceProviderBuilder;
 
+#[cfg(feature = "cryptoauthlib-provider")]
+use crate::providers::cryptoauthlib::Provider as CryptoAuthLibProvider;
+#[cfg(feature = "mbed-crypto-provider")]
+use crate::providers::mbed_crypto::Provider as MbedCryptoProvider;
+#[cfg(feature = "pkcs11-provider")]
+use crate::providers::pkcs11::Provider as Pkcs11Provider;
+#[cfg(feature = "tpm-provider")]
+use crate::providers::tpm::Provider as TpmProvider;
+#[cfg(feature = "trusted-service-provider")]
+use crate::providers::trusted_service::Provider as TrustedServiceProvider;
+
+#[cfg(any(
+    feature = "mbed-crypto-provider",
+    feature = "pkcs11-provider",
+    feature = "tpm-provider",
+    feature = "cryptoauthlib-provider",
+    feature = "trusted-service-provider"
+))]
+use crate::providers::ProviderIdentity;
+
 #[cfg(any(
     feature = "mbed-crypto-provider",
     feature = "pkcs11-provider",
@@ -99,8 +119,16 @@ impl ServiceBuilder {
             )
             .build();
 
-        let key_info_manager_builders =
-            gey_key_info_manager_builders(config.key_manager.as_ref().unwrap_or(&Vec::new()))?;
+        let authenticators = build_authenticators(&config.authenticator)?;
+
+        if authenticators[0].0 == AuthType::Direct {
+            warn!("Direct authenticator has been set as the default one. It is only secure under specific requirements. Please make sure to read the Recommendations on a Secure Parsec Deployment at https://parallaxsecond.github.io/parsec-book/parsec_security/secure_deployment.html");
+        }
+
+        let key_info_manager_builders = gey_key_info_manager_builders(
+            config.key_manager.as_ref().unwrap_or(&Vec::new()),
+            authenticators[0].0,
+        )?;
 
         let providers = build_providers(
             config.provider.as_ref().unwrap_or(&Vec::new()),
@@ -110,12 +138,6 @@ impl ServiceBuilder {
         if providers.is_empty() {
             error!("Parsec needs at least one provider to start. No valid provider could be created from the configuration.");
             return Err(Error::new(ErrorKind::InvalidData, "need one provider").into());
-        }
-
-        let authenticators = build_authenticators(&config.authenticator)?;
-
-        if authenticators[0].0 == AuthType::Direct {
-            warn!("Direct authenticator has been set as the default one. It is only secure under specific requirements. Please make sure to read the Recommendations on a Secure Parsec Deployment at https://parallaxsecond.github.io/parsec-book/parsec_security/secure_deployment.html");
         }
 
         let backend_handlers = build_backend_handlers(providers, &authenticators)?;
@@ -282,9 +304,13 @@ unsafe fn get_provider(
         #[cfg(feature = "mbed-crypto-provider")]
         ProviderConfig::MbedCrypto { .. } => {
             info!("Creating a Mbed Crypto Provider.");
+            let provider_identity = ProviderIdentity::new(
+                MbedCryptoProvider::PROVIDER_UUID.to_string(),
+                config.provider_name()?,
+            );
             Ok(Some(Arc::new(
                 MbedCryptoProviderBuilder::new()
-                    .with_key_info_store(kim_factory.build_client(ProviderId::MbedCrypto))
+                    .with_key_info_store(kim_factory.build_client(provider_identity))
                     .with_provider_name(config.provider_name()?)
                     .build()?,
             )))
@@ -299,9 +325,13 @@ unsafe fn get_provider(
             ..
         } => {
             info!("Creating a PKCS 11 Provider.");
+            let provider_identity = ProviderIdentity::new(
+                Pkcs11Provider::PROVIDER_UUID.to_string(),
+                config.provider_name()?,
+            );
             Ok(Some(Arc::new(
                 Pkcs11ProviderBuilder::new()
-                    .with_key_info_store(kim_factory.build_client(ProviderId::Pkcs11))
+                    .with_key_info_store(kim_factory.build_client(provider_identity))
                     .with_provider_name(config.provider_name()?)
                     .with_pkcs11_library_path(library_path.clone())
                     .with_slot_number(*slot_number)
@@ -321,6 +351,11 @@ unsafe fn get_provider(
             use std::str::FromStr;
             use tss_esapi::tcti_ldr::{TctiContext, TctiNameConf};
             info!("Creating a TPM Provider.");
+
+            let provider_identity = ProviderIdentity::new(
+                TpmProvider::PROVIDER_UUID.to_string(),
+                config.provider_name()?,
+            );
 
             let tcti_name_conf = TctiNameConf::from_str(tcti).map_err(|_| {
                 std::io::Error::new(ErrorKind::InvalidData, "Invalid TCTI configuration string")
@@ -342,7 +377,7 @@ unsafe fn get_provider(
 
             Ok(Some(Arc::new(
                 TpmProviderBuilder::new()
-                    .with_key_info_store(kim_factory.build_client(ProviderId::Tpm))
+                    .with_key_info_store(kim_factory.build_client(provider_identity))
                     .with_provider_name(config.provider_name()?)
                     .with_tcti(tcti)
                     .with_owner_hierarchy_auth(owner_hierarchy_auth.clone())
@@ -362,9 +397,13 @@ unsafe fn get_provider(
             ..
         } => {
             info!("Creating a CryptoAuthentication Library Provider.");
+            let provider_identity = ProviderIdentity::new(
+                CryptoAuthLibProvider::PROVIDER_UUID.to_string(),
+                config.provider_name()?,
+            );
             Ok(Some(Arc::new(
                 CryptoAuthLibProviderBuilder::new()
-                    .with_key_info_store(kim_factory.build_client(ProviderId::CryptoAuthLib))
+                    .with_key_info_store(kim_factory.build_client(provider_identity))
                     .with_provider_name(config.provider_name()?)
                     .with_device_type(device_type.to_string())
                     .with_iface_type(iface_type.to_string())
@@ -380,9 +419,13 @@ unsafe fn get_provider(
         #[cfg(feature = "trusted-service-provider")]
         ProviderConfig::TrustedService { .. } => {
             info!("Creating a TPM Provider.");
+            let provider_identity = ProviderIdentity::new(
+                TrustedServiceProvider::PROVIDER_UUID.to_string(),
+                config.provider_name()?,
+            );
             Ok(Some(Arc::new(
                 TrustedServiceProviderBuilder::new()
-                    .with_key_info_store(kim_factory.build_client(ProviderId::TrustedService))
+                    .with_key_info_store(kim_factory.build_client(provider_identity))
                     .with_provider_name(config.provider_name()?)
                     .build()?,
             )))
@@ -406,10 +449,14 @@ unsafe fn get_provider(
 
 fn gey_key_info_manager_builders(
     configs: &[KeyInfoManagerConfig],
+    default_auth_type: AuthType,
 ) -> Result<HashMap<String, KeyInfoManagerFactory>> {
     let mut map = HashMap::new();
     for config in configs {
-        let _ = map.insert(config.name.clone(), KeyInfoManagerFactory::new(config)?);
+        let _ = map.insert(
+            config.name.clone(),
+            KeyInfoManagerFactory::new(config, default_auth_type)?,
+        );
     }
 
     Ok(map)


### PR DESCRIPTION
`KeyIdentity` contains an `ApplicationIdentity`, `ProviderIdentity` and a `key_name`.
`KeyTriple` still exists but solely for the use by the `OnDiskKeyInfoManager`.
This is preliminary work towards the new `SQLiteKeyInfoManager` as part of #486

Apologies for the large pr... 👨🏼‍💻

There may be some incorrect variable naming in places regarding `key_triple` where it should be `key_identity` instead. I will address this in a future PR as this will be a ~200 loc by itself.

Closes #488

Signed-off-by: Matt Davis <matt.davis@arm.com>