### PR TITLE
[CryptoAuthLib provider] PsaCipherEncrypt and PsaCipherDecrypt implementation

### DIFF
--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 serde = { version = "1.0.123", features = ["derive"] }
-parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust", rev = "119664eac501c7f1d207f03905311a0634db13a6", features = ["testing", "spiffe-auth"] }
+parsec-client = { git = "https://github.com/parallaxsecond/parsec-client-rust", rev = "bf01a58fe20a65f6151fc32c7c6c9d09ae7b741f", features = ["testing", "spiffe-auth"] }
 log = "0.4.14"
 # Compatible version with crate rsa
 rand = "0.7.3"

--- a/e2e_tests/tests/per_provider/normal_tests/cipher.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/cipher.rs
@@ -6,14 +6,25 @@ use e2e_tests::TestClient;
 use parsec_client::core::interface::operations::psa_algorithm::Cipher;
 use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
 
+// Test Vector from:
+// https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_CFB.pdf
+// https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_OFB.pdf
+// https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_CTR.pdf
+// https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_ECB.pdf
+// https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_CBC.pdf
+
 #[cfg(feature = "cryptoauthlib-provider")]
 const KEY_DATA: [u8; 16] = [
-    0x41, 0x89, 0x35, 0x1B, 0x5C, 0xAE, 0xA3, 0x75, 0xA0, 0x29, 0x9E, 0x81, 0xC6, 0x21, 0xBF, 0x43,
+    0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C,
 ];
 
 const IV_SIZE: usize = 16;
 const IV: [u8; IV_SIZE] = [
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+];
+#[cfg(feature = "cryptoauthlib-provider")]
+const IV_CTR: [u8; IV_SIZE] = [
+    0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
 ];
 
 const VALID_DATA_SIZE: usize = 64;
@@ -32,6 +43,42 @@ const CIPHERTEXT: [u8; VALID_DATA_SIZE] = [
     0xC8, 0xA6, 0x45, 0x37, 0xA0, 0xB3, 0xA9, 0x3F, 0xCD, 0xE3, 0xCD, 0xAD, 0x9F, 0x1C, 0xE5, 0x8B,
     0x26, 0x75, 0x1F, 0x67, 0xA3, 0xCB, 0xB1, 0x40, 0xB1, 0x80, 0x8C, 0xF1, 0x87, 0xA4, 0xF4, 0xDF,
     0xC0, 0x4B, 0x05, 0x35, 0x7C, 0x5D, 0x1C, 0x0E, 0xEA, 0xC4, 0xC6, 0x6F, 0x9F, 0xF7, 0xF2, 0xE6,
+];
+#[cfg(feature = "cryptoauthlib-provider")]
+const CIPHERTEXT_OFB: [u8; VALID_DATA_SIZE] = [
+    0x3B, 0x3F, 0xD9, 0x2E, 0xB7, 0x2D, 0xAD, 0x20, 0x33, 0x34, 0x49, 0xF8, 0xE8, 0x3C, 0xFB, 0x4A,
+    0x77, 0x89, 0x50, 0x8D, 0x16, 0x91, 0x8F, 0x03, 0xF5, 0x3C, 0x52, 0xDA, 0xC5, 0x4E, 0xD8, 0x25,
+    0x97, 0x40, 0x05, 0x1E, 0x9C, 0x5F, 0xEC, 0xF6, 0x43, 0x44, 0xF7, 0xA8, 0x22, 0x60, 0xED, 0xCC,
+    0x30, 0x4C, 0x65, 0x28, 0xF6, 0x59, 0xC7, 0x78, 0x66, 0xA5, 0x10, 0xD9, 0xC1, 0xD6, 0xAE, 0x5E,
+];
+#[cfg(feature = "cryptoauthlib-provider")]
+const CIPHERTEXT_CTR: [u8; VALID_DATA_SIZE] = [
+    0x87, 0x4D, 0x61, 0x91, 0xB6, 0x20, 0xE3, 0x26, 0x1B, 0xEF, 0x68, 0x64, 0x99, 0x0D, 0xB6, 0xCE,
+    0x98, 0x06, 0xF6, 0x6B, 0x79, 0x70, 0xFD, 0xFF, 0x86, 0x17, 0x18, 0x7B, 0xB9, 0xFF, 0xFD, 0xFF,
+    0x5A, 0xE4, 0xDF, 0x3E, 0xDB, 0xD5, 0xD3, 0x5E, 0x5B, 0x4F, 0x09, 0x02, 0x0D, 0xB0, 0x3E, 0xAB,
+    0x1E, 0x03, 0x1D, 0xDA, 0x2F, 0xBE, 0x03, 0xD1, 0x79, 0x21, 0x70, 0xA0, 0xF3, 0x00, 0x9C, 0xEE,
+];
+#[cfg(feature = "cryptoauthlib-provider")]
+const CIPHERTEXT_ECB: [u8; VALID_DATA_SIZE] = [
+    0x3A, 0xD7, 0x7B, 0xB4, 0x0D, 0x7A, 0x36, 0x60, 0xA8, 0x9E, 0xCA, 0xF3, 0x24, 0x66, 0xEF, 0x97,
+    0xF5, 0xD3, 0xD5, 0x85, 0x03, 0xB9, 0x69, 0x9D, 0xE7, 0x85, 0x89, 0x5A, 0x96, 0xFD, 0xBA, 0xAF,
+    0x43, 0xB1, 0xCD, 0x7F, 0x59, 0x8E, 0xCE, 0x23, 0x88, 0x1B, 0x00, 0xE3, 0xED, 0x03, 0x06, 0x88,
+    0x7B, 0x0C, 0x78, 0x5E, 0x27, 0xE8, 0xAD, 0x3F, 0x82, 0x23, 0x20, 0x71, 0x04, 0x72, 0x5D, 0xD4,
+];
+#[cfg(feature = "cryptoauthlib-provider")]
+const CIPHERTEXT_CBC: [u8; VALID_DATA_SIZE] = [
+    0x76, 0x49, 0xAB, 0xAC, 0x81, 0x19, 0xB2, 0x46, 0xCE, 0xE9, 0x8E, 0x9B, 0x12, 0xE9, 0x19, 0x7D,
+    0x50, 0x86, 0xCB, 0x9B, 0x50, 0x72, 0x19, 0xEE, 0x95, 0xDB, 0x11, 0x3A, 0x91, 0x76, 0x78, 0xB2,
+    0x73, 0xBE, 0xD6, 0xB8, 0xE3, 0xC1, 0x74, 0x3B, 0x71, 0x16, 0xE6, 0x9E, 0x22, 0x22, 0x95, 0x16,
+    0x3F, 0xF1, 0xCA, 0xA1, 0x68, 0x1F, 0xAC, 0x09, 0x12, 0x0E, 0xCA, 0x30, 0x75, 0x86, 0xE1, 0xA7,
+];
+#[cfg(feature = "cryptoauthlib-provider")]
+const CIPHERTEXT_PKCS7: [u8; VALID_DATA_SIZE + 16] = [
+    0x76, 0x49, 0xAB, 0xAC, 0x81, 0x19, 0xB2, 0x46, 0xCE, 0xE9, 0x8E, 0x9B, 0x12, 0xE9, 0x19, 0x7D,
+    0x50, 0x86, 0xCB, 0x9B, 0x50, 0x72, 0x19, 0xEE, 0x95, 0xDB, 0x11, 0x3A, 0x91, 0x76, 0x78, 0xB2,
+    0x73, 0xBE, 0xD6, 0xB8, 0xE3, 0xC1, 0x74, 0x3B, 0x71, 0x16, 0xE6, 0x9E, 0x22, 0x22, 0x95, 0x16,
+    0x3F, 0xF1, 0xCA, 0xA1, 0x68, 0x1F, 0xAC, 0x09, 0x12, 0x0E, 0xCA, 0x30, 0x75, 0x86, 0xE1, 0xA7,
+    0x8C, 0xB8, 0x28, 0x07, 0x23, 0x0E, 0x13, 0x21, 0xD3, 0xFA, 0xE0, 0x0D, 0x18, 0xCC, 0x20, 0x12,
 ];
 
 #[test]
