### PR TITLE
Update provider to use new version fo TransKeyCtx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hamming"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65043da274378d68241eb9a8f8f8aa54e349136f7b8e12f63e3ef44043cc30e1"
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1215,52 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "primal"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf9e0aea92a2e2a931fafb1b5d4c6e438197bbca4943a9984b3327fb8e3b5d0"
+dependencies = [
+ "primal-check",
+ "primal-estimate",
+ "primal-sieve",
+]
+
+[[package]]
+name = "primal-bit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2837edc85364907810b0ec880f1010dab1a9cc6e75bacb3655c7fd22e125ec1b"
+dependencies = [
+ "hamming",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01419cee72c1a1ca944554e23d83e483e1bccf378753344e881de28b5487511d"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
+name = "primal-estimate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e07b550a7cbfcaa567bcd28042919548016ad615b5731633fa5239992d853f"
+
+[[package]]
+name = "primal-sieve"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0113d948c8f955a7ae96520023fe1e730eadbf26e67c4452f801a485e9d357"
+dependencies = [
+ "primal-bit",
+ "primal-estimate",
+ "smallvec",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -1924,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "6.1.0"
+version = "7.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bb26bea47d9a884f613730d2f68c9aeaef9a6a51ce8277d111042dbb8c5975"
+checksum = "d65600c381941a18c1bfbc3f0f65976e34ef5d22b9b6c1d3d256df28c152601b"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -1935,6 +1987,7 @@ dependencies = [
  "mbox",
  "num-derive",
  "num-traits",
+ "primal",
  "regex",
  "serde",
  "tss-esapi-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.14", features = ["serde"] }
 cryptoki = { version = "0.2.0", optional = true, features = ["psa-crypto-conversions"] }
 picky-asn1-der = { version = "<=0.2.4", optional = true }
 picky-asn1 = { version = ">=0.3.1, <=0.3.1", optional = true }
-tss-esapi = { version = "6.1.0", optional = true }
+tss-esapi = { version = "7.0.0-alpha.1", optional = true }
 bincode = "1.3.1"
 structopt = "0.3.21"
 derivative = "2.2.0"

--- a/e2e_tests/tests/per_provider/mod.rs
+++ b/e2e_tests/tests/per_provider/mod.rs
@@ -3,3 +3,5 @@
 mod key_mappings;
 mod normal_tests;
 mod stress_test;
+#[cfg(feature = "tpm-provider")]
+mod tpm_reset;

--- a/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
@@ -90,7 +90,7 @@ fn asym_verify_fail_ecc_sha256() -> Result<()> {
 #[test]
 fn only_verify_from_internet() -> Result<()> {
     let mut client = TestClient::new();
-    let key_name = String::from("only_verify");
+    let key_name = String::from("only_verify_from_internet");
     if !client.is_operation_supported(Opcode::PsaImportKey) {
         return Ok(());
     }

--- a/e2e_tests/tests/per_provider/normal_tests/import_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/import_key.rs
@@ -365,43 +365,43 @@ fn failed_imported_key_should_be_removed() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "tpm-provider")]
-#[test]
-fn import_key_pair() {
-    let mut client = TestClient::new();
-    let key_name = String::from("failed_imported_key_should_be_removed");
+// #[cfg(feature = "tpm-provider")]
+// #[test]
+// fn import_key_pair() {
+//     let mut client = TestClient::new();
+//     let key_name = String::from("failed_imported_key_should_be_removed");
 
-    client
-        .import_key(
-            key_name,
-            Attributes {
-                lifetime: Lifetime::Persistent,
-                key_type: Type::RsaKeyPair,
-                bits: 1024,
-                policy: Policy {
-                    usage_flags: UsageFlags {
-                        export: false,
-                        copy: false,
-                        cache: false,
-                        encrypt: false,
-                        decrypt: false,
-                        sign_message: true,
-                        sign_hash: true,
-                        verify_message: true,
-                        verify_hash: true,
-                        derive: false,
-                    },
-                    permitted_algorithms: Algorithm::AsymmetricSignature(
-                        AsymmetricSignature::RsaPkcs1v15Sign {
-                            hash_alg: Hash::Sha256.into(),
-                        },
-                    ),
-                },
-            },
-            KEY_PAIR_DATA.to_vec(),
-        )
-        .unwrap();
-}
+//     client
+//         .import_key(
+//             key_name,
+//             Attributes {
+//                 lifetime: Lifetime::Persistent,
+//                 key_type: Type::RsaKeyPair,
+//                 bits: 1024,
+//                 policy: Policy {
+//                     usage_flags: UsageFlags {
+//                         export: false,
+//                         copy: false,
+//                         cache: false,
+//                         encrypt: false,
+//                         decrypt: false,
+//                         sign_message: true,
+//                         sign_hash: true,
+//                         verify_message: true,
+//                         verify_hash: true,
+//                         derive: false,
+//                     },
+//                     permitted_algorithms: Algorithm::AsymmetricSignature(
+//                         AsymmetricSignature::RsaPkcs1v15Sign {
+//                             hash_alg: Hash::Sha256.into(),
+//                         },
+//                     ),
+//                 },
+//             },
+//             KEY_PAIR_DATA.to_vec(),
+//         )
+//         .unwrap();
+// }
 
 #[cfg(any(feature = "mbed-crypto-provider", feature = "cryptoauthlib-provider"))]
 #[test]

--- a/e2e_tests/tests/per_provider/tpm_reset.rs
+++ b/e2e_tests/tests/per_provider/tpm_reset.rs
@@ -1,0 +1,43 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+// These tests track a potential regression where the TPM provider
+// was unable to handle stored keys after a TPM reset.
+//
+// `before_tpm_reset` creates keys that should be usable post-TPM-reset,
+// in `after_tpm_reset`.
+//
+// See: https://github.com/parallaxsecond/parsec/issues/504
+use e2e_tests::TestClient;
+
+const RSA_KEY_NAME: &str = "tpm-reset-rsa";
+const ECC_KEY_NAME: &str = "tpm-reset-ecc";
+
+#[test]
+fn before_tpm_reset() {
+    let mut client = TestClient::new();
+    client.do_not_destroy_keys();
+
+    let rsa_key_name = String::from(RSA_KEY_NAME);
+    let ecc_key_name = String::from(ECC_KEY_NAME);
+
+    client.generate_rsa_sign_key(rsa_key_name.clone()).unwrap();
+    client
+        .generate_ecc_key_pair_secpr1_ecdsa_sha256(ecc_key_name.clone())
+        .unwrap();
+}
+
+#[test]
+fn after_tpm_reset() {
+    let mut client = TestClient::new();
+
+    let rsa_key_name = String::from(RSA_KEY_NAME);
+    let ecc_key_name = String::from(ECC_KEY_NAME);
+
+    let _ = client
+        .sign_with_rsa_sha256(rsa_key_name, vec![0xff; 32])
+        .unwrap();
+    let _ = client
+        .sign_with_ecdsa_sha256(ecc_key_name, vec![0xff; 32])
+        .unwrap();
+}

--- a/src/providers/tpm/key_management.rs
+++ b/src/providers/tpm/key_management.rs
@@ -1,8 +1,10 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::utils;
+use super::utils::validate_public_key;
+#[allow(deprecated)]
+use super::utils::LegacyPasswordContext;
 use super::utils::PasswordContext;
-use super::utils::{validate_private_key, validate_public_key, PUBLIC_EXPONENT};
 use super::Provider;
 use crate::authenticators::ApplicationName;
 use crate::key_info_managers::KeyTriple;
@@ -14,12 +16,60 @@ use parsec_interface::operations::{
 };
 use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
-use picky_asn1_x509::{RSAPrivateKey, RSAPublicKey};
-use tss_esapi::abstraction::transient::RsaExponent;
+use picky_asn1_x509::RSAPublicKey;
+use std::convert::TryInto;
 
 const AUTH_VAL_LEN: usize = 32;
 
 impl Provider {
+    #[allow(deprecated)]
+    pub(super) fn get_key_ctx(&self, key_triple: &KeyTriple) -> Result<PasswordContext> {
+        // Try to deserialize into the new format
+        self.key_info_store
+            .get_key_id::<PasswordContext>(key_triple)
+            .or_else(|e| {
+                // If it failed, check if it was a deserialization error
+                if let ResponseStatus::InvalidEncoding = e {
+                    // Try to deserialize into legacy format
+                    let legacy_ctx = self
+                        .key_info_store
+                        .get_key_id::<LegacyPasswordContext>(key_triple)?;
+
+                    // Try to migrate the key context to the new format
+                    let mut esapi_context = self
+                        .esapi_context
+                        .lock()
+                        .expect("ESAPI Context lock poisoned");
+                    let password_ctx = PasswordContext::new(
+                        esapi_context
+                            .migrate_key_from_ctx(
+                                legacy_ctx.context,
+                                Some(
+                                    legacy_ctx
+                                        .auth_value
+                                        .clone()
+                                        .try_into()
+                                        .map_err(utils::to_response_status)?,
+                                ),
+                            )
+                            .map_err(utils::to_response_status)?,
+                        legacy_ctx.auth_value,
+                    );
+
+                    // Grab key attributes and replace legacy entry with new one
+                    let attributes = self.key_info_store.get_key_attributes(key_triple)?;
+                    let _ = self.key_info_store.replace_key_info(
+                        key_triple.clone(),
+                        &password_ctx,
+                        attributes,
+                    )?;
+                    Ok(password_ctx)
+                } else {
+                    Err(e)
+                }
+            })
+    }
+
     pub(super) fn psa_generate_key_internal(
         &self,
         app_name: ApplicationName,
@@ -41,7 +91,7 @@ impl Provider {
             .lock()
             .expect("ESAPI Context lock poisoned");
 
-        let (key_context, auth_value) = esapi_context
+        let (key_material, auth_value) = esapi_context
             .create_key(utils::parsec_to_tpm_params(attributes)?, AUTH_VAL_LEN)
             .map_err(|e| {
                 format_error!("Error creating a RSA signing key", e);
@@ -52,10 +102,7 @@ impl Provider {
 
         self.key_info_store.insert_key_info(
             key_triple,
-            &PasswordContext {
-                context: key_context,
-                auth_value: auth_value.value().to_vec(),
-            },
+            &PasswordContext::new(key_material, auth_value.value().to_vec()),
             attributes,
         )?;
 
@@ -69,7 +116,6 @@ impl Provider {
     ) -> Result<psa_import_key::Result> {
         match op.attributes.key_type {
             Type::RsaPublicKey => self.psa_import_key_internal_rsa_public(app_name, op),
-            Type::RsaKeyPair => self.psa_import_key_internal_rsa_keypair(app_name, op),
             _ => {
                 error!(
                     "The TPM provider does not support importing for the {:?} key type.",
@@ -114,7 +160,7 @@ impl Provider {
         validate_public_key(&public_key, &attributes)?;
 
         let key_data = public_key.modulus.as_unsigned_bytes_be();
-        let pub_key_context = esapi_context
+        let key_material = esapi_context
             .load_external_rsa_public_key(key_data)
             .map_err(|e| {
                 format_error!("Error creating a RSA signing key", e);
@@ -123,73 +169,7 @@ impl Provider {
 
         self.key_info_store.insert_key_info(
             key_triple,
-            &PasswordContext {
-                context: pub_key_context,
-                auth_value: Vec::new(),
-            },
-            attributes,
-        )?;
-
-        Ok(psa_import_key::Result {})
-    }
-
-    pub(super) fn psa_import_key_internal_rsa_keypair(
-        &self,
-        app_name: ApplicationName,
-        op: psa_import_key::Operation,
-    ) -> Result<psa_import_key::Result> {
-        // Currently only the RSA PKCS1 v1.5 signature scheme is supported
-        // by the tss-esapi crate.
-        if op.attributes.policy.permitted_algorithms
-            != Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
-                hash_alg: SignHash::Specific(Hash::Sha256),
-            })
-        {
-            return Err(ResponseStatus::PsaErrorNotSupported);
-        }
-        let key_name = op.key_name;
-        let attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, key_name);
-        let key_data = op.data;
-
-        self.key_info_store.does_not_exist(&key_triple)?;
-        let mut esapi_context = self
-            .esapi_context
-            .lock()
-            .expect("ESAPI Context lock poisoned");
-
-        let private_key: RSAPrivateKey = picky_asn1_der::from_bytes(key_data.expose_secret())
-            .map_err(|err| {
-                format_error!("Could not deserialise key elements", err);
-                ResponseStatus::PsaErrorInvalidArgument
-            })?;
-
-        // Derive the public key from the keypair.
-        let public_key = RSAPublicKey {
-            modulus: private_key.modulus.clone(),
-            public_exponent: private_key.public_exponent.clone(),
-        };
-
-        // Validate the public and the private key.
-        validate_public_key(&public_key, &attributes)?;
-        validate_private_key(&private_key, &attributes)?;
-
-        let key_prime = private_key.prime_1.as_unsigned_bytes_be();
-        let public_modulus = private_key.modulus.as_unsigned_bytes_be();
-
-        let keypair_context = esapi_context
-            .load_external_rsa(key_prime, public_modulus, RsaExponent::new(PUBLIC_EXPONENT))
-            .map_err(|e| {
-                format_error!("Error creating a RSA signing key", e);
-                utils::to_response_status(e)
-            })?;
-
-        self.key_info_store.insert_key_info(
-            key_triple,
-            &PasswordContext {
-                context: keypair_context,
-                auth_value: Vec::new(),
-            },
+            &PasswordContext::new(key_material, Vec::new()),
             attributes,
         )?;
 
@@ -204,23 +184,15 @@ impl Provider {
         let key_name = op.key_name;
         let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, key_name);
 
-        let mut esapi_context = self
-            .esapi_context
-            .lock()
-            .expect("ESAPI Context lock poisoned");
-
-        let password_context: PasswordContext = self.key_info_store.get_key_id(&key_triple)?;
+        let password_context = self.get_key_ctx(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
-        let pub_key_data = esapi_context
-            .read_public_key(password_context.context)
-            .map_err(|e| {
-                format_error!("Error reading a public key", e);
-                utils::to_response_status(e)
-            })?;
-
         Ok(psa_export_public_key::Result {
-            data: utils::pub_key_to_bytes(pub_key_data, key_attributes)?.into(),
+            data: utils::pub_key_to_bytes(
+                password_context.key_material().public().clone(),
+                key_attributes,
+            )?
+            .into(),
         })
     }
 


### PR DESCRIPTION
This commit updates the TPM provider to use the updated version of the
TransientKeyContext which handles key material in the form of public and
private fields (instead of an encrypted context).

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>