### PR TITLE
Add ActivateCredential tests and fixes

### DIFF
--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -21,7 +21,7 @@ stdext = "0.3.1"
 [dev-dependencies]
 ring = "0.16.20"
 rsa = "0.3.0"
-picky-asn1-x509 = "0.6.0"
+picky-asn1-x509 = "0.6.1"
 base64 = "0.13.0"
 num_cpus = "1.13.0"
 picky-asn1-der = "0.2.4"

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -28,6 +28,7 @@ picky-asn1-der = "0.2.4"
 picky-asn1 = "0.3.1"
 sha2 = "0.9.3"
 tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi.git", rev = "62fb9b7b05b1e607518ae127406f3b85991205b9" }
+serial_test = "0.5.1"
 
 [features]
 mbed-crypto-provider = []

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -28,7 +28,6 @@ use parsec_client::core::interface::requests::{Opcode, ProviderId, ResponseStatu
 use parsec_client::error::Error;
 use std::collections::HashSet;
 
-
 /// Client structure automatically choosing a provider and high-level operation functions.
 #[derive(Debug)]
 pub struct TestClient {
@@ -811,8 +810,16 @@ impl TestClient {
         &self,
         key_name: String,
     ) -> Result<parsec_client::core::basic_client::PrepareActivateCredential> {
+        self.prepare_activate_credential_with_key(key_name, None)
+    }
+
+    pub fn prepare_activate_credential_with_key(
+        &self,
+        key_name: String,
+        attesting_key: Option<String>,
+    ) -> Result<parsec_client::core::basic_client::PrepareActivateCredential> {
         self.basic_client
-            .prepare_activate_credential(key_name, None)
+            .prepare_activate_credential(key_name, attesting_key)
             .map_err(convert_error)
     }
 
@@ -822,8 +829,18 @@ impl TestClient {
         credential: Vec<u8>,
         secret: Vec<u8>,
     ) -> Result<Vec<u8>> {
+        self.activate_credential_with_key(key_name, None, credential, secret)
+    }
+
+    pub fn activate_credential_with_key(
+        &self,
+        key_name: String,
+        attesting_key: Option<String>,
+        credential: Vec<u8>,
+        secret: Vec<u8>,
+    ) -> Result<Vec<u8>> {
         self.basic_client
-            .activate_credential_attestation(key_name, None, credential, secret)
+            .activate_credential_attestation(key_name, attesting_key, credential, secret)
             .map_err(convert_error)
     }
 }
@@ -847,8 +864,6 @@ impl Drop for TestClient {
         }
     }
 }
-
-
 
 #[macro_export]
 // Create a name unique to the calling function for key names in tests.  Can supply one or more suffixes which will be

--- a/e2e_tests/tests/all_providers/config/mod.rs
+++ b/e2e_tests/tests/all_providers/config/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use log::{error, info};
 use parsec_client::core::interface::operations::list_providers::Uuid;
 use parsec_client::core::interface::operations::psa_algorithm::Hash;
@@ -285,7 +285,7 @@ fn ts_pkcs11_cross() {
         signature.clone(),
     );
 