@@ -120,6 +167,31 @@ fn cipher_encrypt_decrypt_ctr() {
 // Cipher operations are only supported by cryptoauthlib provider.
 #[cfg(feature = "cryptoauthlib-provider")]
 #[test]
+fn cipher_decrypt_ctr() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    let mut ciphertext = IV_CTR.to_vec();
+    ciphertext.append(&mut CIPHERTEXT_CTR.to_vec());
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::Ctr)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name, Cipher::Ctr, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
 fn cipher_encrypt_decrypt_ofb() {
     let key_name = auto_test_keyname!();
     let mut client = TestClient::new();
@@ -136,6 +208,31 @@ fn cipher_encrypt_decrypt_ofb() {
 
     let ciphertext = client
         .cipher_encrypt_message(key_name.clone(), Cipher::Ofb, &PLAINTEXT)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name, Cipher::Ofb, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_decrypt_ofb() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    let mut ciphertext = IV.to_vec();
+    ciphertext.append(&mut CIPHERTEXT_OFB.to_vec());
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::Ofb)
         .unwrap();
 
     let plaintext = client
@@ -168,6 +265,28 @@ fn cipher_encrypt_decrypt_ecb() {
 
     let plaintext = client
         .cipher_decrypt_message(key_name, Cipher::EcbNoPadding, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_decrypt_ecb() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::EcbNoPadding)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name, Cipher::EcbNoPadding, &CIPHERTEXT_ECB)
         .unwrap();
 
     assert_eq!(&PLAINTEXT, plaintext.as_slice());
@@ -243,6 +362,31 @@ fn cipher_encrypt_decrypt_cbc() {
 
     let ciphertext = client
         .cipher_encrypt_message(key_name.clone(), Cipher::CbcNoPadding, &PLAINTEXT)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name, Cipher::CbcNoPadding, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_decrypt_cbc() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    let mut ciphertext = IV.to_vec();
+    ciphertext.append(&mut CIPHERTEXT_CBC.to_vec());
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcNoPadding)
         .unwrap();
 
     let plaintext = client
@@ -335,6 +479,31 @@ fn cipher_encrypt_decrypt_cbc_pkcs7() {
 
     assert_eq!(&PLAINTEXT[..INVALID_DATA_SIZE], plaintext.as_slice());
     assert_eq!(INVALID_DATA_SIZE, plaintext.len());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_decrypt_cbc_pkcs7() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    let mut ciphertext = IV.to_vec();
+    ciphertext.append(&mut CIPHERTEXT_PKCS7.to_vec());
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcPkcs7)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name, Cipher::CbcPkcs7, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
 }
 
 // Cipher operations are only supported by cryptoauthlib provider.

