### PR TITLE
Add clippy and fmt checkt to e2e_tests

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -294,9 +294,11 @@ echo "Static checks"
 # On native target clippy or fmt might not be available.
 if rustup component list | grep -q fmt; then
     cargo fmt --all -- --check
+    cargo fmt --all $TEST_FEATURES --manifest-path e2e_tests/Cargo.toml -- --check
 fi
 if rustup component list | grep -q clippy; then
     cargo clippy --all-targets $FEATURES -- -D clippy::all -D clippy::cargo
+    cargo clippy --all-targets &TEST_FEATURES --manifest-path e2e_tests/Cargo.toml -- -D clippy::all -D clippy::cargo
 fi
 
 echo "Unit, doc and integration tests"

--- a/ci.sh
+++ b/ci.sh
@@ -294,7 +294,7 @@ echo "Static checks"
 # On native target clippy or fmt might not be available.
 if rustup component list | grep -q fmt; then
     cargo fmt --all -- --check
-    cargo fmt --all $TEST_FEATURES --manifest-path e2e_tests/Cargo.toml -- --check
+    cargo fmt --all --manifest-path e2e_tests/Cargo.toml -- --check
 fi
 if rustup component list | grep -q clippy; then
     cargo clippy --all-targets $FEATURES -- -D clippy::all -D clippy::cargo

--- a/ci.sh
+++ b/ci.sh
@@ -298,7 +298,7 @@ if rustup component list | grep -q fmt; then
 fi
 if rustup component list | grep -q clippy; then
     cargo clippy --all-targets $FEATURES -- -D clippy::all -D clippy::cargo
-    cargo clippy --all-targets &TEST_FEATURES --manifest-path e2e_tests/Cargo.toml -- -D clippy::all -D clippy::cargo
+    cargo clippy --all-targets $TEST_FEATURES --manifest-path e2e_tests/Cargo.toml -- -D clippy::all -D clippy::cargo
 fi
 
 echo "Unit, doc and integration tests"

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -1,5 +1,32 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+#![deny(
+    nonstandard_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    private_in_public,
+    unconditional_recursion,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true,
+    missing_debug_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results,
+    missing_copy_implementations
+)]
+// This one is hard to avoid.
 #![allow(clippy::multiple_crate_versions)]
 pub mod raw_request;
 pub mod stress;