-    let key_name_ecc = auto_test_keyname!("ts","ecc");
+    let key_name_ecc = auto_test_keyname!("ts", "ecc");
     let (mut client, pub_key, signature) = setup_sign_ecc(ProviderId::Pkcs11, key_name_ecc.clone());
     import_and_verify_ecc(
         &mut client,
@@ -309,6 +309,16 @@ fn no_user_pin() {
 #[test]
 fn no_slot_number() {
     set_config("no_slot_number.toml");
+    // The service should still start, without the slot number.
+    reload_service();
+
+    let mut client = TestClient::new();
+    let _ = client.ping().unwrap();
+}
+
+#[test]
+fn no_endorsement_auth() {
+    set_config("no_endorsement_auth.toml");
     // The service should still start, without the slot number.
     reload_service();
 

--- a/e2e_tests/tests/all_providers/config/tomls/no_endorsement_auth.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_endorsement_auth.toml
@@ -1,0 +1,29 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
+[listener]
+listener_type = "DomainSocket"
+# The timeout needs to be smaller than the test client timeout (five seconds) as it is testing
+# that the service does not hang for very big values of body or authentication length.
+timeout = 3000 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+provider_type = "Tpm"
+key_info_manager = "on-disk-manager"
+tcti = "mssim:host=127.0.0.1,port=2321"
+owner_hierarchy_auth = "hex:74706d5f70617373" # "tpm_pass" in hex

--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -1,8 +1,8 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+use e2e_tests::auto_test_keyname;
 use e2e_tests::RawRequestClient;
 use e2e_tests::TestClient;
-use e2e_tests::auto_test_keyname;
 use parsec_client::core::interface::operations::list_providers::Uuid;
 use parsec_client::core::interface::requests::request::RawHeader;
 use parsec_client::core::interface::requests::{
@@ -106,6 +106,8 @@ fn list_opcodes() {
 
     let mut crypto_providers_tpm = HashSet::from_iter(common_opcodes.clone());
     let _ = crypto_providers_tpm.insert(Opcode::CanDoCrypto);
+    let _ = crypto_providers_tpm.insert(Opcode::AttestKey);
+    let _ = crypto_providers_tpm.insert(Opcode::PrepareKeyAttestation);
 
     let mut crypto_providers_hsm = HashSet::from_iter(common_opcodes.clone());
     let _ = crypto_providers_hsm.insert(Opcode::CanDoCrypto);

--- a/e2e_tests/tests/per_provider/normal_tests/key_attestation.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attestation.rs
@@ -1,10 +1,10 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-#![cfg(feature = "tpm-provider")]
 use e2e_tests::auto_test_keyname;
 use e2e_tests::parsec_client::core::basic_client::PrepareActivateCredential;
 use e2e_tests::TestClient;
-use parsec_client::core::interface::requests::Opcode;
+use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
+use picky_asn1_x509::RsaPublicKey;
 use std::{
     convert::{TryFrom, TryInto},
     env,
@@ -12,11 +12,9 @@ use std::{
 };
 use tss_esapi::{
     abstraction::ek,
-    abstraction::transient::MakeCredParams,
     interface_types::{algorithm::AsymmetricAlgorithm, resource_handles::Hierarchy},
     structures::{Public, PublicKeyRsa},
     tcti_ldr::{NetworkTPMConfig, TctiNameConf},
-    utils::PublicKey,
     Context,
 };
 
@@ -34,11 +32,6 @@ fn create_tcti() -> TctiNameConf {
 }
 
 fn make_credential(prep_activ_cred: PrepareActivateCredential) -> (Vec<u8>, Vec<u8>) {
-    let make_cred_params = MakeCredParams {
-        name: prep_activ_cred.name,
-        public: prep_activ_cred.public,
-        attesting_key_pub: PublicKey::Rsa(prep_activ_cred.attesting_key_pub),
-    };
     let mut basic_ctx = Context::new(create_tcti()).expect("Failed to start TPM context");
     // the public part of the EK is used, so we retrieve the parameters
     let key_pub =
@@ -46,21 +39,20 @@ fn make_credential(prep_activ_cred: PrepareActivateCredential) -> (Vec<u8>, Vec<
     let key_pub = if let Public::Rsa {
         object_attributes,
         name_hashing_algorithm,
-        auth_policy,
         parameters,
         ..
     } = key_pub
     {
+        // we need to extract the modulus from the public key
+        let public_key: RsaPublicKey =
+            picky_asn1_der::from_bytes(&prep_activ_cred.attesting_key_pub).unwrap();
         Public::Rsa {
             object_attributes,
             name_hashing_algorithm,
-            auth_policy,
+            auth_policy: Default::default(),
             parameters,
-            unique: if let PublicKey::Rsa(val) = make_cred_params.attesting_key_pub {
-                PublicKeyRsa::try_from(val).unwrap()
-            } else {
-                panic!("Wrong public key type");
-            },
+            unique: PublicKeyRsa::try_from(public_key.modulus.as_unsigned_bytes_be().to_vec())
+                .unwrap(),
         }
     } else {
         panic!("Wrong Public type");
@@ -73,14 +65,14 @@ fn make_credential(prep_activ_cred: PrepareActivateCredential) -> (Vec<u8>, Vec<
         .make_credential(
             pub_handle,
             CREDENTIAL.to_vec().try_into().unwrap(),
-            make_cred_params.name.to_vec().try_into().unwrap(),
+            prep_activ_cred.name.to_vec().try_into().unwrap(),
         )
         .unwrap();
     (cred.value().to_vec(), secret.value().to_vec())
 }
 
 #[test]
-fn activate_credential() {
+fn activate_credential_rsa() {
     let key_name = auto_test_keyname!();
     let mut client = TestClient::new();
     if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
@@ -100,4 +92,97 @@ fn activate_credential() {
         .expect("Failed to activate credential");
 
     assert_eq!(cred_out, CREDENTIAL.to_vec());
+}
+
+#[test]
+fn activate_credential_ecc() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+        return;
+    }
+    client
+        .generate_ecc_key_pair_secpr1_ecdsa_sha256(key_name.clone())
+        .expect("Failed to generate key");
+    let prep_activ_cred = client
+        .prepare_activate_credential(key_name.clone())
+        .expect("Failed to get parameters for MakeCredential");
+
+    let (cred, secret) = make_credential(prep_activ_cred);
+
+    let cred_out = client
+        .activate_credential(key_name, cred, secret)
+        .expect("Failed to activate credential");
+
+    assert_eq!(cred_out, CREDENTIAL.to_vec());
+}
+
+#[test]
+fn activate_credential_bad_data() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+        return;
+    }
+    client
+        .generate_rsa_sign_key(key_name.clone())
+        .expect("Failed to generate key");
+
+    let _error = client
+        .activate_credential(key_name, vec![0xDE; 52], vec![0xAD; 256])
+        .unwrap_err();
+    // TODO: https://github.com/parallaxsecond/parsec/issues/539#issuecomment-978021705
+    // Figure out what error code we should expect here
+}
+
+#[test]
+fn activate_with_key() {
+    let key_name_1 = auto_test_keyname!("1");
+    let key_name_2 = auto_test_keyname!("2");
+    let mut client = TestClient::new();
+    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+        return;
+    }
+
+    assert_eq!(
+        client
+            .prepare_activate_credential_with_key(key_name_1.clone(), Some(key_name_2.clone()))
+            .unwrap_err(),
+        ResponseStatus::PsaErrorNotSupported
+    );
+    assert_eq!(
+        client
+            .activate_credential_with_key(
+                key_name_1,
+                Some(key_name_2),
+                vec![0x33; 16],
+                vec![0x22; 16]
+            )
+            .unwrap_err(),
+        ResponseStatus::PsaErrorNotSupported
+    );
+}
+
+#[test]
+fn check_name() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+        return;
+    }
+    client
+        .generate_rsa_sign_key(key_name.clone())
+        .expect("Failed to generate key");
+    let prep_activ_cred = client
+        .prepare_activate_credential(key_name)
+        .expect("Failed to get parameters for MakeCredential");
+
+    // Verify that the name provided in the parameters is
+    // consistent with the public buffer
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(prep_activ_cred.public);
+    let hash = hasher.finalize();
+    // The first 2 bytes of the name represent the hash algorithm used
+    assert_eq!(prep_activ_cred.name[2..], hash[..]);
 }

--- a/e2e_tests/tests/per_provider/normal_tests/key_attestation.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attestation.rs
@@ -1,188 +1,197 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use e2e_tests::auto_test_keyname;
-use e2e_tests::parsec_client::core::basic_client::PrepareActivateCredential;
-use e2e_tests::TestClient;
-use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
-use picky_asn1_x509::RsaPublicKey;
-use std::{
-    convert::{TryFrom, TryInto},
-    env,
-    str::FromStr,
-};
-use tss_esapi::{
-    abstraction::ek,
-    interface_types::{algorithm::AsymmetricAlgorithm, resource_handles::Hierarchy},
-    structures::{Public, PublicKeyRsa},
-    tcti_ldr::{NetworkTPMConfig, TctiNameConf},
-    Context,
-};
 
-const DEFAULT_HELPER_TPM_CONF: &str = "port=4321";
-const CREDENTIAL: [u8; 16] = [0x11; 16];
+#[cfg(feature = "tpm-provider")]
+mod activate_credential {
+    use e2e_tests::auto_test_keyname;
+    use e2e_tests::parsec_client::core::basic_client::PrepareActivateCredential;
+    use e2e_tests::TestClient;
+    use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
+    use picky_asn1_x509::RsaPublicKey;
+    use serial_test::serial;
+    use std::{
+        convert::{TryFrom, TryInto},
+        env,
+        str::FromStr,
+    };
+    use tss_esapi::{
+        abstraction::ek,
+        interface_types::{algorithm::AsymmetricAlgorithm, resource_handles::Hierarchy},
+        structures::{Public, PublicKeyRsa},
+        tcti_ldr::{NetworkTPMConfig, TctiNameConf},
+        Context,
+    };
 
-fn create_tcti() -> TctiNameConf {
-    match env::var("TEST_TCTI") {
-        Err(_) => TctiNameConf::Mssim(
-            NetworkTPMConfig::from_str(DEFAULT_HELPER_TPM_CONF)
-                .expect("Failed to parse default TPM config"),
-        ),
-        Ok(tctistr) => TctiNameConf::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
+    const DEFAULT_HELPER_TPM_CONF: &str = "port=4321";
+    const CREDENTIAL: [u8; 16] = [0x11; 16];
+
+    fn create_tcti() -> TctiNameConf {
+        match env::var("TEST_TCTI") {
+            Err(_) => TctiNameConf::Mssim(
+                NetworkTPMConfig::from_str(DEFAULT_HELPER_TPM_CONF)
+                    .expect("Failed to parse default TPM config"),
+            ),
+            Ok(tctistr) => TctiNameConf::from_str(&tctistr).expect("Error parsing TEST_TCTI"),
+        }
     }
-}
 
-fn make_credential(prep_activ_cred: PrepareActivateCredential) -> (Vec<u8>, Vec<u8>) {
-    let mut basic_ctx = Context::new(create_tcti()).expect("Failed to start TPM context");
-    // the public part of the EK is used, so we retrieve the parameters
-    let key_pub =
-        ek::create_ek_public_from_default_template(AsymmetricAlgorithm::Rsa, None).unwrap();
-    let key_pub = if let Public::Rsa {
-        object_attributes,
-        name_hashing_algorithm,
-        parameters,
-        ..
-    } = key_pub
-    {
-        // we need to extract the modulus from the public key
-        let public_key: RsaPublicKey =
-            picky_asn1_der::from_bytes(&prep_activ_cred.attesting_key_pub).unwrap();
-        Public::Rsa {
+    /// Tests using this function are marked as `serial`, since attempting to open two
+    /// `Context`s at the same time could lead to the tests hanging.
+    fn make_credential(prep_activ_cred: PrepareActivateCredential) -> (Vec<u8>, Vec<u8>) {
+        let mut basic_ctx = Context::new(create_tcti()).expect("Failed to start TPM context");
+        // the public part of the EK is used, so we retrieve the parameters
+        let key_pub =
+            ek::create_ek_public_from_default_template(AsymmetricAlgorithm::Rsa, None).unwrap();
+        let key_pub = if let Public::Rsa {
             object_attributes,
             name_hashing_algorithm,
-            auth_policy: Default::default(),
             parameters,
-            unique: PublicKeyRsa::try_from(public_key.modulus.as_unsigned_bytes_be().to_vec())
-                .unwrap(),
-        }
-    } else {
-        panic!("Wrong Public type");
-    };
-    let pub_handle = basic_ctx
-        .load_external_public(&key_pub, Hierarchy::Owner)
-        .unwrap();
+            ..
+        } = key_pub
+        {
+            // we need to extract the modulus from the public key
+            let public_key: RsaPublicKey =
+                picky_asn1_der::from_bytes(&prep_activ_cred.attesting_key_pub).unwrap();
+            Public::Rsa {
+                object_attributes,
+                name_hashing_algorithm,
+                auth_policy: Default::default(),
+                parameters,
+                unique: PublicKeyRsa::try_from(public_key.modulus.as_unsigned_bytes_be().to_vec())
+                    .unwrap(),
+            }
+        } else {
+            panic!("Wrong Public type");
+        };
+        let pub_handle = basic_ctx
+            .load_external_public(&key_pub, Hierarchy::Owner)
+            .unwrap();
 
-    let (cred, secret) = basic_ctx
-        .make_credential(
-            pub_handle,
-            CREDENTIAL.to_vec().try_into().unwrap(),
-            prep_activ_cred.name.to_vec().try_into().unwrap(),
-        )
-        .unwrap();
-    (cred.value().to_vec(), secret.value().to_vec())
-}
-
-#[test]
-fn activate_credential_rsa() {
-    let key_name = auto_test_keyname!();
-    let mut client = TestClient::new();
-    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
-        return;
-    }
-    client
-        .generate_rsa_sign_key(key_name.clone())
-        .expect("Failed to generate key");
-    let prep_activ_cred = client
-        .prepare_activate_credential(key_name.clone())
-        .expect("Failed to get parameters for MakeCredential");
-
-    let (cred, secret) = make_credential(prep_activ_cred);
-
-    let cred_out = client
-        .activate_credential(key_name, cred, secret)
-        .expect("Failed to activate credential");
-
-    assert_eq!(cred_out, CREDENTIAL.to_vec());
-}
-
-#[test]
-fn activate_credential_ecc() {
-    let key_name = auto_test_keyname!();
-    let mut client = TestClient::new();
-    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
-        return;
-    }
-    client
-        .generate_ecc_key_pair_secpr1_ecdsa_sha256(key_name.clone())
-        .expect("Failed to generate key");
-    let prep_activ_cred = client
-        .prepare_activate_credential(key_name.clone())
-        .expect("Failed to get parameters for MakeCredential");
-
-    let (cred, secret) = make_credential(prep_activ_cred);
-
-    let cred_out = client
-        .activate_credential(key_name, cred, secret)
-        .expect("Failed to activate credential");
-
-    assert_eq!(cred_out, CREDENTIAL.to_vec());
-}
-
-#[test]
-fn activate_credential_bad_data() {
-    let key_name = auto_test_keyname!();
-    let mut client = TestClient::new();
-    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
-        return;
-    }
-    client
-        .generate_rsa_sign_key(key_name.clone())
-        .expect("Failed to generate key");
-
-    let _error = client
-        .activate_credential(key_name, vec![0xDE; 52], vec![0xAD; 256])
-        .unwrap_err();
-    // TODO: https://github.com/parallaxsecond/parsec/issues/539#issuecomment-978021705
-    // Figure out what error code we should expect here
-}
-
-#[test]
-fn activate_with_key() {
-    let key_name_1 = auto_test_keyname!("1");
-    let key_name_2 = auto_test_keyname!("2");
-    let mut client = TestClient::new();
-    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
-        return;
-    }
-
-    assert_eq!(
-        client
-            .prepare_activate_credential_with_key(key_name_1.clone(), Some(key_name_2.clone()))
-            .unwrap_err(),
-        ResponseStatus::PsaErrorNotSupported
-    );
-    assert_eq!(
-        client
-            .activate_credential_with_key(
-                key_name_1,
-                Some(key_name_2),
-                vec![0x33; 16],
-                vec![0x22; 16]
+        let (cred, secret) = basic_ctx
+            .make_credential(
+                pub_handle,
+                CREDENTIAL.to_vec().try_into().unwrap(),
+                prep_activ_cred.name.to_vec().try_into().unwrap(),
             )
-            .unwrap_err(),
-        ResponseStatus::PsaErrorNotSupported
-    );
-}
-
-#[test]
-fn check_name() {
-    let key_name = auto_test_keyname!();
-    let mut client = TestClient::new();
-    if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
-        return;
+            .unwrap();
+        (cred.value().to_vec(), secret.value().to_vec())
     }
-    client
-        .generate_rsa_sign_key(key_name.clone())
-        .expect("Failed to generate key");
-    let prep_activ_cred = client
-        .prepare_activate_credential(key_name)
-        .expect("Failed to get parameters for MakeCredential");
 
-    // Verify that the name provided in the parameters is
-    // consistent with the public buffer
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(prep_activ_cred.public);
-    let hash = hasher.finalize();
-    // The first 2 bytes of the name represent the hash algorithm used
-    assert_eq!(prep_activ_cred.name[2..], hash[..]);
+    #[test]
+    #[serial]
+    fn activate_credential_rsa() {
+        let key_name = auto_test_keyname!();
+        let mut client = TestClient::new();
+        if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+            return;
+        }
+        client
+            .generate_rsa_sign_key(key_name.clone())
+            .expect("Failed to generate key");
+        let prep_activ_cred = client
+            .prepare_activate_credential(key_name.clone())
+            .expect("Failed to get parameters for MakeCredential");
+
+        let (cred, secret) = make_credential(prep_activ_cred);
+
+        let cred_out = client
+            .activate_credential(key_name, cred, secret)
+            .expect("Failed to activate credential");
+
+        assert_eq!(cred_out, CREDENTIAL.to_vec());
+    }
+
+    #[test]
+    #[serial]
+    fn activate_credential_ecc() {
+        let key_name = auto_test_keyname!();
+        let mut client = TestClient::new();
+        if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+            return;
+        }
+        client
+            .generate_ecc_key_pair_secpr1_ecdsa_sha256(key_name.clone())
+            .expect("Failed to generate key");
+        let prep_activ_cred = client
+            .prepare_activate_credential(key_name.clone())
+            .expect("Failed to get parameters for MakeCredential");
+
+        let (cred, secret) = make_credential(prep_activ_cred);
+
+        let cred_out = client
+            .activate_credential(key_name, cred, secret)
+            .expect("Failed to activate credential");
+
+        assert_eq!(cred_out, CREDENTIAL.to_vec());
+    }
+
+    #[test]
+    fn activate_credential_bad_data() {
+        let key_name = auto_test_keyname!();
+        let mut client = TestClient::new();
+        if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+            return;
+        }
+        client
+            .generate_rsa_sign_key(key_name.clone())
+            .expect("Failed to generate key");
+
+        let _error = client
+            .activate_credential(key_name, vec![0xDE; 52], vec![0xAD; 256])
+            .unwrap_err();
+        // TODO: https://github.com/parallaxsecond/parsec/issues/539#issuecomment-978021705
+        // Figure out what error code we should expect here
+    }
+
+    #[test]
+    fn activate_with_key() {
+        let key_name_1 = auto_test_keyname!("1");
+        let key_name_2 = auto_test_keyname!("2");
+        let mut client = TestClient::new();
+        if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+            return;
+        }
+
+        assert_eq!(
+            client
+                .prepare_activate_credential_with_key(key_name_1.clone(), Some(key_name_2.clone()))
+                .unwrap_err(),
+            ResponseStatus::PsaErrorNotSupported
+        );
+        assert_eq!(
+            client
+                .activate_credential_with_key(
+                    key_name_1,
+                    Some(key_name_2),
+                    vec![0x33; 16],
+                    vec![0x22; 16]
+                )
+                .unwrap_err(),
+            ResponseStatus::PsaErrorNotSupported
+        );
+    }
+
+    #[test]
+    fn check_name() {
+        let key_name = auto_test_keyname!();
+        let mut client = TestClient::new();
+        if !client.is_operation_supported(Opcode::PrepareKeyAttestation) {
+            return;
+        }
+        client
+            .generate_rsa_sign_key(key_name.clone())
+            .expect("Failed to generate key");
+        let prep_activ_cred = client
+            .prepare_activate_credential(key_name)
+            .expect("Failed to get parameters for MakeCredential");
+
+        // Verify that the name provided in the parameters is
+        // consistent with the public buffer
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(prep_activ_cred.public);
+        let hash = hasher.finalize();
+        // The first 2 bytes of the name represent the hash algorithm used
+        assert_eq!(prep_activ_cred.name[2..], hash[..]);
+    }
 }