--- a/e2e_tests/tests/per_provider/normal_tests/cipher.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/cipher.rs
@@ -1,0 +1,422 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+#[cfg(feature = "cryptoauthlib-provider")]
+use e2e_tests::auto_test_keyname;
+use e2e_tests::TestClient;
+use parsec_client::core::interface::operations::psa_algorithm::Cipher;
+use parsec_client::core::interface::requests::{Opcode, ResponseStatus};
+
+#[cfg(feature = "cryptoauthlib-provider")]
+const KEY_DATA: [u8; 16] = [
+    0x41, 0x89, 0x35, 0x1B, 0x5C, 0xAE, 0xA3, 0x75, 0xA0, 0x29, 0x9E, 0x81, 0xC6, 0x21, 0xBF, 0x43,
+];
+
+const IV_SIZE: usize = 16;
+const IV: [u8; IV_SIZE] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+];
+
+const VALID_DATA_SIZE: usize = 64;
+#[cfg(feature = "cryptoauthlib-provider")]
+const INVALID_DATA_SIZE: usize = 17;
+
+const PLAINTEXT: [u8; VALID_DATA_SIZE] = [
+    0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96, 0xE9, 0x3D, 0x7E, 0x11, 0x73, 0x93, 0x17, 0x2A,
+    0xAE, 0x2D, 0x8A, 0x57, 0x1E, 0x03, 0xAC, 0x9C, 0x9E, 0xB7, 0x6F, 0xAC, 0x45, 0xAF, 0x8E, 0x51,
+    0x30, 0xC8, 0x1C, 0x46, 0xA3, 0x5C, 0xE4, 0x11, 0xE5, 0xFB, 0xC1, 0x19, 0x1A, 0x0A, 0x52, 0xEF,
+    0xF6, 0x9F, 0x24, 0x45, 0xDF, 0x4F, 0x9B, 0x17, 0xAD, 0x2B, 0x41, 0x7B, 0xE6, 0x6C, 0x37, 0x10,
+];
+
+const CIPHERTEXT: [u8; VALID_DATA_SIZE] = [
+    0x3B, 0x3F, 0xD9, 0x2E, 0xB7, 0x2D, 0xAD, 0x20, 0x33, 0x34, 0x49, 0xF8, 0xE8, 0x3C, 0xFB, 0x4A,
+    0xC8, 0xA6, 0x45, 0x37, 0xA0, 0xB3, 0xA9, 0x3F, 0xCD, 0xE3, 0xCD, 0xAD, 0x9F, 0x1C, 0xE5, 0x8B,
+    0x26, 0x75, 0x1F, 0x67, 0xA3, 0xCB, 0xB1, 0x40, 0xB1, 0x80, 0x8C, 0xF1, 0x87, 0xA4, 0xF4, 0xDF,
+    0xC0, 0x4B, 0x05, 0x35, 0x7C, 0x5D, 0x1C, 0x0E, 0xEA, 0xC4, 0xC6, 0x6F, 0x9F, 0xF7, 0xF2, 0xE6,
+];
+
+#[test]
+fn cipher_not_supported() {
+    let mut client = TestClient::new();
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt) {
+        assert_eq!(
+            client
+                .cipher_encrypt_message(String::from("some key name"), Cipher::Cfb, &PLAINTEXT)
+                .unwrap_err(),
+            ResponseStatus::PsaErrorNotSupported
+        );
+    }
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        let mut ciphertext = IV.to_vec();
+        ciphertext.append(&mut CIPHERTEXT.to_vec());
+        assert_eq!(
+            client.cipher_decrypt_message(
+                    String::from("some key name"),
+                    Cipher::Cfb,
+                    &ciphertext[..],
+                )
+                .unwrap_err(),
+            ResponseStatus::PsaErrorNotSupported
+        );
+    }
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_decrypt_cfb() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt)
+        && !client.is_operation_supported(Opcode::PsaCipherDecrypt)
+    {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::Cfb)
+        .unwrap();
+
+    let ciphertext = client
+        .cipher_encrypt_message(key_name.clone(), Cipher::Cfb, &PLAINTEXT)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name.clone(), Cipher::Cfb, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_decrypt_ctr() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt)
+        && !client.is_operation_supported(Opcode::PsaCipherDecrypt)
+    {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::Ctr)
+        .unwrap();
+
+    let ciphertext = client
+        .cipher_encrypt_message(key_name.clone(), Cipher::Ctr, &PLAINTEXT)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name.clone(), Cipher::Ctr, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_decrypt_ofb() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt)
+        && !client.is_operation_supported(Opcode::PsaCipherDecrypt)
+    {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::Ofb)
+        .unwrap();
+
+    let ciphertext = client
+        .cipher_encrypt_message(key_name.clone(), Cipher::Ofb, &PLAINTEXT)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name.clone(), Cipher::Ofb, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_decrypt_ecb() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt)
+        && !client.is_operation_supported(Opcode::PsaCipherDecrypt)
+    {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::EcbNoPadding)
+        .unwrap();
+
+    let ciphertext = client
+        .cipher_encrypt_message(key_name.clone(), Cipher::EcbNoPadding, &PLAINTEXT)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name.clone(), Cipher::EcbNoPadding, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_ecb_invalid_data_size() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt) {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::EcbNoPadding)
+        .unwrap();
+
+    let invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
+
+    assert_eq!(
+        client
+            .cipher_encrypt_message(
+                key_name.clone(),
+                Cipher::EcbNoPadding,
+                &invalid_plaintext[..],
+            )
+            .unwrap_err(),
+        ResponseStatus::PsaErrorInvalidArgument
+    );
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_decrypt_ecb_invalid_data_size() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::EcbNoPadding)
+        .unwrap();
+
+    let invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
+    let mut ciphertext = IV.to_vec();
+    ciphertext.append(&mut invalid_plaintext.clone());
+    assert_eq!(
+        client
+            .cipher_decrypt_message(key_name.clone(), Cipher::EcbNoPadding, &ciphertext[..])
+            .unwrap_err(),
+        ResponseStatus::PsaErrorInvalidArgument
+    );
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_decrypt_cbc() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt)
+        && !client.is_operation_supported(Opcode::PsaCipherDecrypt)
+    {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcNoPadding)
+        .unwrap();
+
+    let ciphertext = client
+        .cipher_encrypt_message(key_name.clone(), Cipher::CbcNoPadding, &PLAINTEXT)
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name.clone(), Cipher::CbcNoPadding, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT, plaintext.as_slice());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_cbc_invalid_data_size() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt) {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcNoPadding)
+        .unwrap();
+
+    let invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
+
+    assert_eq!(
+        client
+            .cipher_encrypt_message(
+                key_name.clone(),
+                Cipher::CbcNoPadding,
+                &invalid_plaintext[..],
+            )
+            .unwrap_err(),
+        ResponseStatus::PsaErrorInvalidArgument
+    );
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_decrypt_cbc_invalid_data_size() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcNoPadding)
+        .unwrap();
+
+    let invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
+    let mut ciphertext = IV.to_vec();
+    ciphertext.append(&mut invalid_plaintext.clone());
+    assert_eq!(
+        client
+            .cipher_decrypt_message(key_name.clone(), Cipher::CbcNoPadding, &ciphertext[..])
+            .unwrap_err(),
+        ResponseStatus::PsaErrorInvalidArgument
+    );
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_decrypt_cbc_pkcs7() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt)
+        && !client.is_operation_supported(Opcode::PsaCipherDecrypt)
+    {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcPkcs7)
+        .unwrap();
+
+    // Size of plaintext changed to other than divisible by block size.
+    let ciphertext = client
+        .cipher_encrypt_message(
+            key_name.clone(),
+            Cipher::CbcPkcs7,
+            &PLAINTEXT[..INVALID_DATA_SIZE],
+        )
+        .unwrap();
+
+    let plaintext = client
+        .cipher_decrypt_message(key_name.clone(), Cipher::CbcPkcs7, &ciphertext)
+        .unwrap();
+
+    assert_eq!(&PLAINTEXT[..INVALID_DATA_SIZE], plaintext.as_slice());
+    assert_eq!(INVALID_DATA_SIZE, plaintext.len());
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_decrypt_cbc_pkcs7_invalid_data_size() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcPkcs7)
+        .unwrap();
+
+    let invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
+    let mut ciphertext = IV.to_vec();
+    ciphertext.append(&mut invalid_plaintext.clone());
+    assert_eq!(
+        client
+            .cipher_decrypt_message(key_name.clone(), Cipher::CbcPkcs7, &ciphertext[..],)
+            .unwrap_err(),
+        ResponseStatus::PsaErrorInvalidArgument
+    );
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_encrypt_empty_data() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherEncrypt) {
+        return;
+    }
+
+    let empty_plaintext = vec![];
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::Cfb)
+        .unwrap();
+
+    assert_eq!(
+        client
+            .cipher_encrypt_message(key_name.clone(), Cipher::Cfb, &empty_plaintext[..],)
+            .unwrap_err(),
+        ResponseStatus::PsaErrorInvalidArgument
+    );
+}
+
+// Cipher operations are only supported by cryptoauthlib provider.
+#[cfg(feature = "cryptoauthlib-provider")]
+#[test]
+fn cipher_decrypt_empty_data() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaCipherDecrypt) {
+        return;
+    }
+
+    let empty_ciphertext = vec![];
+
+    client
+        .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::Cfb)
+        .unwrap();
+
+    assert_eq!(
+        client
+            .cipher_encrypt_message(key_name.clone(), Cipher::Cfb, &empty_ciphertext[..],)
+            .unwrap_err(),
+        ResponseStatus::PsaErrorInvalidArgument
+    );
+}