@@ -100,7 +127,7 @@ impl TestClient {
     /// Creates a key with specific attributes.
     pub fn generate_key(&mut self, key_name: String, attributes: Attributes) -> Result<()> {
         self.basic_client
-            .psa_generate_key(&key_name.clone(), attributes)
+            .psa_generate_key(&key_name, attributes)
             .map_err(convert_error)?;
 
         let provider = self.provider();
@@ -304,7 +331,7 @@ impl TestClient {
         data: Vec<u8>,
     ) -> Result<()> {
         self.basic_client
-            .psa_import_key(&key_name.clone(), &data, attributes)
+            .psa_import_key(&key_name, &data, attributes)
             .map_err(convert_error)?;
 
         let provider = self.provider();
@@ -436,7 +463,7 @@ impl TestClient {
     /// Destroys a key.
     pub fn destroy_key(&mut self, key_name: String) -> Result<()> {
         self.basic_client
-            .psa_destroy_key(&key_name.clone())
+            .psa_destroy_key(&key_name)
             .map_err(convert_error)?;
 
         let provider = self.provider();

--- a/e2e_tests/tests/all_providers/config/mod.rs
+++ b/e2e_tests/tests/all_providers/config/mod.rs
@@ -259,9 +259,9 @@ fn ts_pkcs11_cross() {
     import_and_verify(
         &mut client,
         ProviderId::Pkcs11,
-        key_name.clone(),
-        pub_key.clone(),
-        signature.clone(),
+        key_name,
+        pub_key,
+        signature,
     );
 
     let key_name_ecc = auto_test_keyname!("ecc");
@@ -270,9 +270,9 @@ fn ts_pkcs11_cross() {
     import_and_verify_ecc(
         &mut client,
         ProviderId::Pkcs11,
-        key_name_ecc.clone(),
-        pub_key.clone(),
-        signature.clone(),
+        key_name_ecc,
+        pub_key,
+        signature,
     );
 
     let key_name = auto_test_keyname!("ts");
@@ -280,9 +280,9 @@ fn ts_pkcs11_cross() {
     import_and_verify(
         &mut client,
         ProviderId::TrustedService,
-        key_name.clone(),
-        pub_key.clone(),
-        signature.clone(),
+        key_name,
+        pub_key,
+        signature,
     );
 
     let key_name_ecc = auto_test_keyname!("ts", "ecc");
@@ -290,9 +290,9 @@ fn ts_pkcs11_cross() {
     import_and_verify_ecc(
         &mut client,
         ProviderId::TrustedService,
-        key_name_ecc.clone(),
-        pub_key.clone(),
-        signature.clone(),
+        key_name_ecc,
+        pub_key,
+        signature,
     );
 }
 

--- a/e2e_tests/tests/all_providers/cross.rs
+++ b/e2e_tests/tests/all_providers/cross.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::requests::{ProviderId, Result};
 
 const HASH: [u8; 32] = [

--- a/e2e_tests/tests/all_providers/cross.rs
+++ b/e2e_tests/tests/all_providers/cross.rs
@@ -186,9 +186,9 @@ fn pkcs11_sign_cross_ecc() {
     import_and_verify_ecc(
         &mut client,
         ProviderId::MbedCrypto,
-        key_name.clone(),
-        pub_key.clone(),
-        signature.clone(),
+        key_name,
+        pub_key,
+        signature,
     );
 }
 
@@ -219,9 +219,9 @@ fn mbed_crypto_sign_cross_ecc() {
     import_and_verify_ecc(
         &mut client,
         ProviderId::Pkcs11,
-        key_name.clone(),
-        pub_key.clone(),
-        signature.clone(),
+        key_name,
+        pub_key,
+        signature,
     );
 }
 

--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -109,7 +109,7 @@ fn list_opcodes() {
     let _ = crypto_providers_tpm.insert(Opcode::AttestKey);
     let _ = crypto_providers_tpm.insert(Opcode::PrepareKeyAttestation);
 
-    let mut crypto_providers_hsm = HashSet::from_iter(common_opcodes.clone());
+    let mut crypto_providers_hsm = HashSet::from_iter(common_opcodes);
     let _ = crypto_providers_hsm.insert(Opcode::CanDoCrypto);
 
     let crypto_providers_mbed_crypto = HashSet::from_iter(mbed_crypto_opcodes);

--- a/e2e_tests/tests/per_provider/normal_tests/aead.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/aead.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::operations::psa_algorithm::{Aead, AeadWithDefaultLengthTag};
 use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
 

--- a/e2e_tests/tests/per_provider/normal_tests/aead.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/aead.rs
@@ -323,7 +323,7 @@ fn aead_encrypt_ccm_encrypt_nonce_too_short() {
     assert_eq!(
         client
             .aead_encrypt_message(
-                key_name.clone(),
+                key_name,
                 Aead::AeadWithDefaultLengthTag(AeadWithDefaultLengthTag::Ccm),
                 &NONCE_TOO_SHORT,
                 &ADDITIONAL_DATA,
@@ -351,7 +351,7 @@ fn aead_encrypt_ccm_encrypt_nonce_too_long() {
     assert_eq!(
         client
             .aead_encrypt_message(
-                key_name.clone(),
+                key_name,
                 Aead::AeadWithDefaultLengthTag(AeadWithDefaultLengthTag::Ccm),
                 &NONCE_TOO_LONG,
                 &ADDITIONAL_DATA,
@@ -382,7 +382,7 @@ fn aead_encrypt_ccm_encrypt_tag_length_too_short() {
     assert_eq!(
         client
             .aead_encrypt_message(
-                key_name.clone(),
+                key_name,
                 Aead::AeadWithShortenedTag {
                     aead_alg: AeadWithDefaultLengthTag::Ccm,
                     tag_length: 3
@@ -416,7 +416,7 @@ fn aead_encrypt_ccm_encrypt_tag_length_too_long() {
     assert_eq!(
         client
             .aead_encrypt_message(
-                key_name.clone(),
+                key_name,
                 Aead::AeadWithShortenedTag {
                     aead_alg: AeadWithDefaultLengthTag::Ccm,
                     tag_length: 17
@@ -642,7 +642,7 @@ fn aead_encrypt_gcm_encrypt_nonce_too_short() {
     assert_eq!(
         client
             .aead_encrypt_message(
-                key_name.clone(),
+                key_name,
                 Aead::AeadWithDefaultLengthTag(AeadWithDefaultLengthTag::Gcm),
                 &NONCE_TOO_SHORT,
                 &ADDITIONAL_DATA,
@@ -673,7 +673,7 @@ fn aead_encrypt_gcm_encrypt_nonce_too_long() {
     assert_eq!(
         client
             .aead_encrypt_message(
-                key_name.clone(),
+                key_name,
                 Aead::AeadWithDefaultLengthTag(AeadWithDefaultLengthTag::Gcm),
                 &NONCE_TOO_LONG,
                 &ADDITIONAL_DATA,
@@ -707,7 +707,7 @@ fn aead_encrypt_gcm_encrypt_tag_length_too_short() {
     assert_eq!(
         client
             .aead_encrypt_message(
-                key_name.clone(),
+                key_name,
                 Aead::AeadWithShortenedTag {
                     aead_alg: AeadWithDefaultLengthTag::Gcm,
                     tag_length: 11
@@ -741,7 +741,7 @@ fn aead_encrypt_gcm_encrypt_tag_length_too_long() {
     assert_eq!(
         client
             .aead_encrypt_message(
-                key_name.clone(),
+                key_name,
                 Aead::AeadWithShortenedTag {
                     aead_alg: AeadWithDefaultLengthTag::Gcm,
                     tag_length: 17

--- a/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
@@ -393,7 +393,7 @@ fn asym_encrypt_not_permitted() {
     client.generate_key(key_name.clone(), attributes).unwrap();
 
     let error = client
-        .asymmetric_encrypt_message_with_rsapkcs1v15(key_name.clone(), PLAINTEXT_MESSAGE.to_vec())
+        .asymmetric_encrypt_message_with_rsapkcs1v15(key_name, PLAINTEXT_MESSAGE.to_vec())
         .unwrap_err();
     assert_eq!(error, ResponseStatus::PsaErrorNotPermitted);
 }

--- a/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
@@ -758,9 +758,7 @@ fn verify_ecc_with_ring() {
     let mut hasher = Sha256::new();
     hasher.update(message);
     let hash = hasher.finalize().to_vec();
-    let signature = client
-        .sign_with_ecdsa_sha256(key_name, hash)
-        .unwrap();
+    let signature = client.sign_with_ecdsa_sha256(key_name, hash).unwrap();
 
     let pk = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_FIXED, pub_key);
     pk.verify(message, &signature).unwrap();

--- a/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
@@ -735,7 +735,7 @@ fn verify_with_ring() {
     let mut hasher = Sha256::new();
     hasher.update(message);
     let hash = hasher.finalize().to_vec();
-    let signature = client.sign_with_rsa_sha256(key_name, hash.clone()).unwrap();
+    let signature = client.sign_with_rsa_sha256(key_name, hash).unwrap();
 
     let pk = UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, pub_key);
     pk.verify(message, &signature).unwrap();
@@ -759,7 +759,7 @@ fn verify_ecc_with_ring() {
     hasher.update(message);
     let hash = hasher.finalize().to_vec();
     let signature = client
-        .sign_with_ecdsa_sha256(key_name, hash.clone())
+        .sign_with_ecdsa_sha256(key_name, hash)
         .unwrap();
 
     let pk = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_FIXED, pub_key);
@@ -787,7 +787,7 @@ fn sign_verify_hash_ecc() {
         .sign_with_ecdsa_sha256(key_name.clone(), hash.clone())
         .unwrap();
     client
-        .verify_with_ecdsa_sha256(key_name.clone(), hash, signature)
+        .verify_with_ecdsa_sha256(key_name, hash, signature)
         .unwrap();
 }
 
@@ -810,7 +810,7 @@ fn sign_verify_message_ecc() {
         .sign_msg_with_ecdsa_sha256(key_name.clone(), msg.to_vec())
         .unwrap();
     client
-        .verify_msg_with_ecdsa_sha256(key_name.clone(), msg.to_vec(), signature)
+        .verify_msg_with_ecdsa_sha256(key_name, msg.to_vec(), signature)
         .unwrap();
 }
 
@@ -847,7 +847,7 @@ fn sign_message_not_permitted() {
         .unwrap();
 
     let error = client
-        .sign_msg_with_ecdsa_sha256(key_name.clone(), msg.to_vec())
+        .sign_msg_with_ecdsa_sha256(key_name, msg.to_vec())
         .unwrap_err();
 
     assert_eq!(error, ResponseStatus::PsaErrorNotPermitted);
@@ -893,7 +893,7 @@ fn verify_message_not_permitted() {
         .unwrap();
 
     let error = client
-        .verify_msg_with_ecdsa_sha256(key_name.clone(), msg.to_vec(), signature)
+        .verify_msg_with_ecdsa_sha256(key_name, msg.to_vec(), signature)
         .unwrap_err();
 
     assert_eq!(error, ResponseStatus::PsaErrorNotPermitted);

--- a/e2e_tests/tests/per_provider/normal_tests/auth.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/auth.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::requests::{Opcode, ResponseStatus, Result};
 
 #[test]

--- a/e2e_tests/tests/per_provider/normal_tests/auth.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/auth.rs
@@ -23,9 +23,9 @@ fn two_auths_same_key_name() -> Result<()> {
 
     client.set_default_auth(Some(auth2));
     #[cfg(not(feature = "cryptoauthlib-provider"))]
-    let result = client.generate_rsa_sign_key(key_name.clone());
+    let result = client.generate_rsa_sign_key(key_name);
     #[cfg(feature = "cryptoauthlib-provider")]
-    let result = client.generate_ecc_key_pair_secpr1_ecdsa_sha256(key_name.clone());
+    let result = client.generate_ecc_key_pair_secpr1_ecdsa_sha256(key_name);
 
     result
 }

--- a/e2e_tests/tests/per_provider/normal_tests/capability_discovery.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/capability_discovery.rs
@@ -53,7 +53,7 @@ fn rsa_encrypt_use_check() {
     let all_algs = vec![
         AsymmetricEncryption::RsaPkcs1v15Crypt {},
         AsymmetricEncryption::RsaOaep {
-            hash_alg: Hash::Sha256.into(),
+            hash_alg: Hash::Sha256,
         },
     ];
 
@@ -84,7 +84,7 @@ fn rsa_encrypt_use_check() {
         attributes.policy.permitted_algorithms = (*alg).into();
         assert_eq!(
             result,
-            client.can_do_crypto(CheckType::Generate, attributes.clone())
+            client.can_do_crypto(CheckType::Generate, attributes)
         );
     }
 }
@@ -134,7 +134,7 @@ fn ecc_curve_use_check() {
         };
         assert_eq!(
             result,
-            client.can_do_crypto(CheckType::Generate, attributes.clone())
+            client.can_do_crypto(CheckType::Generate, attributes)
         );
     }
 }
@@ -197,7 +197,7 @@ fn hash_use_check() {
         .into();
         assert_eq!(
             result,
-            client.can_do_crypto(CheckType::Generate, attributes.clone())
+            client.can_do_crypto(CheckType::Generate, attributes)
         );
     }
 }
@@ -232,14 +232,14 @@ fn key_size_check() {
     // Unsupported RSA key size
     assert_eq!(
         Err(ResponseStatus::PsaErrorNotSupported),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     attributes.bits = 2048;
     // Supported RSA key size
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     let mut attributes = get_default_ecc_attrs();
@@ -247,14 +247,14 @@ fn key_size_check() {
     // Supported ECC key size
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     attributes.bits = 1024;
     // Usupported ECC key size
     assert_eq!(
         Err(ResponseStatus::PsaErrorNotSupported),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 }
 
@@ -269,14 +269,14 @@ fn use_check() {
     // Can't use a key without any usage flag defined
     assert_eq!(
         Err(ResponseStatus::PsaErrorNotSupported),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     let _ = attributes.policy.usage_flags.set_sign_hash();
     // Can use ECC key with sign_hash usage flag
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     attributes.policy.usage_flags = UsageFlags::default();
@@ -284,7 +284,7 @@ fn use_check() {
     // Can use ECC key with sign_message usage flag
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     attributes.policy.usage_flags = UsageFlags::default();
@@ -292,7 +292,7 @@ fn use_check() {
     // Can use ECC key with verify_hash usage flag
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     attributes.policy.usage_flags = UsageFlags::default();
@@ -300,7 +300,7 @@ fn use_check() {
     // Can use ECC key with verify_message usage flag
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     attributes.policy.usage_flags = UsageFlags::default();
@@ -308,7 +308,7 @@ fn use_check() {
     // Can use ECC key with decrypt usage flag
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     attributes.policy.usage_flags = UsageFlags::default();
@@ -316,7 +316,7 @@ fn use_check() {
     // Can use ECC key with encrypt usage flag
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes.clone())
+        client.can_do_crypto(CheckType::Use, attributes)
     );
 
     let mut attributes = get_default_rsa_attrs();
@@ -355,7 +355,7 @@ fn generate_check() {
     // Can't generate ECC public key only
     assert_eq!(
         Err(ResponseStatus::PsaErrorNotSupported),
-        client.can_do_crypto(CheckType::Generate, attributes.clone())
+        client.can_do_crypto(CheckType::Generate, attributes)
     );
 
     let mut attributes = get_default_ecc_attrs();
@@ -363,21 +363,21 @@ fn generate_check() {
     // Can generate ECC key pair
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Generate, attributes.clone())
+        client.can_do_crypto(CheckType::Generate, attributes)
     );
 
     attributes.policy.permitted_algorithms = Algorithm::None;
     // Can generate ECC key pair without an algorithm defined
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Generate, attributes.clone())
+        client.can_do_crypto(CheckType::Generate, attributes)
     );
 
     attributes.bits = 1024;
     // Can't generate wrong size ECC key pair
     assert_eq!(
         Err(ResponseStatus::PsaErrorNotSupported),
-        client.can_do_crypto(CheckType::Generate, attributes.clone())
+        client.can_do_crypto(CheckType::Generate, attributes)
     );
 }
 
@@ -393,7 +393,7 @@ fn import_check() {
     // Can't import ECC key pair
     assert_eq!(
         Err(ResponseStatus::PsaErrorNotSupported),
-        client.can_do_crypto(CheckType::Import, attributes.clone())
+        client.can_do_crypto(CheckType::Import, attributes)
     );
 
     attributes.key_type = Type::EccPublicKey {
@@ -402,13 +402,13 @@ fn import_check() {
     // Can import ECC public key
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Import, attributes.clone())
+        client.can_do_crypto(CheckType::Import, attributes)
     );
 
     attributes.policy.permitted_algorithms = Algorithm::None;
     // Can import public ECC key without an algorithm defined
     assert_eq!(
         Ok(()),
-        client.can_do_crypto(CheckType::Import, attributes.clone())
+        client.can_do_crypto(CheckType::Import, attributes)
     );
 }

--- a/e2e_tests/tests/per_provider/normal_tests/capability_discovery.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/capability_discovery.rs
@@ -237,18 +237,12 @@ fn key_size_check() {
 
     attributes.bits = 2048;
     // Supported RSA key size
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Use, attributes));
 
     let mut attributes = get_default_ecc_attrs();
     let _ = attributes.policy.usage_flags.set_sign_hash();
     // Supported ECC key size
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Use, attributes));
 
     attributes.bits = 1024;
     // Usupported ECC key size
@@ -274,50 +268,32 @@ fn use_check() {
 
     let _ = attributes.policy.usage_flags.set_sign_hash();
     // Can use ECC key with sign_hash usage flag
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Use, attributes));
 
     attributes.policy.usage_flags = UsageFlags::default();
     let _ = attributes.policy.usage_flags.set_sign_message();
     // Can use ECC key with sign_message usage flag
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Use, attributes));
 
     attributes.policy.usage_flags = UsageFlags::default();
     let _ = attributes.policy.usage_flags.set_verify_hash();
     // Can use ECC key with verify_hash usage flag
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Use, attributes));
 
     attributes.policy.usage_flags = UsageFlags::default();
     let _ = attributes.policy.usage_flags.set_verify_message();
     // Can use ECC key with verify_message usage flag
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Use, attributes));
 
     attributes.policy.usage_flags = UsageFlags::default();
     let _ = attributes.policy.usage_flags.set_decrypt();
     // Can use ECC key with decrypt usage flag
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Use, attributes));
 
     attributes.policy.usage_flags = UsageFlags::default();
     let _ = attributes.policy.usage_flags.set_encrypt();
     // Can use ECC key with encrypt usage flag
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Use, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Use, attributes));
 
     let mut attributes = get_default_rsa_attrs();
     let _ = attributes.policy.usage_flags.set_encrypt();
@@ -400,15 +376,9 @@ fn import_check() {
         curve_family: EccFamily::SecpR1,
     };
     // Can import ECC public key
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Import, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Import, attributes));
 
     attributes.policy.permitted_algorithms = Algorithm::None;
     // Can import public ECC key without an algorithm defined
-    assert_eq!(
-        Ok(()),
-        client.can_do_crypto(CheckType::Import, attributes)
-    );
+    assert_eq!(Ok(()), client.can_do_crypto(CheckType::Import, attributes));
 }

--- a/e2e_tests/tests/per_provider/normal_tests/create_destroy_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/create_destroy_key.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
 
 #[cfg(not(feature = "cryptoauthlib-provider"))]

--- a/e2e_tests/tests/per_provider/normal_tests/export_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/export_key.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(unused_imports, unused)]
 use crate::per_provider::normal_tests::import_key::ECC_PUBLIC_KEY;
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::operations::psa_algorithm::*;
 use parsec_client::core::interface::operations::psa_key_attributes::*;
 use parsec_client::core::interface::requests::Result;

--- a/e2e_tests/tests/per_provider/normal_tests/export_public_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/export_public_key.rs
@@ -116,10 +116,10 @@ fn check_public_ecc_export_format() -> Result<()> {
     let private_key_name = String::from("check_public_ecc_export_format_prv");
     client.generate_ecc_key_pair_secpr1_ecdsa_sha256(private_key_name.clone())?;
     let public_key_name = String::from("check_public_ecc_export_format_pub");
-    let public_key = client.export_public_key(private_key_name.clone())?;
+    let public_key = client.export_public_key(private_key_name)?;
 
     // That should not fail if the bytes are in the expected format.
-    client.import_ecc_public_secp_r1_ecdsa_sha256_key(public_key_name.clone(), public_key)?;
+    client.import_ecc_public_secp_r1_ecdsa_sha256_key(public_key_name, public_key)?;
     Ok(())
 }
 

--- a/e2e_tests/tests/per_provider/normal_tests/export_public_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/export_public_key.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(unused_imports, unused)]
 use crate::per_provider::normal_tests::import_key::ECC_PUBLIC_KEY;
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::operations::psa_algorithm::*;
 use parsec_client::core::interface::operations::psa_key_attributes::*;
 use parsec_client::core::interface::requests::Opcode;

--- a/e2e_tests/tests/per_provider/normal_tests/import_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/import_key.rs
@@ -1,8 +1,8 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 #![allow(unused_imports, unused)]
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::operations::psa_algorithm::*;
 use parsec_client::core::interface::operations::psa_key_attributes::*;
 use parsec_client::core::interface::requests::Opcode;

--- a/e2e_tests/tests/per_provider/normal_tests/key_agreement.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_agreement.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::operations::psa_algorithm::RawKeyAgreement;
 use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
 
@@ -119,7 +119,7 @@ fn raw_key_agreement_brainpoolpr1() {
 
 #[test]
 fn raw_key_agreement_two_generated_parties() {
-    let key_name_1 = auto_test_keyname!("1"); 
+    let key_name_1 = auto_test_keyname!("1");
     let key_name_2 = auto_test_keyname!("2");
     let mut client = TestClient::new();
 

--- a/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
@@ -188,6 +188,6 @@ fn no_usage_flag_set() {
     };
 
     client
-        .generate_key(key_name.clone(), key_attributes)
+        .generate_key(key_name, key_attributes)
         .unwrap();
 }

--- a/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
@@ -1,8 +1,8 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 #![allow(unused_imports)]
-use e2e_tests::TestClient;
 use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
 use parsec_client::core::interface::operations::psa_algorithm::{
     Algorithm, AsymmetricSignature, Hash,
 };
@@ -187,7 +187,5 @@ fn no_usage_flag_set() {
         },
     };
 
-    client
-        .generate_key(key_name, key_attributes)
-        .unwrap();
+    client.generate_key(key_name, key_attributes).unwrap();
 }

--- a/e2e_tests/tests/per_provider/tpm_reset.rs
+++ b/e2e_tests/tests/per_provider/tpm_reset.rs
@@ -21,9 +21,9 @@ fn before_tpm_reset() {
     let rsa_key_name = String::from(RSA_KEY_NAME);
     let ecc_key_name = String::from(ECC_KEY_NAME);
 
-    client.generate_rsa_sign_key(rsa_key_name.clone()).unwrap();
+    client.generate_rsa_sign_key(rsa_key_name).unwrap();
     client
-        .generate_ecc_key_pair_secpr1_ecdsa_sha256(ecc_key_name.clone())
+        .generate_ecc_key_pair_secpr1_ecdsa_sha256(ecc_key_name)
         .unwrap();
 }
 


### PR DESCRIPTION
Adding extra checks in ci.sh to ensure that the e2e_tests crate is also
correctly formatted and that clippy is fine with its contents.

A number of fixes are also implemented to make clippy happy.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>