### PR TITLE
Disable broken workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,19 +96,20 @@ jobs:
       # When running the container built on the CI
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
 
-  fuzz-test-checker:
-    name: Check that the fuzz testing framework is still working
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
-      - name: Run the fuzz test script
-        # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
-        run: ./fuzz.sh test
-      # When running the container built on the CI
-      # run: CONTAINER_TAG=parsec-service-test-all ./fuzz.sh test
+  # Disabled due to the issue discussed in https://github.com/parallaxsecond/parsec/issues/514
+  # fuzz-test-checker:
+  #   name: Check that the fuzz testing framework is still working
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     # Use the following step when updating the `parsec-service-test-all` image
+  #     # - name: Build the container
+  #     #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+  #     - name: Run the fuzz test script
+  #       # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
+  #       run: ./fuzz.sh test
+  #     # When running the container built on the CI
+  #     # run: CONTAINER_TAG=parsec-service-test-all ./fuzz.sh test
 
   cross-compilation:
     # Currently only the Mbed Crypto, PKCS 11, and TPM providers are tested as the other ones need to cross-compile other libraries.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,21 +12,22 @@ on:
         default: ""
 
 jobs:
-  dependencies:
-    name: Check for unused dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: "${{ github.event.inputs.rev }}"
-      - name: Install latest Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-      - name: Install cargo udeps
-        run: cargo install cargo-udeps --locked
-      - name: Execute cargo udeps
-        run: cargo +nightly udeps
+  # Disabled due to the issue discussed in https://github.com/parallaxsecond/parsec/issues/514
+  # dependencies:
+  #   name: Check for unused dependencies
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         ref: "${{ github.event.inputs.rev }}"
+  #     - name: Install latest Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: nightly
+  #     - name: Install cargo udeps
+  #       run: cargo install cargo-udeps --locked
+  #     - name: Execute cargo udeps
+  #       run: cargo +nightly udeps
 
   audit:
     name: Check for crates with security vulnerabilities


### PR DESCRIPTION
This commit disables some of the CI and nightly workflows that were
failing due to the issues described in
https://github.com/parallaxsecond/parsec/issues/514

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>