### PR TITLE
Added provider name config tests.

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,16 @@ pub mod cli;
 pub mod config;
 mod global_config;
 mod service_builder;
+#[cfg(all(
+    feature = "mbed-crypto-provider",
+    feature = "pkcs11-provider",
+    feature = "tpm-provider",
+    feature = "cryptoauthlib-provider",
+    feature = "trusted-service-provider",
+    feature = "direct-authenticator"
+))]
+#[cfg(test)]
+mod tests;
 
 pub use global_config::GlobalConfig;
 pub use service_builder::ServiceBuilder;

--- a/src/utils/tests/config/providers_different_type.toml
+++ b/src/utils/tests/config/providers_different_type.toml
@@ -1,0 +1,25 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+provider_type = "MbedCrypto"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/config/providers_different_type_same_name.toml
+++ b/src/utils/tests/config/providers_different_type_same_name.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+name="a-name"
+provider_type = "MbedCrypto"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+name="a-name"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/config/providers_same_type_default_name.toml
+++ b/src/utils/tests/config/providers_same_type_default_name.toml
@@ -1,0 +1,25 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/config/providers_same_type_different_name.toml
+++ b/src/utils/tests/config/providers_same_type_different_name.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+name="trusted-service-provider-0"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+name="trusted-service-provider-1"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/config/providers_same_type_same_name.toml
+++ b/src/utils/tests/config/providers_same_type_same_name.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+name="a-name"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+name="a-name"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/mod.rs
+++ b/src/utils/tests/mod.rs
@@ -1,0 +1,107 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! Static config tests to see if the service starts with different configurations.
+
+use crate::utils::config::ServiceConfig;
+use crate::utils::ServiceBuilder;
+use anyhow::anyhow;
+use log::error;
+use std::env;
+use std::io::Error;
+use std::io::ErrorKind;
+
+const CONFIG_TOMLS_FOLDER: &str = "src/utils/tests/config";
+
+fn config_to_toml(file_name: String) -> ServiceConfig {
+    let mut new_config_path = env::current_dir() // this is the root of the crate for tests
+        .unwrap();
+    new_config_path.push(CONFIG_TOMLS_FOLDER);
+    new_config_path.push(file_name.clone());
+    if !new_config_path.exists() {
+        error!("Configuration file {} does not exist", file_name);
+        panic!();
+    }
+
+    let config_file = ::std::fs::read_to_string(new_config_path.clone())
+        .map_err(|e| {
+            error!(
+                "Failed to read config file from path: {:#?}\nError: {:#?}",
+                new_config_path, e
+            );
+            panic!();
+        })
+        .unwrap();
+    toml::from_str(&config_file)
+        .map_err(|e| {
+            error!("Failed to parse service configuration ({})", e);
+            panic!();
+        })
+        .unwrap()
+}
+
+/// Check that the service throws an error when two providers of the same type are started,
+/// without setting a name (therefore they have the same default name).
+#[test]
+fn providers_same_type_default_name() {
+    let config_path: String = "providers_same_type_default_name.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let expected_error = anyhow!(Error::new(
+        ErrorKind::InvalidData,
+        "duplicate provider names found"
+    ));
+
+    let err = ServiceBuilder::build_service(&config).unwrap_err();
+    assert_eq!(format!("{:#?}", err), format!("{:#?}", expected_error));
+}
+
+/// Check that the service starts when two providers of the same type have different names.
+#[test]
+fn providers_same_type_different_name() {
+    let config_path: String = "providers_same_type_different_name.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let _ = ServiceBuilder::build_service(&config).unwrap();
+}
+
+/// Check that the service throws an error when two providers of the same type explicitly
+/// set the same name.
+#[test]
+fn providers_same_type_same_name() {
+    let config_path: String = "providers_same_type_same_name.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let expected_error = anyhow!(Error::new(
+        ErrorKind::InvalidData,
+        "duplicate provider names found"
+    ));
+
+    let err = ServiceBuilder::build_service(&config).unwrap_err();
+    assert_eq!(format!("{:#?}", err), format!("{:#?}", expected_error));
+}
+
+/// Check that the service throws an error when two providers of different types explicitly
+/// set the same name.
+#[test]
+fn providers_different_type_same_name() {
+    let config_path: String = "providers_different_type_same_name.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let expected_error = anyhow!(Error::new(
+        ErrorKind::InvalidData,
+        "duplicate provider names found"
+    ));
+
+    let err = ServiceBuilder::build_service(&config).unwrap_err();
+    assert_eq!(format!("{:#?}", err), format!("{:#?}", expected_error));
+}
+
+/// Check that the service starts when two providers of different types are declared.
+/// (Different default provider names)
+#[test]
+fn providers_different_type() {
+    let config_path: String = "providers_different_type.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let _ = ServiceBuilder::build_service(&config).unwrap();
+}


### PR DESCRIPTION
Added config tests that cover different values given to provider names within the config.
These tests cover two providers where:
- Same provider type, same name. (Throw error)
- Same provider type, different name. (Allow)
- Same provider type, same default name. (Throw error).
- Different types, same name. (Throw error). (We could allow this in the future if we wish).
- Different types, different default names. (Allow)

Closes #496

Signed-off-by: Matt Davis <matt.davis@arm.com>