--- a/e2e_tests/tests/per_provider/normal_tests/cipher.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/cipher.rs
@@ -83,7 +83,7 @@ fn cipher_encrypt_decrypt_cfb() {
         .unwrap();
 
     let plaintext = client
-        .cipher_decrypt_message(key_name.clone(), Cipher::Cfb, &ciphertext)
+        .cipher_decrypt_message(key_name, Cipher::Cfb, &ciphertext)
         .unwrap();
 
     assert_eq!(&PLAINTEXT, plaintext.as_slice());
@@ -111,7 +111,7 @@ fn cipher_encrypt_decrypt_ctr() {
         .unwrap();
 
     let plaintext = client
-        .cipher_decrypt_message(key_name.clone(), Cipher::Ctr, &ciphertext)
+        .cipher_decrypt_message(key_name, Cipher::Ctr, &ciphertext)
         .unwrap();
 
     assert_eq!(&PLAINTEXT, plaintext.as_slice());
@@ -139,7 +139,7 @@ fn cipher_encrypt_decrypt_ofb() {
         .unwrap();
 
     let plaintext = client
-        .cipher_decrypt_message(key_name.clone(), Cipher::Ofb, &ciphertext)
+        .cipher_decrypt_message(key_name, Cipher::Ofb, &ciphertext)
         .unwrap();
 
     assert_eq!(&PLAINTEXT, plaintext.as_slice());
@@ -167,7 +167,7 @@ fn cipher_encrypt_decrypt_ecb() {
         .unwrap();
 
     let plaintext = client
-        .cipher_decrypt_message(key_name.clone(), Cipher::EcbNoPadding, &ciphertext)
+        .cipher_decrypt_message(key_name, Cipher::EcbNoPadding, &ciphertext)
         .unwrap();
 
     assert_eq!(&PLAINTEXT, plaintext.as_slice());
@@ -192,11 +192,7 @@ fn cipher_encrypt_ecb_invalid_data_size() {
 
     assert_eq!(
         client
-            .cipher_encrypt_message(
-                key_name.clone(),
-                Cipher::EcbNoPadding,
-                &invalid_plaintext[..],
-            )
+            .cipher_encrypt_message(key_name, Cipher::EcbNoPadding, &invalid_plaintext[..])
             .unwrap_err(),
         ResponseStatus::PsaErrorInvalidArgument
     );
@@ -217,12 +213,12 @@ fn cipher_decrypt_ecb_invalid_data_size() {
         .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::EcbNoPadding)
         .unwrap();
 
-    let invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
+    let mut invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
     let mut ciphertext = IV.to_vec();
-    ciphertext.append(&mut invalid_plaintext.clone());
+    ciphertext.append(&mut invalid_plaintext);
     assert_eq!(
         client
-            .cipher_decrypt_message(key_name.clone(), Cipher::EcbNoPadding, &ciphertext[..])
+            .cipher_decrypt_message(key_name, Cipher::EcbNoPadding, &ciphertext[..])
             .unwrap_err(),
         ResponseStatus::PsaErrorInvalidArgument
     );
@@ -250,7 +246,7 @@ fn cipher_encrypt_decrypt_cbc() {
         .unwrap();
 
     let plaintext = client
-        .cipher_decrypt_message(key_name.clone(), Cipher::CbcNoPadding, &ciphertext)
+        .cipher_decrypt_message(key_name, Cipher::CbcNoPadding, &ciphertext)
         .unwrap();
 
     assert_eq!(&PLAINTEXT, plaintext.as_slice());
@@ -275,11 +271,7 @@ fn cipher_encrypt_cbc_invalid_data_size() {
 
     assert_eq!(
         client
-            .cipher_encrypt_message(
-                key_name.clone(),
-                Cipher::CbcNoPadding,
-                &invalid_plaintext[..],
-            )
+            .cipher_encrypt_message(key_name, Cipher::CbcNoPadding, &invalid_plaintext[..])
             .unwrap_err(),
         ResponseStatus::PsaErrorInvalidArgument
     );
@@ -300,12 +292,12 @@ fn cipher_decrypt_cbc_invalid_data_size() {
         .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcNoPadding)
         .unwrap();
 
-    let invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
+    let mut invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
     let mut ciphertext = IV.to_vec();
-    ciphertext.append(&mut invalid_plaintext.clone());
+    ciphertext.append(&mut invalid_plaintext);
     assert_eq!(
         client
-            .cipher_decrypt_message(key_name.clone(), Cipher::CbcNoPadding, &ciphertext[..])
+            .cipher_decrypt_message(key_name, Cipher::CbcNoPadding, &ciphertext[..])
             .unwrap_err(),
         ResponseStatus::PsaErrorInvalidArgument
     );
@@ -338,7 +330,7 @@ fn cipher_encrypt_decrypt_cbc_pkcs7() {
         .unwrap();
 
     let plaintext = client
-        .cipher_decrypt_message(key_name.clone(), Cipher::CbcPkcs7, &ciphertext)
+        .cipher_decrypt_message(key_name, Cipher::CbcPkcs7, &ciphertext)
         .unwrap();
 
     assert_eq!(&PLAINTEXT[..INVALID_DATA_SIZE], plaintext.as_slice());
@@ -360,12 +352,12 @@ fn cipher_decrypt_cbc_pkcs7_invalid_data_size() {
         .import_aes_key_cipher(key_name.clone(), KEY_DATA.to_vec(), Cipher::CbcPkcs7)
         .unwrap();
 
-    let invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
+    let mut invalid_plaintext = vec![0u8; INVALID_DATA_SIZE];
     let mut ciphertext = IV.to_vec();
-    ciphertext.append(&mut invalid_plaintext.clone());
+    ciphertext.append(&mut invalid_plaintext);
     assert_eq!(
         client
-            .cipher_decrypt_message(key_name.clone(), Cipher::CbcPkcs7, &ciphertext[..],)
+            .cipher_decrypt_message(key_name, Cipher::CbcPkcs7, &ciphertext[..],)
             .unwrap_err(),
         ResponseStatus::PsaErrorInvalidArgument
     );
@@ -390,7 +382,7 @@ fn cipher_encrypt_empty_data() {
 
     assert_eq!(
         client
-            .cipher_encrypt_message(key_name.clone(), Cipher::Cfb, &empty_plaintext[..],)
+            .cipher_encrypt_message(key_name, Cipher::Cfb, &empty_plaintext[..],)
             .unwrap_err(),
         ResponseStatus::PsaErrorInvalidArgument
     );
@@ -415,7 +407,7 @@ fn cipher_decrypt_empty_data() {
 
     assert_eq!(
         client
-            .cipher_encrypt_message(key_name.clone(), Cipher::Cfb, &empty_ciphertext[..],)
+            .cipher_encrypt_message(key_name, Cipher::Cfb, &empty_ciphertext[..],)
             .unwrap_err(),
         ResponseStatus::PsaErrorInvalidArgument
     );

--- a/e2e_tests/tests/per_provider/normal_tests/mod.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/mod.rs
@@ -6,6 +6,7 @@ mod asym_sign_verify;
 mod auth;
 mod basic;
 mod capability_discovery;
+mod cipher;
 mod create_destroy_key;
 mod export_key;
 mod export_public_key;

--- a/src/back/backend_handler.rs
+++ b/src/back/backend_handler.rs
@@ -323,12 +323,6 @@ impl BackEndHandler {
                 trace!("attest_key egress");
                 self.result_to_response(NativeResult::AttestKey(result), header)
             }
-            _ => {
-                // This default arm should be removed
-                // when all operation defind in Parsec-interface are implemented in the match.
-                trace!("Not yet implemented operation");
-                Response::from_request_header(header, ResponseStatus::OpcodeDoesNotExist)
-            }
         }
     }
 }

--- a/src/back/backend_handler.rs
+++ b/src/back/backend_handler.rs
@@ -284,6 +284,22 @@ impl BackEndHandler {
                 trace!("psa_verify_message egress");
                 self.result_to_response(NativeResult::PsaVerifyMessage(result), header)
             }
+            NativeOperation::PsaCipherEncrypt(op_cipher_encrypt) => {
+                let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .psa_cipher_encrypt(app.into(), op_cipher_encrypt));
+                trace!("op_cipher_encrypt egress");
+                self.result_to_response(NativeResult::PsaCipherEncrypt(result), header)
+            }
+            NativeOperation::PsaCipherDecrypt(op_cipher_decrypt) => {
+                let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .psa_cipher_decrypt(app.into(), op_cipher_decrypt));
+                trace!("psa_cipher_decrypt egress");
+                self.result_to_response(NativeResult::PsaCipherDecrypt(result), header)
+            }
             NativeOperation::CanDoCrypto(op_can_do_crypto) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self

--- a/src/back/backend_handler.rs
+++ b/src/back/backend_handler.rs
@@ -288,7 +288,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_cipher_encrypt(app.into(), op_cipher_encrypt));
+                    .psa_cipher_encrypt(app.identity(), op_cipher_encrypt));
                 trace!("op_cipher_encrypt egress");
                 self.result_to_response(NativeResult::PsaCipherEncrypt(result), header)
             }
@@ -296,7 +296,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_cipher_decrypt(app.into(), op_cipher_decrypt));
+                    .psa_cipher_decrypt(app.identity(), op_cipher_decrypt));
                 trace!("psa_cipher_decrypt egress");
                 self.result_to_response(NativeResult::PsaCipherDecrypt(result), header)
             }

