### PR TITLE
Added additional unit tests to SQLiteKeyInfoManager.

### DIFF
--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -131,7 +131,9 @@ impl Provider {
                                     max_key_id = key_id;
                                 }
                             }
-                            Err(status::Error::InvalidHandle) => to_remove.push(key_triple.clone()),
+                            Err(status::Error::InvalidHandle) => {
+                                to_remove.push(key_identity.clone())
+                            }
                             Err(e) => {
                                 format_error!("Failed to open persistent Mbed Crypto key", e);
                                 return None;


### PR DESCRIPTION
These tests ensure that keys are segmented correctly by the defined namespace.

Separated by:
    - Application Name
    - Authenticator
    - Key Name

Not separated by:
    - Provider Name
    - Provider UUID

Closes #510

Signed-off-by: Matt Davis <matt.davis@arm.com>