--- a/src/providers/tpm/key_attestation.rs
+++ b/src/providers/tpm/key_attestation.rs
@@ -70,8 +70,8 @@ impl Provider {
 
         Ok(prepare_key_attestation::Result::ActivateCredential {
             name: params.name.into(),
-            attesting_key_pub: params.public.into(),
-            public: utils::ek_pub_key_to_bytes(params.attesting_key_pub)?.into(),
+            attesting_key_pub: utils::ek_pub_key_to_bytes(params.attesting_key_pub)?.into(),
+            public: params.public.into(),
         })
     }
 

--- a/src/providers/tpm/mod.rs
+++ b/src/providers/tpm/mod.rs
@@ -35,7 +35,7 @@ mod key_attestation;
 mod key_management;
 mod utils;
 
-const SUPPORTED_OPCODES: [Opcode; 9] = [
+const SUPPORTED_OPCODES: [Opcode; 11] = [
     Opcode::PsaGenerateKey,
     Opcode::PsaDestroyKey,
     Opcode::PsaSignHash,
@@ -45,6 +45,8 @@ const SUPPORTED_OPCODES: [Opcode; 9] = [
     Opcode::PsaAsymmetricDecrypt,
     Opcode::PsaAsymmetricEncrypt,
     Opcode::CanDoCrypto,
+    Opcode::AttestKey,
+    Opcode::PrepareKeyAttestation,
 ];
 
 const ROOT_KEY_SIZE: u16 = 2048;


### PR DESCRIPTION
A number of new tests are added for the new ActivateCredential key
attestation mechanism.

A couple of fixes were also implemented, based on issues discovered
during testing:
* the TPM provider now acknowledges that it supports key attestation
* PrepareKeyAttestation now returns buffers under the correct name

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>