--- a/src/providers/cryptoauthlib/cipher.rs
+++ b/src/providers/cryptoauthlib/cipher.rs
@@ -1,0 +1,143 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::Provider;
+use crate::authenticators::ApplicationName;
+use log::error;
+use parsec_interface::operations::psa_algorithm::Cipher;
+use parsec_interface::operations::{psa_cipher_decrypt, psa_cipher_encrypt, psa_generate_random};
+use parsec_interface::requests::{ResponseStatus, Result};
+use std::convert::TryInto;
+
+const CIPHER_IV_SIZE: usize = 16;
+const CIPHER_CTR_SIZE: u8 = 4;
+
+pub fn get_cipher_algorithm(
+    mut cipher_params: rust_cryptoauthlib::CipherParam,
+    alg: &Cipher,
+) -> Result<rust_cryptoauthlib::CipherAlgorithm> {
+    match alg {
+        Cipher::Cfb => Ok(rust_cryptoauthlib::CipherAlgorithm::Cfb(cipher_params)),
+        Cipher::Ctr => {
+            cipher_params.counter_size = Some(CIPHER_CTR_SIZE);
+            Ok(rust_cryptoauthlib::CipherAlgorithm::Ctr(cipher_params))
+        }
+        Cipher::Ofb => Ok(rust_cryptoauthlib::CipherAlgorithm::Ofb(cipher_params)),
+        Cipher::EcbNoPadding => Ok(rust_cryptoauthlib::CipherAlgorithm::Ecb(cipher_params)),
+        Cipher::CbcNoPadding => Ok(rust_cryptoauthlib::CipherAlgorithm::Cbc(cipher_params)),
+        Cipher::CbcPkcs7 => Ok(rust_cryptoauthlib::CipherAlgorithm::CbcPkcs7(cipher_params)),
+        _ => {
+            error!("Cipher encryption failed: given algorithm is not supported.");
+            Err(ResponseStatus::PsaErrorNotSupported)
+        }
+    }
+}
+
+impl Provider {
+    /// Generate random non-zero initialization vector
+    pub fn generate_iv(&self) -> Result<zeroize::Zeroizing<Vec<u8>>> {
+        let mut count = 0u8;
+        let random_op = psa_generate_random::Operation {
+            size: CIPHER_IV_SIZE,
+        };
+        let zero_iv = vec![0u8; CIPHER_IV_SIZE];
+        // In case of generating vector of zeros function will attempt at most twice
+        // to generate non-zero vector.
+        loop {
+            let random_bytes = self.psa_generate_random_internal(random_op)?.random_bytes;
+            match random_bytes.to_vec() != zero_iv {
+                true => break Ok(random_bytes),
+                false => {
+                    count += 1;
+                    if count < 3 {
+                        continue;
+                    }
+                    error!("Cipher encryption failed: could not generate non-zero initialization vector");
+                    return Err(ResponseStatus::PsaErrorGenericError);
+                }
+            }
+        }
+    }
+
+    pub(super) fn psa_cipher_encrypt_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_cipher_encrypt::Operation,
+    ) -> Result<psa_cipher_encrypt::Result> {
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(app_name, op.key_name.clone());
+        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        op.validate(key_attributes)?;
+
+        let generated_iv = self.generate_iv()?;
+        let cipher_param = rust_cryptoauthlib::CipherParam {
+            iv: Some(generated_iv.to_vec()[..].try_into()?),
+            ..Default::default()
+        };
+        let mut plaintext = op.plaintext.to_vec();
+        let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+
+        let result = self.device.cipher_encrypt(
+            get_cipher_algorithm(cipher_param, &op.alg)?,
+            key_id,
+            &mut plaintext,
+        );
+        match result {
+            rust_cryptoauthlib::AtcaStatus::AtcaSuccess => {
+                let mut generated_iv_as_vec = generated_iv.to_vec();
+                generated_iv_as_vec.append(&mut plaintext);
+                let ciphertext = zeroize::Zeroizing::new(generated_iv_as_vec);
+                Ok(psa_cipher_encrypt::Result { ciphertext })
+            }
+            rust_cryptoauthlib::AtcaStatus::AtcaInvalidSize
+            | rust_cryptoauthlib::AtcaStatus::AtcaInvalidId
+            | rust_cryptoauthlib::AtcaStatus::AtcaBadParam => {
+                error!("Cipher encryption failed: given plaintext is invalid.");
+                Err(ResponseStatus::PsaErrorInvalidArgument)
+            }
+            _ => Err(ResponseStatus::PsaErrorGenericError),
+        }
+    }
+
+    pub(super) fn psa_cipher_decrypt_internal(
+        &self,
+        app_name: ApplicationName,
+        op: psa_cipher_decrypt::Operation,
+    ) -> Result<psa_cipher_decrypt::Result> {
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(app_name, op.key_name.clone());
+        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        op.validate(key_attributes)?;
+
+        let mut op_iv: Vec<u8> = Vec::new();
+        op_iv.extend_from_slice(&op.ciphertext[..CIPHER_IV_SIZE]);
+        let mut ciphertext: Vec<u8> = Vec::new();
+        ciphertext.extend_from_slice(&op.ciphertext[CIPHER_IV_SIZE..]);
+        let cipher_param = rust_cryptoauthlib::CipherParam {
+            iv: Some(op_iv[..].try_into()?),
+            ..Default::default()
+        };
+        let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+
+        let result = self.device.cipher_decrypt(
+            get_cipher_algorithm(cipher_param, &op.alg)?,
+            key_id,
+            &mut ciphertext,
+        );
+
+        match result {
+            rust_cryptoauthlib::AtcaStatus::AtcaSuccess => {
+                let plaintext = zeroize::Zeroizing::new(ciphertext);
+                Ok(psa_cipher_decrypt::Result { plaintext })
+            }
+            rust_cryptoauthlib::AtcaStatus::AtcaInvalidSize
+            | rust_cryptoauthlib::AtcaStatus::AtcaInvalidId
+            | rust_cryptoauthlib::AtcaStatus::AtcaBadParam => {
+                error!("Cipher decryption failed: given ciphertext is invalid.");
+                Err(ResponseStatus::PsaErrorInvalidArgument)
+            }
+            _ => Err(ResponseStatus::PsaErrorGenericError),
+        }
+    }
+}

