### PR TITLE
Renamed all references of KeyTriple to KeyIdentity.

### DIFF
--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-//! Persistent mapping between key triples and key information
+//! Persistent mapping between key identities and key information
 //!
 //! This module declares a [`ManageKeyInfo`](https://parallaxsecond.github.io/parsec-book/parsec_service/key_info_managers.html)
 //! trait to help providers to store in a persistent manner the mapping between the name and the
@@ -110,7 +110,7 @@ pub fn to_response_status(error_string: String) -> ResponseStatus {
 ///
 /// Interface to be implemented for persistent storage of key name -> key info mappings.
 trait ManageKeyInfo {
-    /// Returns a reference to the key info corresponding to this key triple or `None` if it does not
+    /// Returns a reference to the key info corresponding to this KeyIdentity or `None` if it does not
     /// exist.
     ///
     /// # Errors
@@ -118,14 +118,14 @@ trait ManageKeyInfo {
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn get(&self, key_identity: &KeyIdentity) -> Result<Option<&KeyInfo>, String>;
 
-    /// Returns a Vec of reference to the key triples corresponding to this provider.
+    /// Returns a Vec of reference to the key identities corresponding to this provider.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn get_all(&self, provider_identity: ProviderIdentity) -> Result<Vec<KeyIdentity>, String>;
 
-    /// Inserts a new mapping between the key triple and the key info. If the triple already exists,
+    /// Inserts a new mapping between the KeyIdentity and the key info. If the KeyIdentity already exists,
     /// overwrite the existing mapping and returns the old `KeyInfo`. Otherwise returns `None`.
     ///
     /// # Errors
@@ -137,7 +137,7 @@ trait ManageKeyInfo {
         key_info: KeyInfo,
     ) -> Result<Option<KeyInfo>, String>;
 
-    /// Removes a key triple mapping and returns it. Does nothing and returns `None` if the mapping
+    /// Removes a KeyIdentity mapping and returns it. Does nothing and returns `None` if the mapping
     /// does not exist.
     ///
     /// # Errors
@@ -145,7 +145,7 @@ trait ManageKeyInfo {
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn remove(&mut self, key_identity: &KeyIdentity) -> Result<Option<KeyInfo>, String>;
 
-    /// Check if a key triple mapping exists.
+    /// Check if a KeyIdentity mapping exists.
     ///
     /// # Errors
     ///
@@ -164,8 +164,8 @@ pub struct KeyInfoManagerClient {
 }
 
 impl KeyInfoManagerClient {
-    /// Get the KeyTriple representing a key.
-    pub fn get_key_triple(
+    /// Get the KeyIdentity representing a key.
+    pub fn get_key_identity(
         &self,
         application: ApplicationIdentity,
         key_name: String,
@@ -173,7 +173,7 @@ impl KeyInfoManagerClient {
         KeyIdentity::new(application, self.provider_identity.clone(), key_name)
     }
 
-    /// Get the key ID for a given key triple
+    /// Get the key ID for a given KeyIdentity
     ///
     /// The ID does not have to be a specific type. Rather, it must implement the `serde::Deserialize`
     /// trait. Before returning, an instance of that type is created from the bytes stored by the KIM.
@@ -201,7 +201,7 @@ impl KeyInfoManagerClient {
         Ok(bincode::deserialize(&key_info.id)?)
     }
 
-    /// Get the `Attributes` for a given key triple
+    /// Get the `Attributes` for a given KeyIdentity
     ///
     /// # Errors
     ///
@@ -209,13 +209,13 @@ impl KeyInfoManagerClient {
     /// KeyInfoManagerError is returned.
     pub fn get_key_attributes(
         &self,
-        key_triple: &KeyIdentity,
+        key_identity: &KeyIdentity,
     ) -> parsec_interface::requests::Result<Attributes> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
-        let key_info = match key_info_manager_impl.get(key_triple) {
+        let key_info = match key_info_manager_impl.get(key_identity) {
             Ok(Some(key_info)) => key_info,
             Ok(None) => return Err(ResponseStatus::PsaErrorDoesNotExist),
             Err(string) => return Err(to_response_status(string)),
@@ -223,7 +223,7 @@ impl KeyInfoManagerClient {
         Ok(key_info.attributes)
     }
 
-    /// Get all the key triples for the current provider
+    /// Get all the key identities for the current provider
     pub fn get_all(&self) -> parsec_interface::requests::Result<Vec<KeyIdentity>> {
         let key_info_manager_impl = self
             .key_info_manager_impl
@@ -236,7 +236,7 @@ impl KeyInfoManagerClient {
             .map_err(to_response_status)
     }
 
-    /// Remove the key represented by a key triple and return the stored info.
+    /// Remove the key represented by a KeyIdentity and return the stored info.
     ///
     /// # Errors
     ///
@@ -244,28 +244,28 @@ impl KeyInfoManagerClient {
     /// KeyInfoManagerError is returned.
     pub fn remove_key_info(
         &self,
-        key_triple: &KeyIdentity,
+        key_identity: &KeyIdentity,
     ) -> parsec_interface::requests::Result<()> {
         let mut key_info_manager_impl = self
             .key_info_manager_impl
             .write()
             .expect("Key Info Manager lock poisoned");
-        match key_info_manager_impl.remove(key_triple) {
+        match key_info_manager_impl.remove(key_identity) {
             Ok(Some(_key_info)) => Ok(()),
             Ok(None) => Err(ResponseStatus::PsaErrorDoesNotExist),
             Err(string) => Err(to_response_status(string)),
         }
     }
 
-    /// Insert key info for a given triple.
+    /// Insert key info for a given KeyIdentity.
     ///
     /// # Errors
     ///
-    /// If the key triple already existed in the KIM, PsaErrorAlreadyExists is returned. For
+    /// If the KeyIdentity already existed in the KIM, PsaErrorAlreadyExists is returned. For
     /// any other error occurring in the KIM, KeyInfoManagerError is returned.
     pub fn insert_key_info<T: Serialize>(
         &self,
-        key_triple: KeyIdentity,
+        key_identity: KeyIdentity,
         key_id: &T,
         attributes: Attributes,
     ) -> parsec_interface::requests::Result<()> {
@@ -278,7 +278,7 @@ impl KeyInfoManagerClient {
             attributes,
         };
 
-        match key_info_manager_impl.insert(key_triple, key_info) {
+        match key_info_manager_impl.insert(key_identity, key_info) {
             Ok(None) => Ok(()),
             Ok(Some(_)) => Err(ResponseStatus::PsaErrorAlreadyExists),
             Err(string) => Err(to_response_status(string)),
@@ -362,20 +362,20 @@ impl KeyInfoManagerClient {
         Ok(keys)
     }
 
-    /// Check if a key triple exists in the Key Info Manager and return a ResponseStatus
+    /// Check if a KeyIdentity exists in the Key Info Manager and return a ResponseStatus
     ///
     /// # Errors
     ///
-    /// Returns PsaErrorAlreadyExists if the key triple already exists or KeyInfoManagerError for
+    /// Returns PsaErrorAlreadyExists if the KeyIdentity already exists or KeyInfoManagerError for
     /// another error.
-    pub fn does_not_exist(&self, key_triple: &KeyIdentity) -> Result<(), ResponseStatus> {
+    pub fn does_not_exist(&self, key_identity: &KeyIdentity) -> Result<(), ResponseStatus> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
 
         if key_info_manager_impl
-            .exists(key_triple)
+            .exists(key_identity)
             .map_err(to_response_status)?
         {
             Err(ResponseStatus::PsaErrorAlreadyExists)

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -655,24 +655,24 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_get_key_info_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("insert_get_key_info".to_string());
+        let key_identity = new_key_identity("insert_get_key_info".to_string());
         let key_info = test_key_info();
 
-        assert!(manager.get(&key_triple).unwrap().is_none());
+        assert!(manager.get(&key_identity).unwrap().is_none());
 
         assert!(manager
-            .insert(key_triple.clone(), key_info.clone())
+            .insert(key_identity.clone(), key_info.clone())
             .unwrap()
             .is_none());
 
         let stored_key_info = manager
-            .get(&key_triple)
+            .get(&key_identity)
             .unwrap()
             .expect("Failed to get key info")
             .clone();
 
         assert_eq!(stored_key_info, key_info);
-        assert!(manager.remove(&key_triple).unwrap().is_some());
+        assert!(manager.remove(&key_identity).unwrap().is_some());
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -681,12 +681,12 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_remove_key_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("insert_remove_key".to_string());
+        let key_identity = new_key_identity("insert_remove_key".to_string());
         let key_info = test_key_info();
 
-        let _ = manager.insert(key_triple.clone(), key_info).unwrap();
+        let _ = manager.insert(key_identity.clone(), key_info).unwrap();
 
-        assert!(manager.remove(&key_triple).unwrap().is_some());
+        assert!(manager.remove(&key_identity).unwrap().is_some());
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -695,8 +695,8 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/remove_unexisting_key_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("remove_unexisting_key".to_string());
-        assert_eq!(manager.remove(&key_triple).unwrap(), None);
+        let key_identity = new_key_identity("remove_unexisting_key".to_string());
+        assert_eq!(manager.remove(&key_identity).unwrap(), None);
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -705,16 +705,16 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/exists_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("exists".to_string());
+        let key_identity = new_key_identity("exists".to_string());
         let key_info = test_key_info();
 
-        assert!(!manager.exists(&key_triple).unwrap());
+        assert!(!manager.exists(&key_identity).unwrap());
 
-        let _ = manager.insert(key_triple.clone(), key_info).unwrap();
-        assert!(manager.exists(&key_triple).unwrap());
+        let _ = manager.insert(key_identity.clone(), key_info).unwrap();
+        assert!(manager.exists(&key_identity).unwrap());
 
-        let _ = manager.remove(&key_triple).unwrap();
-        assert!(!manager.exists(&key_triple).unwrap());
+        let _ = manager.remove(&key_identity).unwrap();
+        assert!(!manager.exists(&key_identity).unwrap());
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -723,26 +723,26 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_overwrites_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("insert_overwrites".to_string());
+        let key_identity = new_key_identity("insert_overwrites".to_string());
         let key_info_1 = test_key_info();
         let key_info_2 = KeyInfo {
             id: vec![0xaa, 0xbb, 0xcc],
             attributes: test_key_attributes(),
         };
 
-        let _ = manager.insert(key_triple.clone(), key_info_1).unwrap();
+        let _ = manager.insert(key_identity.clone(), key_info_1).unwrap();
         let _ = manager
-            .insert(key_triple.clone(), key_info_2.clone())
+            .insert(key_identity.clone(), key_info_2.clone())
             .unwrap();
 
         let stored_key_info = manager
-            .get(&key_triple)
+            .get(&key_identity)
             .unwrap()
             .expect("Failed to get key info")
             .clone();
 
         assert_eq!(stored_key_info, key_info_2);
-        assert!(manager.remove(&key_triple).unwrap().is_some());
+        assert!(manager.remove(&key_identity).unwrap().is_some());
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -754,7 +754,7 @@ mod test {
         let big_app_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
         let big_key_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             ApplicationIdentity::new(big_app_name_ascii, AuthType::NoAuth),
             ProviderIdentity::new(
                 CoreProvider::PROVIDER_UUID.to_string(),
@@ -765,9 +765,9 @@ mod test {
         let key_info = test_key_info();
 
         let _ = manager
-            .insert(key_triple.clone(), key_info.clone())
+            .insert(key_identity.clone(), key_info.clone())
             .unwrap();
-        assert_eq!(manager.remove(&key_triple).unwrap().unwrap(), key_info);
+        assert_eq!(manager.remove(&key_identity).unwrap().unwrap(), key_info);
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -867,7 +867,7 @@ mod test {
         fs::remove_dir_all(path).unwrap();
     }
 
-    fn new_key_triple(key_name: String) -> KeyIdentity {
+    fn new_key_identity(key_name: String) -> KeyIdentity {
         KeyIdentity::new(
             ApplicationIdentity::new("Testing Application 😎".to_string(), AuthType::NoAuth),
             ProviderIdentity::new(

--- a/src/providers/cryptoauthlib/asym_sign.rs
+++ b/src/providers/cryptoauthlib/asym_sign.rs
@@ -79,12 +79,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
         if op.hash.len() != Hash::Sha256.hash_length() {
@@ -95,7 +95,7 @@ impl Provider {
             AsymmetricSignature::Ecdsa {
                 hash_alg: SignHash::Specific(Hash::Sha256),
             } => {
-                let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+                let key_id = self.key_info_store.get_key_id::<u8>(&key_identity)?;
                 self.ecdsa_hash_sign(key_id, &op.hash)
             }
             _ => Err(ResponseStatus::PsaErrorNotSupported),
@@ -107,10 +107,10 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = self
+        let key_identity = self
             .key_info_store
-            .get_key_triple(application_identity.clone(), op.key_name.clone());
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+            .get_key_identity(application_identity.clone(), op.key_name.clone());
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
         if op.hash.len() != Hash::Sha256.hash_length() {
@@ -121,7 +121,7 @@ impl Provider {
             AsymmetricSignature::Ecdsa {
                 hash_alg: SignHash::Specific(Hash::Sha256),
             } => {
-                let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+                let key_id = self.key_info_store.get_key_id::<u8>(&key_identity)?;
                 let verify_mode = self.ecdsa_verify_mode_get(key_id, key_attributes.key_type)?;
                 self.ecdsa_hash_verify(verify_mode, op.hash, op.signature)
             }
@@ -134,10 +134,10 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_message::Operation,
     ) -> Result<psa_sign_message::Result> {
-        let key_triple = self
+        let key_identity = self
             .key_info_store
-            .get_key_triple(application_identity.clone(), op.key_name.clone());
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+            .get_key_identity(application_identity.clone(), op.key_name.clone());
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -145,7 +145,7 @@ impl Provider {
             AsymmetricSignature::Ecdsa {
                 hash_alg: SignHash::Specific(Hash::Sha256),
             } => {
-                let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+                let key_id = self.key_info_store.get_key_id::<u8>(&key_identity)?;
                 // Compute a hash
                 let hash = self.sha256(&op.message)?.hash;
                 // Sign computed hash
@@ -162,10 +162,10 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_message::Operation,
     ) -> Result<psa_verify_message::Result> {
-        let key_triple = self
+        let key_identity = self
             .key_info_store
-            .get_key_triple(application_identity.clone(), op.key_name.clone());
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+            .get_key_identity(application_identity.clone(), op.key_name.clone());
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -173,7 +173,7 @@ impl Provider {
             AsymmetricSignature::Ecdsa {
                 hash_alg: SignHash::Specific(Hash::Sha256),
             } => {
-                let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+                let key_id = self.key_info_store.get_key_id::<u8>(&key_identity)?;
                 // Calculate a hash of a message
                 let hash = self.sha256(&op.message)?.hash;
                 // Determine verify mode

--- a/src/providers/cryptoauthlib/key_slot.rs
+++ b/src/providers/cryptoauthlib/key_slot.rs
@@ -21,7 +21,7 @@ pub enum KeySlotStatus {
 #[derive(Copy, Clone, Debug)]
 /// Hardware slot information
 pub struct AteccKeySlot {
-    /// Diagnostic field. Number of key triples pointing at this slot
+    /// Diagnostic field. Number of key identities pointing at this slot
     pub ref_count: u8,
     /// Slot status
     pub status: KeySlotStatus,

--- a/src/providers/cryptoauthlib/key_slot_storage.rs
+++ b/src/providers/cryptoauthlib/key_slot_storage.rs
@@ -30,9 +30,9 @@ impl KeySlotStorage {
     ) -> Result<Option<String>, String> {
         let mut key_slots = self.storage.write().unwrap();
 
-        // Get CryptoAuthLibProvider mapping of key triple to key info and check
-        // (1) if the key info matches ATECC configuration - drop key triple if not
-        // (2) if there are no two key triples mapping to a single ATECC slot - warning only ATM
+        // Get CryptoAuthLibProvider mapping of KeyIdentity to key info and check
+        // (1) if the key info matches ATECC configuration - drop KeyIdentity if not
+        // (2) if there are no two key identities mapping to a single ATECC slot - warning only ATM
 
         // check (1)
         match key_slots[key_id as usize].key_attr_vs_config(key_id, &key_attr, None) {

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -115,47 +115,47 @@ impl Provider {
         // Mark the slots free/busy appropriately.
         let mut to_remove: Vec<KeyIdentity> = Vec::new();
         match cryptoauthlib_provider.key_info_store.get_all() {
-            Ok(key_triples) => {
-                for key_triple in key_triples.iter().cloned() {
+            Ok(key_identities) => {
+                for key_identity in key_identities.iter().cloned() {
                     match cryptoauthlib_provider
                         .key_info_store
-                        .does_not_exist(&key_triple)
+                        .does_not_exist(&key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {
-                            warn!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...",
-                                key_triple,
+                            warn!("Error getting the Key ID for KeyIdentity:\n{}\n(error: {}), continuing...",
+                                key_identity,
                                 err
                             );
-                            to_remove.push(key_triple.clone());
+                            to_remove.push(key_identity.clone());
                             continue;
                         }
                     };
                     let key_info_id = match cryptoauthlib_provider
                         .key_info_store
-                        .get_key_id::<u8>(&key_triple)
+                        .get_key_id::<u8>(&key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {
                             warn!(
-                                "Could not get key info id for key triple {:?} because {}",
-                                key_triple, err
+                                "Could not get key info id for KeyIdentity {:?} because {}",
+                                key_identity, err
                             );
-                            to_remove.push(key_triple.clone());
+                            to_remove.push(key_identity.clone());
                             continue;
                         }
                     };
                     let key_info_attributes = match cryptoauthlib_provider
                         .key_info_store
-                        .get_key_attributes(&key_triple)
+                        .get_key_attributes(&key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {
                             warn!(
-                                "Could not get key attributes for key triple {:?} because {}",
-                                key_triple, err
+                                "Could not get key attributes for KeyIdentity {:?} because {}",
+                                key_identity, err
                             );
-                            to_remove.push(key_triple.clone());
+                            to_remove.push(key_identity.clone());
                             continue;
                         }
                     };
@@ -164,10 +164,12 @@ impl Provider {
                         .key_validate_and_mark_busy(key_info_id, &key_info_attributes)
                     {
                         Ok(None) => (),
-                        Ok(Some(warning)) => warn!("{} for key triple {:?}", warning, key_triple),
+                        Ok(Some(warning)) => {
+                            warn!("{} for KeyIdentity {:?}", warning, key_identity)
+                        }
                         Err(err) => {
-                            warn!("{} for key triple {:?}", err, key_triple);
-                            to_remove.push(key_triple.clone());
+                            warn!("{} for KeyIdentity {:?}", err, key_identity);
+                            to_remove.push(key_identity.clone());
                             continue;
                         }
                     }
@@ -178,10 +180,10 @@ impl Provider {
                 return None;
             }
         };
-        for key_triple in to_remove.iter() {
+        for key_identity in to_remove.iter() {
             if let Err(err) = cryptoauthlib_provider
                 .key_info_store
-                .remove_key_info(key_triple)
+                .remove_key_info(key_identity)
             {
                 error!("Key Info Manager error: {}", err);
                 return None;

--- a/src/providers/mbed_crypto/aead.rs
+++ b/src/providers/mbed_crypto/aead.rs
@@ -16,12 +16,12 @@ impl Provider {
     ) -> Result<psa_aead_encrypt::Result> {
         let key_name = op.key_name.clone();
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
         let _guard = self
             .key_handle_mutex
             .lock()
@@ -61,12 +61,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_aead_decrypt::Operation,
     ) -> Result<psa_aead_decrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/asym_encryption.rs
+++ b/src/providers/mbed_crypto/asym_encryption.rs
@@ -16,12 +16,12 @@ impl Provider {
     ) -> Result<psa_asymmetric_encrypt::Result> {
         let key_name = op.key_name.clone();
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
         let _guard = self
             .key_handle_mutex
             .lock()
@@ -55,12 +55,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/asym_sign.rs
+++ b/src/providers/mbed_crypto/asym_sign.rs
@@ -17,12 +17,12 @@ impl Provider {
         let key_name = op.key_name;
         let hash = op.hash;
         let alg = op.alg;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex
@@ -58,12 +58,12 @@ impl Provider {
         let hash = op.hash;
         let alg = op.alg;
         let signature = op.signature;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/key_agreement.rs
+++ b/src/providers/mbed_crypto/key_agreement.rs
@@ -17,12 +17,12 @@ impl Provider {
     ) -> Result<psa_raw_key_agreement::Result> {
         let key_name = op.private_key_name.clone();
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
         let _guard = self
             .key_handle_mutex
             .lock()

--- a/src/providers/mbed_crypto/key_management.rs
+++ b/src/providers/mbed_crypto/key_management.rs
@@ -39,13 +39,13 @@ impl Provider {
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
 
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let key_id = create_key_id(&self.id_counter)?;
 
@@ -58,7 +58,7 @@ impl Provider {
             Ok(key) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     // Safe as this thread should be the only one accessing this key yet.
                     if unsafe { psa_crypto_key_management::destroy(key) }.is_err() {
@@ -85,12 +85,12 @@ impl Provider {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_data = op.data;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let key_id = create_key_id(&self.id_counter)?;
 
@@ -107,7 +107,7 @@ impl Provider {
             Ok(key) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     // Safe as this thread should be the only one accessing this key yet.
                     if unsafe { psa_crypto_key_management::destroy(key) }.is_err() {
@@ -132,12 +132,12 @@ impl Provider {
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex
@@ -163,12 +163,12 @@ impl Provider {
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex
@@ -194,14 +194,14 @@ impl Provider {
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
 
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let _ = self.key_info_store.remove_key_info(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let _ = self.key_info_store.remove_key_info(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -107,20 +107,20 @@ impl Provider {
         let mut max_key_id: key::psa_key_id_t = key::PSA_KEY_ID_USER_MIN;
         {
             let mut to_remove: Vec<KeyIdentity> = Vec::new();
-            // Go through all MbedCryptoProvider key triple to key info mappings and check if they are still
+            // Go through all MbedCryptoProvider key identities to key info mappings and check if they are still
             // present.
             // Delete those who are not present and add to the local_store the ones present.
             match mbed_crypto_provider.key_info_store.get_all() {
-                Ok(key_triples) => {
-                    for key_triple in key_triples.iter().cloned() {
+                Ok(key_identities) => {
+                    for key_identity in key_identities.iter().cloned() {
                         let key_id = match mbed_crypto_provider
                             .key_info_store
-                            .get_key_id(&key_triple)
+                            .get_key_id(&key_identity)
                         {
                             Ok(key_id) => key_id,
                             Err(response_status) => {
-                                error!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...", key_triple, response_status);
-                                to_remove.push(key_triple.clone());
+                                error!("Error getting the Key ID for KeyIdentity:\n{}\n(error: {}), continuing...", key_identity, response_status);
+                                to_remove.push(key_identity.clone());
                                 continue;
                             }
                         };
@@ -131,7 +131,9 @@ impl Provider {
                                     max_key_id = key_id;
                                 }
                             }
-                            Err(status::Error::DoesNotExist) => to_remove.push(key_triple.clone()),
+                            Err(status::Error::DoesNotExist) => {
+                                to_remove.push(key_identity.clone())
+                            }
                             Err(e) => {
                                 format_error!("Failed to open persistent Mbed Crypto key", e);
                                 return None;
@@ -143,10 +145,10 @@ impl Provider {
                     return None;
                 }
             };
-            for key_triple in to_remove.iter() {
+            for key_identity in to_remove.iter() {
                 if mbed_crypto_provider
                     .key_info_store
-                    .remove_key_info(key_triple)
+                    .remove_key_info(key_identity)
                     .is_err()
                 {
                     return None;

--- a/src/providers/pkcs11/asym_encryption.rs
+++ b/src/providers/pkcs11/asym_encryption.rs
@@ -18,13 +18,13 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -49,13 +49,13 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -80,12 +80,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -93,7 +93,7 @@ impl Provider {
         let salt_buff = op.salt.as_ref().map(|salt| salt.as_slice());
         let buffer_size = key_attributes.asymmetric_encrypt_output_size(alg)?;
         let mut ciphertext = vec![0u8; buffer_size];
-        let pub_key_id = self.move_pub_key_to_psa_crypto(&key_triple)?;
+        let pub_key_id = self.move_pub_key_to_psa_crypto(&key_identity)?;
 
         info!("Encrypting plaintext with PSA Crypto");
         let res = match psa_crypto::operations::asym_encryption::encrypt(

--- a/src/providers/pkcs11/asym_sign.rs
+++ b/src/providers/pkcs11/asym_sign.rs
@@ -19,14 +19,14 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
 
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -59,13 +59,13 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -98,16 +98,16 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
-        let pub_key_id = self.move_pub_key_to_psa_crypto(&key_triple)?;
+        let pub_key_id = self.move_pub_key_to_psa_crypto(&key_identity)?;
 
         info!("Verifying signature with PSA Crypto");
         let res = match psa_crypto::operations::asym_signature::verify_hash(

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -120,30 +120,31 @@ impl Provider {
                 .write()
                 .expect("Local ID lock poisoned");
             let mut to_remove: Vec<KeyIdentity> = Vec::new();
-            // Go through all PKCS 11 key triple to key info mappings and check if they are still
+            // Go through all PKCS 11 key identities to key info mappings and check if they are still
             // present.
             // Delete those who are not present and add to the local_store the ones present.
             match pkcs11_provider.key_info_store.get_all() {
-                Ok(key_triples) => {
+                Ok(key_identities) => {
                     let session = pkcs11_provider.new_session().ok()?;
 
-                    for key_triple in key_triples.iter().cloned() {
-                        let key_id = match pkcs11_provider.key_info_store.get_key_id(&key_triple) {
+                    for key_identity in key_identities.iter().cloned() {
+                        let key_id = match pkcs11_provider.key_info_store.get_key_id(&key_identity)
+                        {
                             Ok(id) => id,
                             Err(ResponseStatus::PsaErrorDoesNotExist) => {
-                                error!("Stored key info missing for key triple {}.", key_triple);
+                                error!("Stored key info missing for KeyIdentity {}.", key_identity);
                                 continue;
                             }
                             Err(e) => {
                                 format_error!(
                                     format!(
-                                        "Stored key info invalid for key triple {}.",
-                                        key_triple
+                                        "Stored key info invalid for KeyIdentity {}.",
+                                        key_identity
                                     ),
                                     e
                                 );
 
-                                to_remove.push(key_triple.clone());
+                                to_remove.push(key_identity.clone());
                                 continue;
                             }
                         };
@@ -153,7 +154,7 @@ impl Provider {
                                 if crate::utils::GlobalConfig::log_error_details() {
                                     warn!(
                                         "Key {} found in the PKCS 11 library, adding it.",
-                                        key_triple
+                                        key_identity
                                     );
                                 } else {
                                     warn!("Key found in the PKCS 11 library, adding it.");
@@ -164,12 +165,12 @@ impl Provider {
                                 if crate::utils::GlobalConfig::log_error_details() {
                                     warn!(
                                         "Key {} not found in the PKCS 11 library, deleting it.",
-                                        key_triple
+                                        key_identity
                                     );
                                 } else {
                                     warn!("Key not found in the PKCS 11 library, deleting it.");
                                 }
-                                to_remove.push(key_triple.clone());
+                                to_remove.push(key_identity.clone());
                             }
                             Err(e) => {
                                 format_error!("Error finding key objects", e);
@@ -183,10 +184,10 @@ impl Provider {
                     return None;
                 }
             };
-            for key_triple in to_remove.iter() {
+            for key_identity in to_remove.iter() {
                 if pkcs11_provider
                     .key_info_store
-                    .remove_key_info(&key_triple)
+                    .remove_key_info(&key_identity)
                     .is_err()
                 {
                     return None;

--- a/src/providers/tpm/asym_encryption.rs
+++ b/src/providers/tpm/asym_encryption.rs
@@ -17,7 +17,7 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
@@ -28,8 +28,8 @@ impl Provider {
             .lock()
             .expect("ESAPI Context lock poisoned");
 
-        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -73,7 +73,7 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
@@ -84,8 +84,8 @@ impl Provider {
             .lock()
             .expect("ESAPI Context lock poisoned");
 
-        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 

--- a/src/providers/tpm/asym_sign.rs
+++ b/src/providers/tpm/asym_sign.rs
@@ -19,7 +19,7 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
@@ -30,8 +30,8 @@ impl Provider {
             .lock()
             .expect("ESAPI Context lock poisoned");
 
-        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         match op.alg {
             AsymmetricSignature::RsaPkcs1v15Sign { .. } => (),
@@ -77,7 +77,7 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
@@ -88,8 +88,8 @@ impl Provider {
             .lock()
             .expect("ESAPI Context lock poisoned");
 
-        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         match op.alg {
             AsymmetricSignature::RsaPkcs1v15Sign { .. } => (),

--- a/src/providers/tpm/key_management.rs
+++ b/src/providers/tpm/key_management.rs
@@ -27,13 +27,13 @@ impl Provider {
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
         let attributes = op.attributes;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
 
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         if op.attributes.key_type.is_public_key() {
             error!("A public key type can not be generated.");
@@ -55,7 +55,7 @@ impl Provider {
         let auth_value = auth_value.unwrap();
 
         self.key_info_store.insert_key_info(
-            key_triple,
+            key_identity,
             &PasswordContext {
                 context: key_context,
                 auth_value: auth_value.value().to_vec(),
@@ -101,13 +101,13 @@ impl Provider {
 
         let key_name = op.key_name;
         let attributes = op.attributes;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
         let key_data = op.data;
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
         let mut esapi_context = self
             .esapi_context
             .lock()
@@ -130,7 +130,7 @@ impl Provider {
             })?;
 
         self.key_info_store.insert_key_info(
-            key_triple,
+            key_identity,
             &PasswordContext {
                 context: pub_key_context,
                 auth_value: Vec::new(),
@@ -157,14 +157,14 @@ impl Provider {
         }
         let key_name = op.key_name;
         let attributes = op.attributes;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
         let key_data = op.data;
 
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
         let mut esapi_context = self
             .esapi_context
             .lock()
@@ -197,7 +197,7 @@ impl Provider {
             })?;
 
         self.key_info_store.insert_key_info(
-            key_triple,
+            key_identity,
             &PasswordContext {
                 context: keypair_context,
                 auth_value: Vec::new(),
@@ -214,7 +214,7 @@ impl Provider {
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
@@ -225,8 +225,8 @@ impl Provider {
             .lock()
             .expect("ESAPI Context lock poisoned");
 
-        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         let pub_key_data = esapi_context
             .read_public_key(password_context.context)
@@ -246,13 +246,13 @@ impl Provider {
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
 
-        let _ = self.key_info_store.remove_key_info(&key_triple)?;
+        let _ = self.key_info_store.remove_key_info(&key_identity)?;
 
         Ok(psa_destroy_key::Result {})
     }

--- a/src/providers/trusted_service/asym_sign.rs
+++ b/src/providers/trusted_service/asym_sign.rs
@@ -12,12 +12,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         Ok(psa_sign_hash::Result {
             signature: self
@@ -32,12 +32,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         self.context
             .verify_hash(key_id, op.hash.to_vec(), op.signature.to_vec(), op.alg)?;

--- a/src/providers/trusted_service/key_management.rs
+++ b/src/providers/trusted_service/key_management.rs
@@ -36,12 +36,12 @@ impl Provider {
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let key_id = create_key_id(&self.id_counter)?;
 
@@ -49,7 +49,7 @@ impl Provider {
             Ok(_) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     if self.context.destroy_key(key_id).is_err() {
                         error!("Failed to destroy the previously generated key.");
@@ -75,12 +75,12 @@ impl Provider {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_data = op.data;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let key_id = create_key_id(&self.id_counter)?;
 
@@ -91,7 +91,7 @@ impl Provider {
             Ok(_) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     if self.context.destroy_key(key_id).is_err() {
                         error!("Failed to destroy the previously generated key.");
@@ -114,12 +114,12 @@ impl Provider {
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         match self.context.export_public_key(key_id) {
             Ok(pub_key) => Ok(psa_export_public_key::Result {
@@ -138,12 +138,12 @@ impl Provider {
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         match self.context.export_key(key_id) {
             Ok(key) => Ok(psa_export_key::Result {
@@ -162,13 +162,13 @@ impl Provider {
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let _ = self.key_info_store.remove_key_info(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let _ = self.key_info_store.remove_key_info(&key_identity)?;
 
         match self.context.destroy_key(key_id) {
             Ok(()) => Ok(psa_destroy_key::Result {}),

--- a/src/providers/trusted_service/mod.rs
+++ b/src/providers/trusted_service/mod.rs
@@ -83,17 +83,17 @@ impl Provider {
         let mut max_key_id: key::psa_key_id_t = key::PSA_KEY_ID_USER_MIN;
         {
             let mut to_remove: Vec<KeyIdentity> = Vec::new();
-            // Go through all TrustedServiceProvider key triples to key info mappings and check if they are still
+            // Go through all TrustedServiceProvider key identities to key info mappings and check if they are still
             // present.
             // Delete those who are not present and add to the local_store the ones present.
             match ts_provider.key_info_store.get_all() {
-                Ok(key_triples) => {
-                    for key_triple in key_triples.iter().cloned() {
-                        let key_id = match ts_provider.key_info_store.get_key_id(&key_triple) {
+                Ok(key_identities) => {
+                    for key_identity in key_identities.iter().cloned() {
+                        let key_id = match ts_provider.key_info_store.get_key_id(&key_identity) {
                             Ok(key_id) => key_id,
                             Err(response_status) => {
-                                error!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...", key_triple, response_status);
-                                to_remove.push(key_triple.clone());
+                                error!("Error getting the Key ID for KeyIdentity:\n{}\n(error: {}), continuing...", key_identity, response_status);
+                                to_remove.push(key_identity.clone());
                                 continue;
                             }
                         };
@@ -108,8 +108,8 @@ impl Provider {
                     return Err(std::io::Error::new(std::io::ErrorKind::Other, string).into());
                 }
             };
-            for key_triple in to_remove.iter() {
-                if let Err(string) = ts_provider.key_info_store.remove_key_info(key_triple) {
+            for key_identity in to_remove.iter() {
+                if let Err(string) = ts_provider.key_info_store.remove_key_info(key_identity) {
                     return Err(std::io::Error::new(std::io::ErrorKind::Other, string).into());
                 }
             }


### PR DESCRIPTION
As KeyTriple is now internal to the OnDiskKeyInfoManager. All outside documentation and references
to KIM key "indentifiers" have been updated to KeyIdentity.

This PR simply renames these outside of the OnDiskKeyInfoManager:
`key_triple` -> `key_identity`
`key_triples` -> `key_identities`
`KeyTriple` -> `KeyIdentity`
`key triple` -> `key identity`
`key triples` -> `key identities`

Signed-off-by: Matt Davis <matt.davis@arm.com>