--- a/src/providers/cryptoauthlib/cipher.rs
+++ b/src/providers/cryptoauthlib/cipher.rs
@@ -45,20 +45,11 @@ impl Provider {
         let random_op = psa_generate_random::Operation {
             size: CIPHER_IV_SIZE,
         };
-        let zero_iv = vec![0u8; CIPHER_IV_SIZE];
         let random_bytes = self
             .psa_generate_random_internal(random_op)?
             .random_bytes
             .to_vec();
-        match random_bytes != zero_iv {
-            true => Ok(random_bytes),
-            false => {
-                error!(
-                    "Cipher encryption failed: could not generate non-zero initialization vector"
-                );
-                Err(ResponseStatus::PsaErrorInsufficientEntropy)
-            }
-        }
+        Ok(random_bytes)
     }
 
     pub(super) fn psa_cipher_encrypt_internal(

--- a/src/providers/cryptoauthlib/cipher.rs
+++ b/src/providers/cryptoauthlib/cipher.rs
@@ -11,49 +11,47 @@ use std::convert::TryInto;
 const CIPHER_IV_SIZE: usize = 16;
 const CIPHER_CTR_SIZE: u8 = 4;
 
-pub fn get_cipher_algorithm(
-    mut cipher_params: rust_cryptoauthlib::CipherParam,
-    alg: &Cipher,
-) -> Result<rust_cryptoauthlib::CipherAlgorithm> {
-    match alg {
-        Cipher::Cfb => Ok(rust_cryptoauthlib::CipherAlgorithm::Cfb(cipher_params)),
-        Cipher::Ctr => {
-            cipher_params.counter_size = Some(CIPHER_CTR_SIZE);
-            Ok(rust_cryptoauthlib::CipherAlgorithm::Ctr(cipher_params))
-        }
-        Cipher::Ofb => Ok(rust_cryptoauthlib::CipherAlgorithm::Ofb(cipher_params)),
-        Cipher::EcbNoPadding => Ok(rust_cryptoauthlib::CipherAlgorithm::Ecb(cipher_params)),
-        Cipher::CbcNoPadding => Ok(rust_cryptoauthlib::CipherAlgorithm::Cbc(cipher_params)),
-        Cipher::CbcPkcs7 => Ok(rust_cryptoauthlib::CipherAlgorithm::CbcPkcs7(cipher_params)),
-        _ => {
-            error!("Cipher encryption failed: given algorithm is not supported.");
-            Err(ResponseStatus::PsaErrorNotSupported)
+impl Provider {
+    /// Convert Cipher Algorithm type from parsec to rust_cryptoauthlib type
+    pub(super) fn get_cipher_algorithm(
+        &self,
+        mut cipher_params: rust_cryptoauthlib::CipherParam,
+        alg: &Cipher,
+    ) -> Result<rust_cryptoauthlib::CipherAlgorithm> {
+        match alg {
+            Cipher::Cfb => Ok(rust_cryptoauthlib::CipherAlgorithm::Cfb(cipher_params)),
+            Cipher::Ctr => {
+                cipher_params.counter_size = Some(CIPHER_CTR_SIZE);
+                Ok(rust_cryptoauthlib::CipherAlgorithm::Ctr(cipher_params))
+            }
+            Cipher::Ofb => Ok(rust_cryptoauthlib::CipherAlgorithm::Ofb(cipher_params)),
+            Cipher::EcbNoPadding => Ok(rust_cryptoauthlib::CipherAlgorithm::Ecb(cipher_params)),
+            Cipher::CbcNoPadding => Ok(rust_cryptoauthlib::CipherAlgorithm::Cbc(cipher_params)),
+            Cipher::CbcPkcs7 => Ok(rust_cryptoauthlib::CipherAlgorithm::CbcPkcs7(cipher_params)),
+            _ => {
+                error!("Cipher encryption failed: given algorithm is not supported.");
+                Err(ResponseStatus::PsaErrorNotSupported)
+            }
         }
     }
-}
 
-impl Provider {
     /// Generate random non-zero initialization vector
-    pub fn generate_iv(&self) -> Result<zeroize::Zeroizing<Vec<u8>>> {
-        let mut count = 0u8;
+    pub fn generate_iv(&self) -> Result<Vec<u8>> {
         let random_op = psa_generate_random::Operation {
             size: CIPHER_IV_SIZE,
         };
         let zero_iv = vec![0u8; CIPHER_IV_SIZE];
-        // In case of generating vector of zeros function will attempt at most twice
-        // to generate non-zero vector.
-        loop {
-            let random_bytes = self.psa_generate_random_internal(random_op)?.random_bytes;
-            match random_bytes.to_vec() != zero_iv {
-                true => break Ok(random_bytes),
-                false => {
-                    count += 1;
-                    if count < 3 {
-                        continue;
-                    }
-                    error!("Cipher encryption failed: could not generate non-zero initialization vector");
-                    return Err(ResponseStatus::PsaErrorGenericError);
-                }
+        let random_bytes = self
+            .psa_generate_random_internal(random_op)?
+            .random_bytes
+            .to_vec();
+        match random_bytes != zero_iv {
+            true => Ok(random_bytes),
+            false => {
+                error!(
+                    "Cipher encryption failed: could not generate non-zero initialization vector"
+                );
+                Err(ResponseStatus::PsaErrorInsufficientEntropy)
             }
         }
     }
@@ -71,20 +69,20 @@ impl Provider {
 
         let generated_iv = self.generate_iv()?;
         let cipher_param = rust_cryptoauthlib::CipherParam {
-            iv: Some(generated_iv.to_vec()[..].try_into()?),
+            iv: Some(generated_iv[..].try_into()?),
             ..Default::default()
         };
         let mut plaintext = op.plaintext.to_vec();
         let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
 
         let result = self.device.cipher_encrypt(
-            get_cipher_algorithm(cipher_param, &op.alg)?,
+            self.get_cipher_algorithm(cipher_param, &op.alg)?,
             key_id,
             &mut plaintext,
         );
         match result {
             rust_cryptoauthlib::AtcaStatus::AtcaSuccess => {
-                let mut generated_iv_as_vec = generated_iv.to_vec();
+                let mut generated_iv_as_vec = generated_iv;
                 generated_iv_as_vec.append(&mut plaintext);
                 let ciphertext = zeroize::Zeroizing::new(generated_iv_as_vec);
                 Ok(psa_cipher_encrypt::Result { ciphertext })
@@ -110,10 +108,15 @@ impl Provider {
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
         op.validate(key_attributes)?;
 
-        let mut op_iv: Vec<u8> = Vec::new();
-        op_iv.extend_from_slice(&op.ciphertext[..CIPHER_IV_SIZE]);
-        let mut ciphertext: Vec<u8> = Vec::new();
-        ciphertext.extend_from_slice(&op.ciphertext[CIPHER_IV_SIZE..]);
+        let mut op_iv = op.ciphertext.to_vec();
+        if op_iv.len() < CIPHER_IV_SIZE {
+            error!(
+                "Cipher decryption failed: given ciphertext is too short to contain initialization vector."
+            );
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+        let mut ciphertext = op_iv.split_off(CIPHER_IV_SIZE);
+
         let cipher_param = rust_cryptoauthlib::CipherParam {
             iv: Some(op_iv[..].try_into()?),
             ..Default::default()
@@ -121,7 +124,7 @@ impl Provider {
         let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
 
         let result = self.device.cipher_decrypt(
-            get_cipher_algorithm(cipher_param, &op.alg)?,
+            self.get_cipher_algorithm(cipher_param, &op.alg)?,
             key_id,
             &mut ciphertext,
         );

--- a/src/providers/cryptoauthlib/generate_random.rs
+++ b/src/providers/cryptoauthlib/generate_random.rs
@@ -45,7 +45,9 @@ impl Provider {
                     if loop_count < 3 {
                         continue;
                     } else {
-                        return Err(ResponseStatus::PsaErrorInsufficientEntropy);
+                        let err = ResponseStatus::PsaErrorInsufficientEntropy;
+                        format_error!("Bytes generation failed ", err);
+                        return Err(err);
                     }
                 }
             }

--- a/src/providers/cryptoauthlib/generate_random.rs
+++ b/src/providers/cryptoauthlib/generate_random.rs
@@ -10,29 +10,45 @@ impl Provider {
         op: psa_generate_random::Operation,
     ) -> Result<psa_generate_random::Result> {
         let mut random_bytes = vec![0u8; 0];
-        // calculate loop count
-        let call_count = (op.size + rust_cryptoauthlib::ATCA_RANDOM_BUFFER_SIZE - 1)
-            / rust_cryptoauthlib::ATCA_RANDOM_BUFFER_SIZE;
-        // loop
-        for _i in 0..call_count {
-            let mut buffer = Vec::with_capacity(rust_cryptoauthlib::ATCA_RANDOM_BUFFER_SIZE);
-            let err = self.device.random(&mut buffer);
-            match err {
-                rust_cryptoauthlib::AtcaStatus::AtcaSuccess => {
-                    // append buffer vector to result vector
-                    random_bytes.append(&mut buffer);
+        let zero_vector = vec![0u8, op.size as u8];
+        let mut loop_count = 0u8;
+        // external loop to retry generation if vector is not secure
+        loop {
+            // calculate internal loop count
+            let call_count = (op.size + rust_cryptoauthlib::ATCA_RANDOM_BUFFER_SIZE - 1)
+                / rust_cryptoauthlib::ATCA_RANDOM_BUFFER_SIZE;
+            // internal loop for vector size greater than buffer size
+            for _i in 0..call_count {
+                let mut buffer = Vec::with_capacity(rust_cryptoauthlib::ATCA_RANDOM_BUFFER_SIZE);
+                let err = self.device.random(&mut buffer);
+                match err {
+                    rust_cryptoauthlib::AtcaStatus::AtcaSuccess => {
+                        // append buffer vector to result vector
+                        random_bytes.append(&mut buffer);
+                    }
+                    _ => {
+                        let error = ResponseStatus::PsaErrorGenericError;
+                        format_error!("Bytes generation failed ", err);
+                        return Err(error);
+                    }
                 }
-                _ => {
-                    let error = ResponseStatus::PsaErrorGenericError;
-                    format_error!("Bytes generation failed ", err);
-                    return Err(error);
+            } // end internal loop
+            random_bytes.truncate(op.size); // cut vector to desired size
+            match random_bytes != zero_vector {
+                true => {
+                    break Ok(psa_generate_random::Result {
+                        random_bytes: random_bytes.into(),
+                    })
+                }
+                false => {
+                    loop_count += 1;
+                    if loop_count < 3 {
+                        continue;
+                    } else {
+                        return Err(ResponseStatus::PsaErrorInsufficientEntropy);
+                    }
                 }
             }
-        }
-        // cut vector to desired size
-        random_bytes.truncate(op.size);
-        Ok(psa_generate_random::Result {
-            random_bytes: random_bytes.into(),
-        })
+        } // end external loop
     }
 }

--- a/src/providers/cryptoauthlib/key_slot.rs
+++ b/src/providers/cryptoauthlib/key_slot.rs
@@ -190,6 +190,8 @@ impl AteccKeySlot {
             }
             // Cipher
             Algorithm::Cipher(Cipher::CbcPkcs7)
+            | Algorithm::Cipher(Cipher::CbcNoPadding)
+            | Algorithm::Cipher(Cipher::EcbNoPadding)
             | Algorithm::Cipher(Cipher::Ctr)
             | Algorithm::Cipher(Cipher::Cfb)
             | Algorithm::Cipher(Cipher::Ofb) => {

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -385,27 +385,27 @@ impl Provide for Provider {
 
     fn psa_cipher_encrypt(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_cipher_encrypt::Operation,
     ) -> Result<psa_cipher_encrypt::Result> {
         trace!("psa_cipher_encrypt ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaCipherEncrypt) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_cipher_encrypt_internal(app_name, op)
+            self.psa_cipher_encrypt_internal(application_identity, op)
         }
     }
 
     fn psa_cipher_decrypt(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_cipher_decrypt::Operation,
     ) -> Result<psa_cipher_decrypt::Result> {
         trace!("psa_cipher_decrypt ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaCipherDecrypt) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_cipher_decrypt_internal(app_name, op)
+            self.psa_cipher_decrypt_internal(application_identity, op)
         }
     }
 

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -19,14 +19,16 @@ use std::io::{Error, ErrorKind};
 use uuid::Uuid;
 
 use parsec_interface::operations::{
-    psa_aead_decrypt, psa_aead_encrypt, psa_destroy_key, psa_export_key, psa_export_public_key,
-    psa_generate_key, psa_generate_random, psa_hash_compare, psa_hash_compute, psa_import_key,
-    psa_sign_hash, psa_sign_message, psa_verify_hash, psa_verify_message,
+    psa_aead_decrypt, psa_aead_encrypt, psa_cipher_decrypt, psa_cipher_encrypt, psa_destroy_key,
+    psa_export_key, psa_export_public_key, psa_generate_key, psa_generate_random, psa_hash_compare,
+    psa_hash_compute, psa_import_key, psa_sign_hash, psa_sign_message, psa_verify_hash,
+    psa_verify_message,
 };
 
 mod access_keys;
 mod aead;
 mod asym_sign;
+mod cipher;
 mod generate_random;
 mod hash;
 mod key_management;
@@ -219,6 +221,8 @@ impl Provider {
                     && self.supported_opcodes.insert(Opcode::PsaImportKey)
                     && self.supported_opcodes.insert(Opcode::PsaSignHash)
                     && self.supported_opcodes.insert(Opcode::PsaVerifyHash)
+                    && self.supported_opcodes.insert(Opcode::PsaCipherEncrypt)
+                    && self.supported_opcodes.insert(Opcode::PsaCipherDecrypt)
                     && self.supported_opcodes.insert(Opcode::PsaSignMessage)
                     && self.supported_opcodes.insert(Opcode::PsaVerifyMessage)
                     && self.supported_opcodes.insert(Opcode::PsaExportPublicKey)
@@ -376,6 +380,32 @@ impl Provide for Provider {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
             self.psa_verify_hash_internal(application_identity, op)
+        }
+    }
+
+    fn psa_cipher_encrypt(
+        &self,
+        app_name: ApplicationName,
+        op: psa_cipher_encrypt::Operation,
+    ) -> Result<psa_cipher_encrypt::Result> {
+        trace!("psa_cipher_encrypt ingress");
+        if !self.supported_opcodes.contains(&Opcode::PsaCipherEncrypt) {
+            Err(ResponseStatus::PsaErrorNotSupported)
+        } else {
+            self.psa_cipher_encrypt_internal(app_name, op)
+        }
+    }
+
+    fn psa_cipher_decrypt(
+        &self,
+        app_name: ApplicationName,
+        op: psa_cipher_decrypt::Operation,
+    ) -> Result<psa_cipher_decrypt::Result> {
+        trace!("psa_cipher_decrypt ingress");
+        if !self.supported_opcodes.contains(&Opcode::PsaCipherDecrypt) {
+            Err(ResponseStatus::PsaErrorNotSupported)
+        } else {
+            self.psa_cipher_decrypt_internal(app_name, op)
         }
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -350,7 +350,7 @@ pub trait Provide {
     /// Encrypt a short message with a symmetric cipher.
     fn psa_cipher_encrypt(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_cipher_encrypt::Operation,
     ) -> Result<psa_cipher_encrypt::Result> {
         trace!("psa_cipher_encrypt ingress");
@@ -360,7 +360,7 @@ pub trait Provide {
     /// Decrypt a short message with a symmetric cipher.
     fn psa_cipher_decrypt(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_cipher_decrypt::Operation,
     ) -> Result<psa_cipher_decrypt::Result> {
         trace!("psa_cipher_decrypt ingress");

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -37,11 +37,10 @@ use crate::authenticators::ApplicationIdentity;
 use parsec_interface::operations::{
     attest_key, can_do_crypto, delete_client, list_authenticators, list_clients, list_keys,
     list_opcodes, list_providers, ping, prepare_key_attestation, psa_aead_decrypt,
-    psa_aead_encrypt, psa_asymmetric_decrypt, psa_cipher_decrypt, psa_cipher_encrypt,
-    psa_asymmetric_encrypt, psa_destroy_key, psa_export_key, psa_export_public_key,
-    psa_generate_key, psa_generate_random, psa_hash_compare,
-    psa_hash_compute, psa_import_key, psa_raw_key_agreement, psa_sign_hash, psa_sign_message,
-    psa_verify_hash, psa_verify_message,
+    psa_aead_encrypt, psa_asymmetric_decrypt, psa_asymmetric_encrypt, psa_cipher_decrypt,
+    psa_cipher_encrypt, psa_destroy_key, psa_export_key, psa_export_public_key, psa_generate_key,
+    psa_generate_random, psa_hash_compare, psa_hash_compute, psa_import_key, psa_raw_key_agreement,
+    psa_sign_hash, psa_sign_message, psa_verify_hash, psa_verify_message,
 };
 use parsec_interface::requests::{ResponseStatus, Result};
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -37,8 +37,9 @@ use crate::authenticators::ApplicationIdentity;
 use parsec_interface::operations::{
     attest_key, can_do_crypto, delete_client, list_authenticators, list_clients, list_keys,
     list_opcodes, list_providers, ping, prepare_key_attestation, psa_aead_decrypt,
-    psa_aead_encrypt, psa_asymmetric_decrypt, psa_asymmetric_encrypt, psa_destroy_key,
-    psa_export_key, psa_export_public_key, psa_generate_key, psa_generate_random, psa_hash_compare,
+    psa_aead_encrypt, psa_asymmetric_decrypt, psa_cipher_decrypt, psa_cipher_encrypt,
+    psa_asymmetric_encrypt, psa_destroy_key, psa_export_key, psa_export_public_key,
+    psa_generate_key, psa_generate_random, psa_hash_compare,
     psa_hash_compute, psa_import_key, psa_raw_key_agreement, psa_sign_hash, psa_sign_message,
     psa_verify_hash, psa_verify_message,
 };
@@ -344,6 +345,26 @@ pub trait Provide {
         _op: psa_generate_random::Operation,
     ) -> Result<psa_generate_random::Result> {
         trace!("psa_generate_random ingress");
+        Err(ResponseStatus::PsaErrorNotSupported)
+    }
+
+    /// Encrypt a short message with a symmetric cipher.
+    fn psa_cipher_encrypt(
+        &self,
+        _app_name: ApplicationName,
+        _op: psa_cipher_encrypt::Operation,
+    ) -> Result<psa_cipher_encrypt::Result> {
+        trace!("psa_cipher_encrypt ingress");
+        Err(ResponseStatus::PsaErrorNotSupported)
+    }
+
+    /// Decrypt a short message with a symmetric cipher.
+    fn psa_cipher_decrypt(
+        &self,
+        _app_name: ApplicationName,
+        _op: psa_cipher_decrypt::Operation,
+    ) -> Result<psa_cipher_decrypt::Result> {
+        trace!("psa_cipher_decrypt ingress");
         Err(ResponseStatus::PsaErrorNotSupported)
     }
 


### PR DESCRIPTION
Implementation for PsaCipherEncrypt and PsaCipherDecrypt operations. 
Implementation of end-2-end test cases for Cipher operations.
Updated to newest parsec-client-rust which includes Cipher operations.

Signed-off-by: artur.kazimierski <artur.kazimierski@globallogic.com>