### PR TITLE
Feature sqlite kim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
       # - name: Build the container
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh all
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec
+          ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh all
       # When running the container built on the CI
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh all
 
@@ -25,7 +27,8 @@ jobs:
       # - name: Build the container
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cargo-check
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cargo-check
       # When running the container built on the CI
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cargo-check
 
@@ -38,7 +41,8 @@ jobs:
       # - name: Build the container
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
       # When running the container built on the CI
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
 
@@ -52,7 +56,8 @@ jobs:
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
         # Not running stress tests because they fail, presumably because of the same issue as #264
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
       # When running the container built on the CI
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
 
@@ -65,7 +70,8 @@ jobs:
       # - name: Build the container
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh tpm
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh tpm
       # When running the container built on the CI
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh tpm
 
@@ -78,7 +84,8 @@ jobs:
       # - name: Build the container
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh trusted-service
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh trusted-service
         # When running the container built on the CI
         # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh trusted-service
 
@@ -92,7 +99,8 @@ jobs:
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
         # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
       # When running the container built on the CI
       # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
 
@@ -110,6 +118,20 @@ jobs:
       # When running the container built on the CI
       # run: CONTAINER_TAG=parsec-service-test-all ./fuzz.sh test
 
+  sqlite-kim:
+    name: SQLiteKIM E2E tests on all providers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Use the following step when updating the `parsec-service-test-all` image
+      # - name: Build the container
+      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Run the container to execute the test script
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh sqlite-kim
+      # When running the container built on the CI
+      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh sqlite-kim
+
   cross-compilation:
     # Currently only the Mbed Crypto, PKCS 11, and TPM providers are tested as the other ones need to cross-compile other libraries.
     name: Cross-compile Parsec to various targets
@@ -120,7 +142,8 @@ jobs:
       # - name: Build the container
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-cross-compile -f parsec-service-test-cross-compile.Dockerfile . && popd
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-cross-compile /tmp/parsec/test/cross-compile.sh
+        run:
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-cross-compile /tmp/parsec/test/cross-compile.sh
         # When running the container built on the CI
         # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-cross-compile /tmp/parsec/test/cross-compile.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,9 @@ tags
 # Git patch files
 *.patch
 
-# Parsec key info mappings directory
+# Parsec key info mappings directories
 mappings/
+kim-mappings/
 
 # TPM simulator state file
 NVChip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +363,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +557,18 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -696,6 +731,17 @@ checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -982,6 +1028,7 @@ dependencies = [
  "hex",
  "libc",
  "log",
+ "num-traits",
  "parsec-interface",
  "picky-asn1",
  "picky-asn1-der",
@@ -990,6 +1037,7 @@ dependencies = [
  "prost-build",
  "psa-crypto",
  "rand",
+ "rusqlite",
  "rust-cryptoauthlib",
  "sd-notify",
  "serde",
@@ -1382,6 +1430,21 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ anyhow = "1.0.38"
 rust-cryptoauthlib = { version = "0.4.2", optional = true }
 spiffe = { version = "0.2.0", optional = true }
 prost = { version = "0.8.0", optional = true }
+rusqlite = { version = "0.25.3", features = ["bundled"] }
+num-traits = "0.2.14"
 
 [dev-dependencies]
 rand = { version = "0.8.3", features = ["small_rng"] }

--- a/ci.sh
+++ b/ci.sh
@@ -125,7 +125,7 @@ while [ "$#" -gt 0 ]; do
             fi
             PROVIDER_NAME=$1
 
-            # If running anything but cargo-check, copy config
+            # Copy provider specific config, unless CI is running `cargo-check` or `sqlite-kim` CI
             if [ "$PROVIDER_NAME" != "cargo-check" ] && [ "$PROVIDER_NAME" != "sqlite-kim" ]; then
                 cp $(pwd)/e2e_tests/provider_cfg/$1/config.toml $CONFIG_PATH
             elif [ "$PROVIDER_NAME" = "sqlite-kim" ]; then

--- a/config.toml
+++ b/config.toml
@@ -101,6 +101,16 @@ manager_type = "OnDisk"
 
 # Example of an Mbed Crypto provider configuration.
 [[provider]]
+# ⚠
+# ⚠ WARNING: Provider name cannot change.
+# ⚠ WARNING: Choose a suitable naming scheme for your providers now.
+# ⚠ WARNING: Provider name defaults to "mbed-crypto-provider" if not provided, you will not be able to change
+# ⚠ the provider's name from this if you decide to use the default.
+# ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
+# ⚠
+# (Optional) The name of the provider
+name = "mbed-crypto-provider"
+
 # (Required) Type of provider.
 provider_type = "MbedCrypto"
 
@@ -114,6 +124,15 @@ key_info_manager = "on-disk-manager"
 
 # Example of a PKCS 11 provider configuration
 #[[provider]]
+# ⚠
+# ⚠ WARNING: Provider name cannot change.
+# ⚠ WARNING: Choose a suitable naming scheme for your providers now.
+# ⚠ WARNING: Provider name defaults to "pkcs11-provider" if not provided, you will not be able to change
+# ⚠ the provider's name from this if you decide to use the default.
+# ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
+# ⚠
+# (Optional) The name of the provider
+# name = "pkcs11-provider"
 #provider_type = "Pkcs11"
 #key_info_manager = "on-disk-manager"
 # (Required for this provider) Path to the location of the dynamic library loaded by this provider.
@@ -135,6 +154,15 @@ key_info_manager = "on-disk-manager"
 
 # Example of a TPM provider configuration
 #[[provider]]
+# ⚠
+# ⚠ WARNING: Provider name cannot change.
+# ⚠ WARNING: Choose a suitable naming scheme for your providers now.
+# ⚠ WARNING: Provider name defaults to "tpm-provider" if not provided, you will not be able to change
+# ⚠ the provider's name from this if you decide to use the default.
+# ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
+# ⚠
+# (Optional) The name of the provider
+# name = "tpm-provider"
 #provider_type = "Tpm"
 #key_info_manager = "on-disk-manager"
 # (Required) TPM TCTI device to use with this provider. The string can include configuration values - if no
@@ -169,6 +197,15 @@ key_info_manager = "on-disk-manager"
 # All below parameters depend on what devices, interfaces or parameters are required or supported by
 # "rust-cryptoauthlib" wrapper for cryptoauthlib and underlying hardware.
 #[[provider]]
+# ⚠
+# ⚠ WARNING: Provider name cannot change.
+# ⚠ WARNING: Choose a suitable naming scheme for your providers now.
+# ⚠ WARNING: Provider name defaults to "cryptoauthlib-provider" if not provided, you will not be able to change
+# ⚠ the provider's name from this if you decide to use the default.
+# ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
+# ⚠
+# (Optional) The name of the provider
+# name = "cryptoauthlib-provider"
 #provider_type = "CryptoAuthLib"
 #key_info_manager = "on-disk-manager"
 ##########
@@ -221,6 +258,15 @@ key_info_manager = "on-disk-manager"
 
 # Example of a Trusted Service provider configuration.
 #[[provider]]
+# ⚠
+# ⚠ WARNING: Provider name cannot change.
+# ⚠ WARNING: Choose a suitable naming scheme for your providers now.
+# ⚠ WARNING: Provider name defaults to "trusted-service-provider" if not provided, you will not be able to change
+# ⚠ the provider's name from this if you decide to use the default.
+# ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
+# ⚠
+# (Optional) The name of the provider
+# name = "trusted-service-provider"
 # (Required) Type of provider.
 #provider_type = "TrustedService"
 

--- a/e2e_tests/provider_cfg/all/sqlite-kim-all-providers.toml
+++ b/e2e_tests/provider_cfg/all/sqlite-kim-all-providers.toml
@@ -1,0 +1,53 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+admins = [ { name = "list_clients test" }, { name = "1000" }, { name = "client1" }, { name = "spiffe://example.org/parsec-client-1" } ]
+#workload_endpoint="unix:///tmp/agent.sock"
+
+[[key_manager]]
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+
+[[provider]]
+provider_type = "MbedCrypto"
+key_info_manager = "sqlite-manager"
+
+[[provider]]
+provider_type = "Tpm"
+key_info_manager = "sqlite-manager"
+tcti = "mssim"
+owner_hierarchy_auth = "tpm_pass"
+
+[[provider]]
+provider_type = "Pkcs11"
+key_info_manager = "sqlite-manager"
+library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
+user_pin = "123456"
+# The slot_number mandatory field is going to replace the following line with a valid number
+# slot_number
+
+[[provider]]
+provider_type = "CryptoAuthLib"
+key_info_manager = "sqlite-manager"
+device_type = "always-success"
+iface_type = "test-interface"
+# wake_delay = 1500
+# rx_retries = 20
+# # i2c parameters for i2c-pseudo proxy
+# slave_address = 0xc0
+# bus = 1
+# baud = 400000

--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -259,7 +259,7 @@ fn list_and_delete_clients() {
 
         client.set_default_auth(Some(all_providers_user.clone()));
         client
-            .generate_rsa_sign_key("all-providers-user-key".to_string())
+            .generate_rsa_sign_key(format!("{}-all-providers-user-key", provider.id))
             .unwrap();
 
         client.set_default_auth(Some(format!("user_{}", provider.id)));

--- a/src/authenticators/jwt_svid_authenticator/mod.rs
+++ b/src/authenticators/jwt_svid_authenticator/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! JWT SVID authenticator
 
-use super::{Admin, AdminList, Application, Authenticate};
+use super::{Admin, AdminList, Application, ApplicationIdentity, Authenticate};
 use crate::front::listener::ConnectionMetadata;
 use log::error;
 use parsec_interface::operations::list_authenticators;
@@ -72,6 +72,12 @@ impl Authenticate for JwtSvidAuthenticator {
             })?;
         let app_name = jwt_token.spiffe_id().to_string();
         let is_admin = self.admins.is_admin(&app_name);
-        Ok(Application::new(app_name, is_admin))
+        Ok(Application {
+            identity: ApplicationIdentity {
+                name: app_name,
+                authenticator_id: AuthType::JwtSvid,
+            },
+            is_admin,
+        })
     }
 }

--- a/src/back/backend_handler.rs
+++ b/src/back/backend_handler.rs
@@ -103,7 +103,7 @@ impl BackEndHandler {
             if !app.is_admin() {
                 warn!(
                     "Application name \"{}\" tried to perform an admin operation ({:?}).",
-                    app.get_name(),
+                    app.identity().name(),
                     opcode
                 );
                 return Response::from_request_header(header, ResponseStatus::AdminOperation);
@@ -131,14 +131,15 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_generate_key(app.into(), op_generate_key));
+                    .psa_generate_key(app.identity(), op_generate_key));
                 trace!("psa_generate_key egress");
                 self.result_to_response(NativeResult::PsaGenerateKey(result), header)
             }
             NativeOperation::PsaImportKey(op_import_key) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
-                let result =
-                    unwrap_or_else_return!(self.provider.psa_import_key(app.into(), op_import_key));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .psa_import_key(app.identity(), op_import_key));
                 trace!("psa_import_key egress");
                 self.result_to_response(NativeResult::PsaImportKey(result), header)
             }
@@ -146,14 +147,15 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_export_public_key(app.into(), op_export_public_key));
+                    .psa_export_public_key(app.identity(), op_export_public_key));
                 trace!("psa_export_public_key egress");
                 self.result_to_response(NativeResult::PsaExportPublicKey(result), header)
             }
             NativeOperation::PsaExportKey(op_export_key) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
-                let result =
-                    unwrap_or_else_return!(self.provider.psa_export_key(app.into(), op_export_key));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .psa_export_key(app.identity(), op_export_key));
                 trace!("psa_export_key egress");
                 self.result_to_response(NativeResult::PsaExportKey(result), header)
             }
@@ -161,14 +163,15 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_destroy_key(app.into(), op_destroy_key));
+                    .psa_destroy_key(app.identity(), op_destroy_key));
                 trace!("psa_destroy_key egress");
                 self.result_to_response(NativeResult::PsaDestroyKey(result), header)
             }
             NativeOperation::PsaSignHash(op_sign_hash) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
-                let result =
-                    unwrap_or_else_return!(self.provider.psa_sign_hash(app.into(), op_sign_hash));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .psa_sign_hash(app.identity(), op_sign_hash));
                 trace!("psa_sign_hash egress");
                 self.result_to_response(NativeResult::PsaSignHash(result), header)
             }
@@ -176,7 +179,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_verify_hash(app.into(), op_verify_hash));
+                    .psa_verify_hash(app.identity(), op_verify_hash));
                 trace!("psa_verify_hash egress");
                 self.result_to_response(NativeResult::PsaVerifyHash(result), header)
             }
@@ -184,7 +187,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_asymmetric_encrypt(app.into(), op_asymmetric_encrypt));
+                    .psa_asymmetric_encrypt(app.identity(), op_asymmetric_encrypt));
                 trace!("psa_asymmetric_encrypt egress");
                 self.result_to_response(NativeResult::PsaAsymmetricEncrypt(result), header)
             }
@@ -192,7 +195,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_asymmetric_decrypt(app.into(), op_asymmetric_decrypt));
+                    .psa_asymmetric_decrypt(app.identity(), op_asymmetric_decrypt));
                 trace!("psa_asymmetric_decrypt egress");
                 self.result_to_response(NativeResult::PsaAsymmetricDecrypt(result), header)
             }
@@ -200,7 +203,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_aead_encrypt(app.into(), op_aead_encrypt));
+                    .psa_aead_encrypt(app.identity(), op_aead_encrypt));
                 trace!("psa_aead_encrypt egress");
                 self.result_to_response(NativeResult::PsaAeadEncrypt(result), header)
             }
@@ -208,7 +211,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_aead_decrypt(app.into(), op_aead_decrypt));
+                    .psa_aead_decrypt(app.identity(), op_aead_decrypt));
                 trace!("psa_aead_decrypt egress");
                 self.result_to_response(NativeResult::PsaAeadDecrypt(result), header)
             }
@@ -222,7 +225,7 @@ impl BackEndHandler {
             NativeOperation::ListKeys(op_list_keys) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result =
-                    unwrap_or_else_return!(self.provider.list_keys(app.into(), op_list_keys));
+                    unwrap_or_else_return!(self.provider.list_keys(app.identity(), op_list_keys));
                 trace!("list_keys egress");
                 self.result_to_response(NativeResult::ListKeys(result), header)
             }
@@ -232,7 +235,10 @@ impl BackEndHandler {
                 self.result_to_response(NativeResult::ListClients(result), header)
             }
             NativeOperation::DeleteClient(op_delete_client) => {
-                let result = unwrap_or_else_return!(self.provider.delete_client(op_delete_client));
+                let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
+                let result = unwrap_or_else_return!(self
+                    .provider
+                    .delete_client(app.identity(), op_delete_client));
                 trace!("delete_client egress");
                 self.result_to_response(NativeResult::DeleteClient(result), header)
             }
@@ -252,7 +258,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_raw_key_agreement(app.into(), op_raw_key_agreement));
+                    .psa_raw_key_agreement(app.identity(), op_raw_key_agreement));
                 trace!("psa_raw_key_agreement egress");
                 self.result_to_response(NativeResult::PsaRawKeyAgreement(result), header)
             }
@@ -266,7 +272,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_sign_message(app.into(), op_sign_message));
+                    .psa_sign_message(app.identity(), op_sign_message));
                 trace!("psa_sign_message egress");
                 self.result_to_response(NativeResult::PsaSignMessage(result), header)
             }
@@ -274,7 +280,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .psa_verify_message(app.into(), op_verify_message));
+                    .psa_verify_message(app.identity(), op_verify_message));
                 trace!("psa_verify_message egress");
                 self.result_to_response(NativeResult::PsaVerifyMessage(result), header)
             }
@@ -282,7 +288,7 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .can_do_crypto(app.into(), op_can_do_crypto));
+                    .can_do_crypto(app.identity(), op_can_do_crypto));
                 trace!("can_do_crypto egress");
                 self.result_to_response(NativeResult::CanDoCrypto(result), header)
             }
@@ -290,14 +296,14 @@ impl BackEndHandler {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result = unwrap_or_else_return!(self
                     .provider
-                    .prepare_key_attestation(app.into(), op_prepare_key_attestation));
+                    .prepare_key_attestation(app.identity(), op_prepare_key_attestation));
                 trace!("prepare_key_attestation egress");
                 self.result_to_response(NativeResult::PrepareKeyAttestation(result), header)
             }
             NativeOperation::AttestKey(op_attest_key) => {
                 let app = unwrap_or_else_return!(app.ok_or(ResponseStatus::NotAuthenticated));
                 let result =
-                    unwrap_or_else_return!(self.provider.attest_key(app.into(), op_attest_key));
+                    unwrap_or_else_return!(self.provider.attest_key(app.identity(), op_attest_key));
                 trace!("attest_key egress");
                 self.result_to_response(NativeResult::AttestKey(result), header)
             }

--- a/src/front/front_end.rs
+++ b/src/front/front_end.rs
@@ -92,7 +92,7 @@ impl FrontEndHandler {
                 if let Some(app) = &app.as_ref() {
                     info!(
                         "New request received from application name \"{}\"",
-                        app.get_name()
+                        app.identity().name()
                     )
                 } else {
                     info!("New request received without authentication")
@@ -111,7 +111,7 @@ impl FrontEndHandler {
                     if let Some(app) = app {
                         info!(
                             "Response for application name \"{}\" sent back",
-                            app.get_name()
+                            app.identity().name()
                         );
                     } else {
                         info!("Response sent back from request without authentication");

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -6,15 +6,18 @@
 //! trait to help providers to store in a persistent manner the mapping between the name and the
 //! information of the keys they manage. Different implementors might store this mapping using different
 //! means but it has to be persistent.
-
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
+#[allow(deprecated)]
+use crate::key_info_managers::on_disk_manager::KeyTriple;
+use crate::providers::ProviderIdentity;
 use crate::utils::config::{KeyInfoManagerConfig, KeyInfoManagerType};
 use anyhow::Result;
 use derivative::Derivative;
 use parsec_interface::operations::psa_key_attributes::Attributes;
-use parsec_interface::requests::{ProviderId, ResponseStatus};
+use parsec_interface::requests::{AuthType, ResponseStatus};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 use std::fmt;
 use std::sync::{Arc, RwLock};
 use zeroize::Zeroize;
@@ -24,18 +27,21 @@ pub mod on_disk_manager;
 /// This structure corresponds to a unique identifier of the key. It is used internally by the Key
 /// ID manager to refer to a key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct KeyTriple {
-    app_name: ApplicationName,
-    provider_id: ProviderId,
+pub struct KeyIdentity {
+    /// The identity of the application that created the key.
+    application: ApplicationIdentity,
+    /// The identity of the provider where the key is stored.
+    provider: ProviderIdentity,
+    /// The key name
     key_name: String,
 }
 
-impl fmt::Display for KeyTriple {
+impl fmt::Display for KeyIdentity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Application Name: \"{}\", Provider ID: {}, Key Name: \"{}\"",
-            self.app_name, self.provider_id, self.key_name
+            "KeyIdentity: {{\n{},\n{},\nkey_name: \"{}\",\n}}",
+            self.application, self.provider, self.key_name
         )
     }
 }
@@ -50,29 +56,43 @@ struct KeyInfo {
     attributes: Attributes,
 }
 
-impl KeyTriple {
-    /// Creates a new instance of KeyTriple.
-    pub fn new(app_name: ApplicationName, provider_id: ProviderId, key_name: String) -> KeyTriple {
-        KeyTriple {
-            app_name,
-            provider_id,
+impl KeyIdentity {
+    /// Creates a new instance of KeyIdentity.
+    pub fn new(
+        application: ApplicationIdentity,
+        provider: ProviderIdentity,
+        key_name: String,
+    ) -> KeyIdentity {
+        KeyIdentity {
+            application,
+            provider,
             key_name,
         }
     }
 
     /// Checks if this key belongs to a specific provider.
-    pub fn belongs_to_provider(&self, provider_id: ProviderId) -> bool {
-        self.provider_id == provider_id
+    pub fn belongs_to_provider(&self, provider_name: String) -> bool {
+        *self.provider().name() == provider_name
     }
 
     /// Get the key name
-    pub fn key_name(&self) -> &str {
+    pub fn key_name(&self) -> &String {
         &self.key_name
     }
 
+    /// Get the application identity of the key
+    pub fn application(&self) -> &ApplicationIdentity {
+        &self.application
+    }
+
+    /// Get the application identity of the key
+    pub fn provider(&self) -> &ProviderIdentity {
+        &self.provider
+    }
+
     /// Get the app name
-    pub fn app_name(&self) -> &ApplicationName {
-        &self.app_name
+    pub fn app_name(&self) -> &String {
+        self.application.name()
     }
 }
 
@@ -96,14 +116,14 @@ trait ManageKeyInfo {
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn get(&self, key_triple: &KeyTriple) -> Result<Option<&KeyInfo>, String>;
+    fn get(&self, key_identity: &KeyIdentity) -> Result<Option<&KeyInfo>, String>;
 
     /// Returns a Vec of reference to the key triples corresponding to this provider.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn get_all(&self, provider_id: ProviderId) -> Result<Vec<&KeyTriple>, String>;
+    fn get_all(&self, provider_identity: ProviderIdentity) -> Result<Vec<KeyIdentity>, String>;
 
     /// Inserts a new mapping between the key triple and the key info. If the triple already exists,
     /// overwrite the existing mapping and returns the old `KeyInfo`. Otherwise returns `None`.
@@ -113,7 +133,7 @@ trait ManageKeyInfo {
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn insert(
         &mut self,
-        key_triple: KeyTriple,
+        key_identity: KeyIdentity,
         key_info: KeyInfo,
     ) -> Result<Option<KeyInfo>, String>;
 
@@ -123,14 +143,14 @@ trait ManageKeyInfo {
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn remove(&mut self, key_triple: &KeyTriple) -> Result<Option<KeyInfo>, String>;
+    fn remove(&mut self, key_identity: &KeyIdentity) -> Result<Option<KeyInfo>, String>;
 
     /// Check if a key triple mapping exists.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    fn exists(&self, key_triple: &KeyTriple) -> Result<bool, String>;
+    fn exists(&self, key_identity: &KeyIdentity) -> Result<bool, String>;
 }
 
 /// KeyInfoManager client structure that bridges between the KIM and the providers that need
@@ -138,15 +158,19 @@ trait ManageKeyInfo {
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct KeyInfoManagerClient {
-    provider_id: ProviderId,
+    provider_identity: ProviderIdentity,
     #[derivative(Debug = "ignore")]
     key_info_manager_impl: Arc<RwLock<dyn ManageKeyInfo + Send + Sync>>,
 }
 
 impl KeyInfoManagerClient {
     /// Get the KeyTriple representing a key.
-    pub fn get_key_triple(&self, app_name: ApplicationName, key_name: String) -> KeyTriple {
-        KeyTriple::new(app_name, self.provider_id, key_name)
+    pub fn get_key_triple(
+        &self,
+        application: ApplicationIdentity,
+        key_name: String,
+    ) -> KeyIdentity {
+        KeyIdentity::new(application, self.provider_identity.clone(), key_name)
     }
 
     /// Get the key ID for a given key triple
@@ -161,13 +185,13 @@ impl KeyInfoManagerClient {
     /// type fails, InvalidEncoding is returned.
     pub fn get_key_id<T: DeserializeOwned>(
         &self,
-        key_triple: &KeyTriple,
+        key_identity: &KeyIdentity,
     ) -> parsec_interface::requests::Result<T> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
-        let key_info = match key_info_manager_impl.get(key_triple) {
+        let key_info = match key_info_manager_impl.get(key_identity) {
             Ok(Some(key_info)) => key_info,
             Ok(None) => return Err(ResponseStatus::PsaErrorDoesNotExist),
             Err(string) => return Err(to_response_status(string)),
@@ -185,7 +209,7 @@ impl KeyInfoManagerClient {
     /// KeyInfoManagerError is returned.
     pub fn get_key_attributes(
         &self,
-        key_triple: &KeyTriple,
+        key_triple: &KeyIdentity,
     ) -> parsec_interface::requests::Result<Attributes> {
         let key_info_manager_impl = self
             .key_info_manager_impl
@@ -200,15 +224,15 @@ impl KeyInfoManagerClient {
     }
 
     /// Get all the key triples for the current provider
-    pub fn get_all(&self) -> parsec_interface::requests::Result<Vec<KeyTriple>> {
+    pub fn get_all(&self) -> parsec_interface::requests::Result<Vec<KeyIdentity>> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
 
         key_info_manager_impl
-            .get_all(self.provider_id)
-            .map(|vec| vec.into_iter().cloned().collect())
+            .get_all(self.provider_identity.clone())
+            // .map(|vec| vec.into_iter().cloned().collect())
             .map_err(to_response_status)
     }
 
@@ -220,7 +244,7 @@ impl KeyInfoManagerClient {
     /// KeyInfoManagerError is returned.
     pub fn remove_key_info(
         &self,
-        key_triple: &KeyTriple,
+        key_triple: &KeyIdentity,
     ) -> parsec_interface::requests::Result<()> {
         let mut key_info_manager_impl = self
             .key_info_manager_impl
@@ -241,7 +265,7 @@ impl KeyInfoManagerClient {
     /// any other error occurring in the KIM, KeyInfoManagerError is returned.
     pub fn insert_key_info<T: Serialize>(
         &self,
-        key_triple: KeyTriple,
+        key_triple: KeyIdentity,
         key_id: &T,
         attributes: Attributes,
     ) -> parsec_interface::requests::Result<()> {
@@ -261,15 +285,15 @@ impl KeyInfoManagerClient {
         }
     }
 
-    /// Replace the key info saved for a given triple
+    /// Replace the KeyInfo saved for a given KeyIdentity
     ///
     /// # Errors
     ///
-    /// If the key triple doesn't exist in the KIM, PsaErrorDoesNotExist is returned. For
+    /// If the key identity doesn't exist in the KIM, PsaErrorDoesNotExist is returned. For
     /// any other error occurring in the KIM, KeyInfoManagerError is returned.
     pub fn replace_key_info<T: Serialize>(
         &self,
-        key_triple: KeyTriple,
+        key_identity: KeyIdentity,
         key_id: &T,
         attributes: Attributes,
     ) -> parsec_interface::requests::Result<()> {
@@ -282,10 +306,10 @@ impl KeyInfoManagerClient {
             attributes,
         };
 
-        match key_info_manager_impl.insert(key_triple.clone(), key_info) {
+        match key_info_manager_impl.insert(key_identity.clone(), key_info) {
             Ok(None) => {
                 let _ = key_info_manager_impl
-                    .remove(&key_triple)
+                    .remove(&key_identity)
                     .map_err(to_response_status)?;
                 Err(ResponseStatus::PsaErrorDoesNotExist)
             }
@@ -299,19 +323,20 @@ impl KeyInfoManagerClient {
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
-    pub fn list_clients(&self) -> parsec_interface::requests::Result<Vec<ApplicationName>> {
+    pub fn list_clients(&self) -> parsec_interface::requests::Result<Vec<ApplicationIdentity>> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
-        let key_triples = key_info_manager_impl
-            .get_all(self.provider_id)
+        let key_identities = key_info_manager_impl
+            .get_all(self.provider_identity.clone())
             .map_err(to_response_status)?;
-        let mut clients = Vec::new();
 
-        for key_triple in key_triples {
-            if !clients.contains(key_triple.app_name()) {
-                let _ = clients.push(key_triple.app_name().clone());
+        let mut clients = Vec::new();
+        for key_identity in key_identities {
+            // TODO: Check this comparison
+            if !clients.contains(&key_identity.application) {
+                let _ = clients.push(key_identity.application.clone());
             }
         }
 
@@ -326,7 +351,7 @@ impl KeyInfoManagerClient {
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     pub fn list_keys(
         &self,
-        app_name: &ApplicationName,
+        application_identity: &ApplicationIdentity,
     ) -> parsec_interface::requests::Result<Vec<parsec_interface::operations::list_keys::KeyInfo>>
     {
         use parsec_interface::operations::list_keys::KeyInfo;
@@ -336,26 +361,33 @@ impl KeyInfoManagerClient {
             .expect("Key Info Manager lock poisoned");
 
         let mut keys: Vec<KeyInfo> = Vec::new();
-        let key_triples = key_info_manager_impl
-            .get_all(self.provider_id)
+        let key_identities = key_info_manager_impl
+            .get_all(self.provider_identity.clone())
             .map_err(to_response_status)?;
 
-        for key_triple in key_triples {
-            if key_triple.app_name() != app_name {
+        for key_identity in key_identities {
+            // TODO: Change this to also match on authenticator_id for SQLiteKeyInfoManager.
+            if key_identity.application.name() != application_identity.name() {
                 continue;
             }
 
             let key_info = key_info_manager_impl
-                .get(key_triple)
+                .get(&key_identity)
                 .map_err(to_response_status)?;
             let key_info = match key_info {
                 Some(key_info) => key_info,
                 _ => continue,
             };
 
+            // TODO: Fix this translation when SQLiteKeyInfoManager is added.
+            #[allow(deprecated)]
+            let key_triple =
+                KeyTriple::try_from(key_identity.clone()).map_err(to_response_status)?;
+
+            #[allow(deprecated)]
             keys.push(KeyInfo {
-                provider_id: key_triple.provider_id,
-                name: key_triple.key_name().to_string(),
+                provider_id: *key_triple.provider_id(),
+                name: key_identity.key_name().to_string(),
                 attributes: key_info.attributes,
             });
         }
@@ -369,7 +401,7 @@ impl KeyInfoManagerClient {
     ///
     /// Returns PsaErrorAlreadyExists if the key triple already exists or KeyInfoManagerError for
     /// another error.
-    pub fn does_not_exist(&self, key_triple: &KeyTriple) -> Result<(), ResponseStatus> {
+    pub fn does_not_exist(&self, key_triple: &KeyIdentity) -> Result<(), ResponseStatus> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
@@ -396,13 +428,14 @@ pub struct KeyInfoManagerFactory {
 
 impl KeyInfoManagerFactory {
     /// Create a KeyInfoManagerFactory
-    pub fn new(config: &KeyInfoManagerConfig) -> Result<Self> {
+    pub fn new(config: &KeyInfoManagerConfig, default_auth_type: AuthType) -> Result<Self> {
         let manager = match config.manager_type {
             KeyInfoManagerType::OnDisk => {
                 let mut builder = on_disk_manager::OnDiskKeyInfoManagerBuilder::new();
                 if let Some(store_path) = &config.store_path {
                     builder = builder.with_mappings_dir_path(store_path.into());
                 }
+                builder = builder.with_auth_type(default_auth_type);
                 builder.build()?
             }
         };
@@ -413,10 +446,10 @@ impl KeyInfoManagerFactory {
     }
 
     /// Build a KeyInfoManagerClient
-    pub fn build_client(&self, provider: ProviderId) -> KeyInfoManagerClient {
+    pub fn build_client(&self, provider_identity: ProviderIdentity) -> KeyInfoManagerClient {
         KeyInfoManagerClient {
             key_info_manager_impl: self.key_info_manager_impl.clone(),
-            provider_id: provider,
+            provider_identity,
         }
     }
 }

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -109,11 +109,6 @@ impl KeyIdentity {
     pub fn provider(&self) -> &ProviderIdentity {
         &self.provider
     }
-
-    /// Get the app name
-    pub fn app_name(&self) -> &String {
-        self.application.name()
-    }
 }
 
 /// Converts the error string returned by the ManageKeyInfo methods to
@@ -255,7 +250,6 @@ impl KeyInfoManagerClient {
 
         key_info_manager_impl
             .get_all(self.provider_identity.clone())
-            // .map(|vec| vec.into_iter().cloned().collect())
             .map_err(to_response_status)
     }
 
@@ -341,7 +335,7 @@ impl KeyInfoManagerClient {
         }
     }
 
-    /// Returns a Vec of ApplicationName of clients having keys in the provider.
+    /// Returns a Vec<ApplicationIdentity> of clients that have keys in this provider.
     ///
     /// # Errors
     ///
@@ -365,8 +359,8 @@ impl KeyInfoManagerClient {
         Ok(clients)
     }
 
-    /// Returns a Vec of the KeyInfo objects corresponding to the given application name and
-    /// provider ID.
+    /// Returns a Vec of the KeyInfo objects corresponding to the given ApplicationIdentity,
+    /// and the KIM client ProviderIdentity.
     ///
     /// # Errors
     ///

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-//! Persistent mapping between key triples and key information
+//! Persistent mapping between key identities and key information
 //!
 //! This module declares a [`ManageKeyInfo`](https://parallaxsecond.github.io/parsec-book/parsec_service/key_info_managers.html)
 //! trait to help providers to store in a persistent manner the mapping between the name and the
@@ -110,7 +110,7 @@ pub fn to_response_status(error_string: String) -> ResponseStatus {
 ///
 /// Interface to be implemented for persistent storage of key name -> key info mappings.
 trait ManageKeyInfo {
-    /// Returns a reference to the key info corresponding to this key triple or `None` if it does not
+    /// Returns a reference to the key info corresponding to this KeyIdentity or `None` if it does not
     /// exist.
     ///
     /// # Errors
@@ -118,14 +118,14 @@ trait ManageKeyInfo {
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn get(&self, key_identity: &KeyIdentity) -> Result<Option<&KeyInfo>, String>;
 
-    /// Returns a Vec of reference to the key triples corresponding to this provider.
+    /// Returns a Vec of reference to the key identities corresponding to this provider.
     ///
     /// # Errors
     ///
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn get_all(&self, provider_identity: ProviderIdentity) -> Result<Vec<KeyIdentity>, String>;
 
-    /// Inserts a new mapping between the key triple and the key info. If the triple already exists,
+    /// Inserts a new mapping between the KeyIdentity and the key info. If the KeyIdentity already exists,
     /// overwrite the existing mapping and returns the old `KeyInfo`. Otherwise returns `None`.
     ///
     /// # Errors
@@ -137,7 +137,7 @@ trait ManageKeyInfo {
         key_info: KeyInfo,
     ) -> Result<Option<KeyInfo>, String>;
 
-    /// Removes a key triple mapping and returns it. Does nothing and returns `None` if the mapping
+    /// Removes a KeyIdentity mapping and returns it. Does nothing and returns `None` if the mapping
     /// does not exist.
     ///
     /// # Errors
@@ -145,7 +145,7 @@ trait ManageKeyInfo {
     /// Returns an error as a String if there was a problem accessing the Key Info Manager.
     fn remove(&mut self, key_identity: &KeyIdentity) -> Result<Option<KeyInfo>, String>;
 
-    /// Check if a key triple mapping exists.
+    /// Check if a KeyIdentity mapping exists.
     ///
     /// # Errors
     ///
@@ -164,8 +164,8 @@ pub struct KeyInfoManagerClient {
 }
 
 impl KeyInfoManagerClient {
-    /// Get the KeyTriple representing a key.
-    pub fn get_key_triple(
+    /// Get the KeyIdentity representing a key.
+    pub fn get_key_identity(
         &self,
         application: ApplicationIdentity,
         key_name: String,
@@ -173,7 +173,7 @@ impl KeyInfoManagerClient {
         KeyIdentity::new(application, self.provider_identity.clone(), key_name)
     }
 
-    /// Get the key ID for a given key triple
+    /// Get the key ID for a given KeyIdentity
     ///
     /// The ID does not have to be a specific type. Rather, it must implement the `serde::Deserialize`
     /// trait. Before returning, an instance of that type is created from the bytes stored by the KIM.
@@ -201,7 +201,7 @@ impl KeyInfoManagerClient {
         Ok(bincode::deserialize(&key_info.id)?)
     }
 
-    /// Get the `Attributes` for a given key triple
+    /// Get the `Attributes` for a given KeyIdentity
     ///
     /// # Errors
     ///
@@ -209,13 +209,13 @@ impl KeyInfoManagerClient {
     /// KeyInfoManagerError is returned.
     pub fn get_key_attributes(
         &self,
-        key_triple: &KeyIdentity,
+        key_identity: &KeyIdentity,
     ) -> parsec_interface::requests::Result<Attributes> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
-        let key_info = match key_info_manager_impl.get(key_triple) {
+        let key_info = match key_info_manager_impl.get(key_identity) {
             Ok(Some(key_info)) => key_info,
             Ok(None) => return Err(ResponseStatus::PsaErrorDoesNotExist),
             Err(string) => return Err(to_response_status(string)),
@@ -223,7 +223,7 @@ impl KeyInfoManagerClient {
         Ok(key_info.attributes)
     }
 
-    /// Get all the key triples for the current provider
+    /// Get all the key identities for the current provider
     pub fn get_all(&self) -> parsec_interface::requests::Result<Vec<KeyIdentity>> {
         let key_info_manager_impl = self
             .key_info_manager_impl
@@ -236,7 +236,7 @@ impl KeyInfoManagerClient {
             .map_err(to_response_status)
     }
 
-    /// Remove the key represented by a key triple and return the stored info.
+    /// Remove the key represented by a KeyIdentity and return the stored info.
     ///
     /// # Errors
     ///
@@ -244,28 +244,28 @@ impl KeyInfoManagerClient {
     /// KeyInfoManagerError is returned.
     pub fn remove_key_info(
         &self,
-        key_triple: &KeyIdentity,
+        key_identity: &KeyIdentity,
     ) -> parsec_interface::requests::Result<()> {
         let mut key_info_manager_impl = self
             .key_info_manager_impl
             .write()
             .expect("Key Info Manager lock poisoned");
-        match key_info_manager_impl.remove(key_triple) {
+        match key_info_manager_impl.remove(key_identity) {
             Ok(Some(_key_info)) => Ok(()),
             Ok(None) => Err(ResponseStatus::PsaErrorDoesNotExist),
             Err(string) => Err(to_response_status(string)),
         }
     }
 
-    /// Insert key info for a given triple.
+    /// Insert key info for a given KeyIdentity.
     ///
     /// # Errors
     ///
-    /// If the key triple already existed in the KIM, PsaErrorAlreadyExists is returned. For
+    /// If the KeyIdentity already existed in the KIM, PsaErrorAlreadyExists is returned. For
     /// any other error occurring in the KIM, KeyInfoManagerError is returned.
     pub fn insert_key_info<T: Serialize>(
         &self,
-        key_triple: KeyIdentity,
+        key_identity: KeyIdentity,
         key_id: &T,
         attributes: Attributes,
     ) -> parsec_interface::requests::Result<()> {
@@ -278,7 +278,7 @@ impl KeyInfoManagerClient {
             attributes,
         };
 
-        match key_info_manager_impl.insert(key_triple, key_info) {
+        match key_info_manager_impl.insert(key_identity, key_info) {
             Ok(None) => Ok(()),
             Ok(Some(_)) => Err(ResponseStatus::PsaErrorAlreadyExists),
             Err(string) => Err(to_response_status(string)),
@@ -395,20 +395,20 @@ impl KeyInfoManagerClient {
         Ok(keys)
     }
 
-    /// Check if a key triple exists in the Key Info Manager and return a ResponseStatus
+    /// Check if a KeyIdentity exists in the Key Info Manager and return a ResponseStatus
     ///
     /// # Errors
     ///
-    /// Returns PsaErrorAlreadyExists if the key triple already exists or KeyInfoManagerError for
+    /// Returns PsaErrorAlreadyExists if the KeyIdentity already exists or KeyInfoManagerError for
     /// another error.
-    pub fn does_not_exist(&self, key_triple: &KeyIdentity) -> Result<(), ResponseStatus> {
+    pub fn does_not_exist(&self, key_identity: &KeyIdentity) -> Result<(), ResponseStatus> {
         let key_info_manager_impl = self
             .key_info_manager_impl
             .read()
             .expect("Key Info Manager lock poisoned");
 
         if key_info_manager_impl
-            .exists(key_triple)
+            .exists(key_identity)
             .map_err(to_response_status)?
         {
             Err(ResponseStatus::PsaErrorAlreadyExists)

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -13,6 +13,7 @@
 //! names will be limited to 188 bytes of UTF-8 characters.
 //! For security reasons, only the PARSEC service should have the ability to modify these files.
 use crate::authenticators::{Application, ApplicationIdentity};
+use crate::utils::config::KeyInfoManagerType;
 
 use super::{KeyIdentity, KeyInfo, ManageKeyInfo, ProviderIdentity};
 use crate::providers::core::Provider as CoreProvider;
@@ -203,8 +204,8 @@ impl TryFrom<(KeyTriple, ProviderIdentity, AuthType)> for KeyIdentity {
         }?;
 
         Ok(KeyIdentity {
-            provider: ProviderIdentity::new(provider_uuid, provider_identity.name().clone()), // TODO: Figure out a better default null name
-            application: ApplicationIdentity::new(key_triple.app_name().to_string(), auth_type), // TODO: Figure out a better default null authenticator_id
+            provider: ProviderIdentity::new(provider_uuid, provider_identity.name().clone()),
+            application: ApplicationIdentity::new(key_triple.app_name().to_string(), auth_type),
             key_name: key_triple.key_name.to_string(),
         })
     }
@@ -493,6 +494,10 @@ impl OnDiskKeyInfoManager {
 
 #[allow(deprecated)]
 impl ManageKeyInfo for OnDiskKeyInfoManager {
+    fn key_info_manager_type(&self) -> KeyInfoManagerType {
+        KeyInfoManagerType::OnDisk
+    }
+
     fn get(&self, key_identity: &KeyIdentity) -> Result<Option<&KeyInfo>, String> {
         let key_triple = KeyTriple::try_from(key_identity.clone())?;
         // An Option<&Vec<u8>> can not automatically coerce to an Option<&[u8]>, it needs to be

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -12,35 +12,221 @@
 //! example, for operating systems having a limit of 255 characters for filenames (Unix systems),
 //! names will be limited to 188 bytes of UTF-8 characters.
 //! For security reasons, only the PARSEC service should have the ability to modify these files.
-use super::{KeyInfo, KeyTriple, ManageKeyInfo};
-use crate::authenticators::ApplicationName;
+use crate::authenticators::{Application, ApplicationIdentity};
+
+use super::{KeyIdentity, KeyInfo, ManageKeyInfo, ProviderIdentity};
+use crate::providers::core::Provider as CoreProvider;
+#[cfg(feature = "cryptoauthlib-provider")]
+use crate::providers::cryptoauthlib::Provider as CryptoAuthLibProvider;
+#[cfg(feature = "mbed-crypto-provider")]
+use crate::providers::mbed_crypto::Provider as MbedCryptoProvider;
+#[cfg(feature = "pkcs11-provider")]
+use crate::providers::pkcs11::Provider as Pkcs11Provider;
+#[cfg(feature = "tpm-provider")]
+use crate::providers::tpm::Provider as TpmProvider;
+#[cfg(feature = "trusted-service-provider")]
+use crate::providers::trusted_service::Provider as TrustedServiceProvider;
 use anyhow::{Context, Result};
 use log::{error, info, warn};
-use parsec_interface::requests::ProviderId;
+use parsec_interface::requests::{AuthType, ProviderId};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::ffi::OsStr;
-use std::fs;
 use std::fs::{DirEntry, File};
 use std::io::{Error, ErrorKind, Read, Write};
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::{fmt, fs};
 
 /// Default path where the mapping files will be stored on disk
 pub const DEFAULT_MAPPINGS_PATH: &str = "/var/lib/parsec/mappings";
+
+/// String wrapper for app names
+#[deprecated(since = "0.9.0", note = "ApplicationIdentity should be used instead.")]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ApplicationName {
+    name: String,
+}
+
+#[allow(deprecated)]
+impl Deref for ApplicationName {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.name
+    }
+}
+
+#[allow(deprecated)]
+#[deprecated(since = "0.9.0", note = "ApplicationIdentity should be used instead.")]
+impl ApplicationName {
+    /// Create ApplicationName from name string only
+    pub fn from_name(name: String) -> ApplicationName {
+        ApplicationName { name }
+    }
+}
+
+#[allow(deprecated)]
+impl std::fmt::Display for ApplicationName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[allow(deprecated)]
+impl From<Application> for ApplicationName {
+    fn from(app: Application) -> Self {
+        ApplicationName::from_name(app.identity().name().clone())
+    }
+}
+
+/// Should only be used internally to map KeyTriple to the new KeyIdentity
+/// for the on_disk_manager KeyInfoManager.
+/// Structure corresponds to a unique identifier of the key.
+/// It is used internally by the Key ID manager to refer to a key.
+#[deprecated(since = "0.9.0", note = "KeyIdentity should be used instead.")]
+#[allow(deprecated)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct KeyTriple {
+    app_name: ApplicationName,
+    provider_id: ProviderId,
+    key_name: String,
+}
+
+#[allow(deprecated)]
+#[deprecated(since = "0.9.0", note = "KeyIdentity should be used instead.")]
+impl KeyTriple {
+    /// Creates a new instance of KeyTriple.
+    pub fn new(app_name: ApplicationName, provider_id: ProviderId, key_name: String) -> KeyTriple {
+        KeyTriple {
+            app_name,
+            provider_id,
+            key_name,
+        }
+    }
+
+    /// Checks if this key belongs to a specific provider.
+    pub fn belongs_to_provider(&self, provider_id: ProviderId) -> bool {
+        self.provider_id == provider_id
+    }
+    /// Get the provider id
+    pub fn provider_id(&self) -> &ProviderId {
+        &self.provider_id
+    }
+
+    /// Get the key name
+    pub fn key_name(&self) -> &str {
+        &self.key_name
+    }
+
+    /// Get the app name
+    pub fn app_name(&self) -> &ApplicationName {
+        &self.app_name
+    }
+}
+
+#[allow(deprecated)]
+impl fmt::Display for KeyTriple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "KeyTriple: app_name=\"{}\" provider_id={} key_name=\"{}\"",
+            self.app_name, self.provider_id, self.key_name
+        )
+    }
+}
+
+#[allow(deprecated)]
+impl TryFrom<KeyIdentity> for KeyTriple {
+    type Error = String;
+
+    fn try_from(key_identity: KeyIdentity) -> ::std::result::Result<Self, Self::Error> {
+        let provider_id = match key_identity.provider.uuid().as_str() {
+            CoreProvider::PROVIDER_UUID => Ok(ProviderId::Core),
+            #[cfg(feature = "cryptoauthlib-provider")]
+            CryptoAuthLibProvider::PROVIDER_UUID => Ok(ProviderId::CryptoAuthLib),
+            #[cfg(feature = "mbed-crypto-provider")]
+            MbedCryptoProvider::PROVIDER_UUID => Ok(ProviderId::MbedCrypto),
+            #[cfg(feature = "pkcs11-provider")]
+            Pkcs11Provider::PROVIDER_UUID => Ok(ProviderId::Pkcs11),
+            #[cfg(feature = "tpm-provider")]
+            TpmProvider::PROVIDER_UUID => Ok(ProviderId::Tpm),
+            #[cfg(feature = "trusted-service-provider")]
+            TrustedServiceProvider::PROVIDER_UUID => Ok(ProviderId::TrustedService),
+            _ => Err(format!(
+                "Cannot convert from KeyIdentity to KeyTriple.
+                Provider \"{}\" is not recognised.
+                Could be it does not exist, or Parsec was not compiled with the required provider feature flags.",
+                key_identity.provider().uuid()
+            )),
+        }?;
+
+        let app_name = ApplicationName::from_name(key_identity.application().name().clone());
+        Ok(KeyTriple {
+            provider_id,
+            app_name,
+            key_name: key_identity.key_name,
+        })
+    }
+}
+
+#[allow(deprecated)]
+impl TryFrom<(KeyTriple, ProviderIdentity, AuthType)> for KeyIdentity {
+    type Error = String;
+
+    fn try_from(
+        (key_triple, provider_identity, auth_type): (KeyTriple, ProviderIdentity, AuthType),
+    ) -> ::std::result::Result<Self, Self::Error> {
+        // Result types required by clippy as Err result has the possibility of not being compiled.
+        let provider_uuid = match key_triple.provider_id {
+            ProviderId::Core => Ok::<String, Self::Error>(
+                CoreProvider::PROVIDER_UUID.to_string(),
+            ),
+            #[cfg(feature = "cryptoauthlib-provider")]
+            ProviderId::CryptoAuthLib => Ok::<String, Self::Error>(CryptoAuthLibProvider::PROVIDER_UUID.to_string()),
+            #[cfg(feature = "mbed-crypto-provider")]
+            ProviderId::MbedCrypto => Ok::<String, Self::Error>(MbedCryptoProvider::PROVIDER_UUID.to_string()),
+            #[cfg(feature = "pkcs11-provider")]
+            ProviderId::Pkcs11 => Ok::<String, Self::Error>(Pkcs11Provider::PROVIDER_UUID.to_string()),
+            #[cfg(feature = "tpm-provider")]
+            ProviderId::Tpm => Ok::<String, Self::Error>(TpmProvider::PROVIDER_UUID.to_string()),
+            #[cfg(feature = "trusted-service-provider")]
+            ProviderId::TrustedService => Ok::<String, Self::Error>(TrustedServiceProvider::PROVIDER_UUID.to_string()),
+            #[cfg(not(all(
+                feature = "cryptoauthlib-provider",
+                feature = "mbed-crypto-provider",
+                feature = "pkcs11-provider",
+                feature = "tpm-provider",
+                feature = "trusted-service-provider",
+            )))]
+            _ => Err(format!("Cannot convert from KeyTriple to KeyIdentity.\nProvider \"{}\" is not recognised.\nCould be it does not exist, or Parsec was not compiled with the required provider feature flags.", key_triple.provider_id)),
+        }?;
+
+        Ok(KeyIdentity {
+            provider: ProviderIdentity::new(provider_uuid, provider_identity.name().clone()), // TODO: Figure out a better default null name
+            application: ApplicationIdentity::new(key_triple.app_name().to_string(), auth_type), // TODO: Figure out a better default null authenticator_id
+            key_name: key_triple.key_name.to_string(),
+        })
+    }
+}
 
 /// A key info manager storing key triple to key info mapping on files on disk
 #[derive(Debug)]
 pub struct OnDiskKeyInfoManager {
     /// Internal mapping, used for non-modifying operations.
+    #[allow(deprecated)]
     key_store: HashMap<KeyTriple, KeyInfo>,
     /// Folder where all the key triple to key info mappings are saved. This folder will be created
     /// if it does already exist.
     mappings_dir_path: PathBuf,
+    /// The AuthType currently being used by Parsec and hence used to namespace the OnDiskKeyInfoManager.
+    auth_type: AuthType,
 }
 
 /// Encodes a KeyTriple's data into base64 strings that can be used as filenames.
 /// The ProviderId will not be converted as a base64 as it can always be represented as a String
 /// being a number from 0 and 255.
+#[allow(deprecated)]
 fn key_triple_to_base64_filenames(key_triple: &KeyTriple) -> (String, String, String) {
     (
         base64::encode_config(key_triple.app_name.as_bytes(), base64::URL_SAFE),
@@ -70,6 +256,7 @@ fn base64_data_to_string(base64_bytes: &[u8]) -> Result<String, String> {
 /// # Errors
 ///
 /// Returns an error as a string if either the decoding or the bytes conversion to UTF-8 failed.
+#[allow(deprecated)]
 fn base64_data_triple_to_key_triple(
     app_name: &[u8],
     provider_id: ProviderId,
@@ -152,6 +339,7 @@ fn list_files(path: &Path) -> std::io::Result<Vec<PathBuf>> {
 ///
 /// The `OnDiskKeyInfoManager` relies on access control mechanisms provided by the OS for
 /// the filesystem to ensure security of the mappings.
+#[allow(deprecated)]
 impl OnDiskKeyInfoManager {
     /// Creates an instance of the on-disk manager from the mapping files. This function will
     /// create the mappings directory if it does not already exist.
@@ -181,7 +369,7 @@ impl OnDiskKeyInfoManager {
     /// # Errors
     ///
     /// Returns an std::io error if the function failed reading the mapping files.
-    fn new(mappings_dir_path: PathBuf) -> Result<OnDiskKeyInfoManager> {
+    fn new(mappings_dir_path: PathBuf, auth_type: AuthType) -> Result<OnDiskKeyInfoManager> {
         let mut key_store = HashMap::new();
 
         // Will ignore if the mappings directory already exists.
@@ -248,6 +436,7 @@ impl OnDiskKeyInfoManager {
         Ok(OnDiskKeyInfoManager {
             key_store,
             mappings_dir_path,
+            auth_type,
         })
     }
 
@@ -302,30 +491,44 @@ impl OnDiskKeyInfoManager {
     }
 }
 
+#[allow(deprecated)]
 impl ManageKeyInfo for OnDiskKeyInfoManager {
-    fn get(&self, key_triple: &KeyTriple) -> Result<Option<&KeyInfo>, String> {
+    fn get(&self, key_identity: &KeyIdentity) -> Result<Option<&KeyInfo>, String> {
+        let key_triple = KeyTriple::try_from(key_identity.clone())?;
         // An Option<&Vec<u8>> can not automatically coerce to an Option<&[u8]>, it needs to be
         // done by hand.
-        if let Some(key_info) = self.key_store.get(key_triple) {
+        if let Some(key_info) = self.key_store.get(&key_triple) {
             Ok(Some(key_info))
         } else {
             Ok(None)
         }
     }
 
-    fn get_all(&self, provider_id: ProviderId) -> Result<Vec<&KeyTriple>, String> {
-        Ok(self
+    fn get_all(&self, provider_identity: ProviderIdentity) -> Result<Vec<KeyIdentity>, String> {
+        let provider_id = ProviderId::try_from(provider_identity.clone())?;
+        let key_triples = self
             .key_store
             .keys()
-            .filter(|key_triple| key_triple.belongs_to_provider(provider_id))
-            .collect())
+            .filter(|key_triple| key_triple.belongs_to_provider(provider_id));
+
+        let mut key_identites = Vec::new();
+        for key_triple in key_triples {
+            let key_identity = KeyIdentity::try_from((
+                key_triple.clone(),
+                provider_identity.clone(),
+                self.auth_type,
+            ))?;
+            key_identites.push(key_identity)
+        }
+        Ok(key_identites)
     }
 
     fn insert(
         &mut self,
-        key_triple: KeyTriple,
+        key_identity: KeyIdentity,
         key_info: KeyInfo,
     ) -> Result<Option<KeyInfo>, String> {
+        let key_triple = KeyTriple::try_from(key_identity)?;
         if let Err(err) = self.save_mapping(&key_triple, &key_info) {
             Err(err.to_string())
         } else {
@@ -333,18 +536,20 @@ impl ManageKeyInfo for OnDiskKeyInfoManager {
         }
     }
 
-    fn remove(&mut self, key_triple: &KeyTriple) -> Result<Option<KeyInfo>, String> {
-        if let Err(err) = self.delete_mapping(key_triple) {
+    fn remove(&mut self, key_identity: &KeyIdentity) -> Result<Option<KeyInfo>, String> {
+        let key_triple = KeyTriple::try_from(key_identity.clone())?;
+        if let Err(err) = self.delete_mapping(&key_triple) {
             Err(err.to_string())
-        } else if let Some(key_info) = self.key_store.remove(key_triple) {
+        } else if let Some(key_info) = self.key_store.remove(&key_triple) {
             Ok(Some(key_info))
         } else {
             Ok(None)
         }
     }
 
-    fn exists(&self, key_triple: &KeyTriple) -> Result<bool, String> {
-        Ok(self.key_store.contains_key(key_triple))
+    fn exists(&self, key_identity: &KeyIdentity) -> Result<bool, String> {
+        let key_triple = KeyTriple::try_from(key_identity.clone())?;
+        Ok(self.key_store.contains_key(&key_triple))
     }
 }
 
@@ -352,6 +557,7 @@ impl ManageKeyInfo for OnDiskKeyInfoManager {
 #[derive(Debug, Default)]
 pub struct OnDiskKeyInfoManagerBuilder {
     mappings_dir_path: Option<PathBuf>,
+    auth_type: Option<AuthType>,
 }
 
 impl OnDiskKeyInfoManagerBuilder {
@@ -359,6 +565,7 @@ impl OnDiskKeyInfoManagerBuilder {
     pub fn new() -> OnDiskKeyInfoManagerBuilder {
         OnDiskKeyInfoManagerBuilder {
             mappings_dir_path: None,
+            auth_type: None,
         }
     }
 
@@ -369,27 +576,43 @@ impl OnDiskKeyInfoManagerBuilder {
         self
     }
 
+    /// Add a mappings directory path to the builder
+    pub fn with_auth_type(mut self, default_auth_type: AuthType) -> OnDiskKeyInfoManagerBuilder {
+        self.auth_type = Some(default_auth_type);
+
+        self
+    }
+
     /// Build into a OnDiskKeyInfoManager
     pub fn build(self) -> Result<OnDiskKeyInfoManager> {
         OnDiskKeyInfoManager::new(
             self.mappings_dir_path
                 .unwrap_or_else(|| PathBuf::from(DEFAULT_MAPPINGS_PATH)),
+            self.auth_type.ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    "AuthType must be supplied to OnDiskKeyInfoManager",
+                )
+            })?,
         )
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::super::{KeyInfo, KeyTriple, ManageKeyInfo};
+    use super::super::{KeyIdentity, KeyInfo, ManageKeyInfo};
     use super::OnDiskKeyInfoManager;
-    use crate::authenticators::ApplicationName;
+    use crate::key_info_managers::{ApplicationIdentity, ProviderIdentity};
+    use crate::providers::core::Provider as CoreProvider;
+    #[cfg(feature = "mbed-crypto-provider")]
+    use crate::providers::mbed_crypto::Provider as MbedCryptoProvider;
     use parsec_interface::operations::psa_algorithm::{
         Algorithm, AsymmetricSignature, Hash, SignHash,
     };
     use parsec_interface::operations::psa_key_attributes::{
         Attributes, Lifetime, Policy, Type, UsageFlags,
     };
-    use parsec_interface::requests::ProviderId;
+    use parsec_interface::requests::AuthType;
     use std::fs;
     use std::path::PathBuf;
 
@@ -423,7 +646,7 @@ mod test {
     #[test]
     fn insert_get_key_info() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_get_key_info_mappings");
-        let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+        let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
         let key_triple = new_key_triple("insert_get_key_info".to_string());
         let key_info = test_key_info();
@@ -449,7 +672,7 @@ mod test {
     #[test]
     fn insert_remove_key() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_remove_key_mappings");
-        let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+        let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
         let key_triple = new_key_triple("insert_remove_key".to_string());
         let key_info = test_key_info();
@@ -463,7 +686,7 @@ mod test {
     #[test]
     fn remove_unexisting_key() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/remove_unexisting_key_mappings");
-        let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+        let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
         let key_triple = new_key_triple("remove_unexisting_key".to_string());
         assert_eq!(manager.remove(&key_triple).unwrap(), None);
@@ -473,7 +696,7 @@ mod test {
     #[test]
     fn exists() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/exists_mappings");
-        let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+        let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
         let key_triple = new_key_triple("exists".to_string());
         let key_info = test_key_info();
@@ -491,7 +714,7 @@ mod test {
     #[test]
     fn insert_overwrites() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_overwrites_mappings");
-        let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+        let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
         let key_triple = new_key_triple("insert_overwrites".to_string());
         let key_info_1 = test_key_info();
@@ -519,12 +742,19 @@ mod test {
     #[test]
     fn big_names_ascii() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/big_names_ascii_mappings");
-        let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+        let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let big_app_name_ascii = ApplicationName::from_name("  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string());
+        let big_app_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
         let big_key_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
 
-        let key_triple = KeyTriple::new(big_app_name_ascii, ProviderId::Core, big_key_name_ascii);
+        let key_triple = KeyIdentity::new(
+            ApplicationIdentity::new(big_app_name_ascii, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            big_key_name_ascii,
+        );
         let key_info = test_key_info();
 
         let _ = manager
@@ -537,78 +767,106 @@ mod test {
     #[test]
     fn big_names_emoticons() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/big_names_emoticons_mappings");
-        let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+        let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let big_app_name_emoticons = ApplicationName::from_name("😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮".to_string());
+        let big_app_name_emoticons = "😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮".to_string();
         let big_key_name_emoticons = "😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮".to_string();
 
-        let key_triple = KeyTriple::new(
-            big_app_name_emoticons,
-            ProviderId::MbedCrypto,
+        let key_identity = KeyIdentity::new(
+            ApplicationIdentity::new(big_app_name_emoticons, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
             big_key_name_emoticons,
         );
         let key_info = test_key_info();
 
         let _ = manager
-            .insert(key_triple.clone(), key_info.clone())
+            .insert(key_identity.clone(), key_info.clone())
             .unwrap();
-        assert_eq!(manager.remove(&key_triple).unwrap().unwrap(), key_info);
+        assert_eq!(manager.remove(&key_identity).unwrap().unwrap(), key_info);
         fs::remove_dir_all(path).unwrap();
     }
 
+    #[cfg(feature = "mbed-crypto-provider")]
     #[test]
     fn create_and_load() {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/create_and_load_mappings");
 
-        let app_name1 = ApplicationName::from_name("😀 Application One 😀".to_string());
+        let app_name1 = "😀 Application One 😀".to_string();
         let key_name1 = "😀 Key One 😀".to_string();
-        let key_triple1 = KeyTriple::new(app_name1, ProviderId::Core, key_name1);
+        let key_identity_1 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name1, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name1,
+        );
         let key_info1 = test_key_info();
 
-        let app_name2 = ApplicationName::from_name("😇 Application Two 😇".to_string());
+        let app_name2 = "😇 Application Two 😇".to_string();
         let key_name2 = "😇 Key Two 😇".to_string();
-        let key_triple2 = KeyTriple::new(app_name2, ProviderId::MbedCrypto, key_name2);
+        let key_identity_2 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name2, AuthType::NoAuth),
+            ProviderIdentity::new(
+                MbedCryptoProvider::PROVIDER_UUID.to_string(),
+                MbedCryptoProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name2,
+        );
         let key_info2 = KeyInfo {
             id: vec![0x12, 0x22, 0x32],
             attributes: test_key_attributes(),
         };
 
-        let app_name3 = ApplicationName::from_name("😈 Application Three 😈".to_string());
+        let app_name3 = "😈 Application Three 😈".to_string();
         let key_name3 = "😈 Key Three 😈".to_string();
-        let key_triple3 = KeyTriple::new(app_name3, ProviderId::Core, key_name3);
+        let key_identity_3 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name3, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name3,
+        );
         let key_info3 = KeyInfo {
             id: vec![0x13, 0x23, 0x33],
             attributes: test_key_attributes(),
         };
         {
-            let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+            let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
             let _ = manager
-                .insert(key_triple1.clone(), key_info1.clone())
+                .insert(key_identity_1.clone(), key_info1.clone())
                 .unwrap();
             let _ = manager
-                .insert(key_triple2.clone(), key_info2.clone())
+                .insert(key_identity_2.clone(), key_info2.clone())
                 .unwrap();
             let _ = manager
-                .insert(key_triple3.clone(), key_info3.clone())
+                .insert(key_identity_3.clone(), key_info3.clone())
                 .unwrap();
         }
         // The local hashmap is dropped when leaving the inner scope.
         {
-            let mut manager = OnDiskKeyInfoManager::new(path.clone()).unwrap();
+            let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-            assert_eq!(manager.remove(&key_triple1).unwrap().unwrap(), key_info1);
-            assert_eq!(manager.remove(&key_triple2).unwrap().unwrap(), key_info2);
-            assert_eq!(manager.remove(&key_triple3).unwrap().unwrap(), key_info3);
+            assert_eq!(manager.remove(&key_identity_1).unwrap().unwrap(), key_info1);
+            assert_eq!(manager.remove(&key_identity_2).unwrap().unwrap(), key_info2);
+            assert_eq!(manager.remove(&key_identity_3).unwrap().unwrap(), key_info3);
         }
 
         fs::remove_dir_all(path).unwrap();
     }
 
-    fn new_key_triple(key_name: String) -> KeyTriple {
-        KeyTriple::new(
-            ApplicationName::from_name("Testing Application 😎".to_string()),
-            ProviderId::MbedCrypto,
+    fn new_key_triple(key_name: String) -> KeyIdentity {
+        KeyIdentity::new(
+            ApplicationIdentity::new("Testing Application 😎".to_string(), AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
             key_name,
         )
     }

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -581,7 +581,7 @@ impl OnDiskKeyInfoManagerBuilder {
         self
     }
 
-    /// Add a mappings directory path to the builder
+    /// Add an authentication type to the builder
     pub fn with_auth_type(mut self, default_auth_type: AuthType) -> OnDiskKeyInfoManagerBuilder {
         self.auth_type = Some(default_auth_type);
 

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -648,24 +648,24 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_get_key_info_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("insert_get_key_info".to_string());
+        let key_identity = new_key_identity("insert_get_key_info".to_string());
         let key_info = test_key_info();
 
-        assert!(manager.get(&key_triple).unwrap().is_none());
+        assert!(manager.get(&key_identity).unwrap().is_none());
 
         assert!(manager
-            .insert(key_triple.clone(), key_info.clone())
+            .insert(key_identity.clone(), key_info.clone())
             .unwrap()
             .is_none());
 
         let stored_key_info = manager
-            .get(&key_triple)
+            .get(&key_identity)
             .unwrap()
             .expect("Failed to get key info")
             .clone();
 
         assert_eq!(stored_key_info, key_info);
-        assert!(manager.remove(&key_triple).unwrap().is_some());
+        assert!(manager.remove(&key_identity).unwrap().is_some());
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -674,12 +674,12 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_remove_key_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("insert_remove_key".to_string());
+        let key_identity = new_key_identity("insert_remove_key".to_string());
         let key_info = test_key_info();
 
-        let _ = manager.insert(key_triple.clone(), key_info).unwrap();
+        let _ = manager.insert(key_identity.clone(), key_info).unwrap();
 
-        assert!(manager.remove(&key_triple).unwrap().is_some());
+        assert!(manager.remove(&key_identity).unwrap().is_some());
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -688,8 +688,8 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/remove_unexisting_key_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("remove_unexisting_key".to_string());
-        assert_eq!(manager.remove(&key_triple).unwrap(), None);
+        let key_identity = new_key_identity("remove_unexisting_key".to_string());
+        assert_eq!(manager.remove(&key_identity).unwrap(), None);
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -698,16 +698,16 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/exists_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("exists".to_string());
+        let key_identity = new_key_identity("exists".to_string());
         let key_info = test_key_info();
 
-        assert!(!manager.exists(&key_triple).unwrap());
+        assert!(!manager.exists(&key_identity).unwrap());
 
-        let _ = manager.insert(key_triple.clone(), key_info).unwrap();
-        assert!(manager.exists(&key_triple).unwrap());
+        let _ = manager.insert(key_identity.clone(), key_info).unwrap();
+        assert!(manager.exists(&key_identity).unwrap());
 
-        let _ = manager.remove(&key_triple).unwrap();
-        assert!(!manager.exists(&key_triple).unwrap());
+        let _ = manager.remove(&key_identity).unwrap();
+        assert!(!manager.exists(&key_identity).unwrap());
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -716,26 +716,26 @@ mod test {
         let path = PathBuf::from(env!("OUT_DIR").to_owned() + "/insert_overwrites_mappings");
         let mut manager = OnDiskKeyInfoManager::new(path.clone(), AuthType::NoAuth).unwrap();
 
-        let key_triple = new_key_triple("insert_overwrites".to_string());
+        let key_identity = new_key_identity("insert_overwrites".to_string());
         let key_info_1 = test_key_info();
         let key_info_2 = KeyInfo {
             id: vec![0xaa, 0xbb, 0xcc],
             attributes: test_key_attributes(),
         };
 
-        let _ = manager.insert(key_triple.clone(), key_info_1).unwrap();
+        let _ = manager.insert(key_identity.clone(), key_info_1).unwrap();
         let _ = manager
-            .insert(key_triple.clone(), key_info_2.clone())
+            .insert(key_identity.clone(), key_info_2.clone())
             .unwrap();
 
         let stored_key_info = manager
-            .get(&key_triple)
+            .get(&key_identity)
             .unwrap()
             .expect("Failed to get key info")
             .clone();
 
         assert_eq!(stored_key_info, key_info_2);
-        assert!(manager.remove(&key_triple).unwrap().is_some());
+        assert!(manager.remove(&key_identity).unwrap().is_some());
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -747,7 +747,7 @@ mod test {
         let big_app_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
         let big_key_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             ApplicationIdentity::new(big_app_name_ascii, AuthType::NoAuth),
             ProviderIdentity::new(
                 CoreProvider::PROVIDER_UUID.to_string(),
@@ -758,9 +758,9 @@ mod test {
         let key_info = test_key_info();
 
         let _ = manager
-            .insert(key_triple.clone(), key_info.clone())
+            .insert(key_identity.clone(), key_info.clone())
             .unwrap();
-        assert_eq!(manager.remove(&key_triple).unwrap().unwrap(), key_info);
+        assert_eq!(manager.remove(&key_identity).unwrap().unwrap(), key_info);
         fs::remove_dir_all(path).unwrap();
     }
 
@@ -860,7 +860,7 @@ mod test {
         fs::remove_dir_all(path).unwrap();
     }
 
-    fn new_key_triple(key_name: String) -> KeyIdentity {
+    fn new_key_identity(key_name: String) -> KeyIdentity {
         KeyIdentity::new(
             ApplicationIdentity::new("Testing Application 😎".to_string(), AuthType::NoAuth),
             ProviderIdentity::new(

--- a/src/key_info_managers/sqlite_manager/mod.rs
+++ b/src/key_info_managers/sqlite_manager/mod.rs
@@ -1,0 +1,579 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! A key info manager storing key identity to key info mappings using a SQLite database.
+//!
+//! For security reasons, only the PARSEC service should have the ability to modify these files.
+use super::{KeyIdentity, KeyInfo, ManageKeyInfo};
+use crate::authenticators::ApplicationIdentity;
+use crate::providers::ProviderIdentity;
+use anyhow::Result;
+use log::info;
+use num_traits::FromPrimitive;
+use parsec_interface::requests::AuthType;
+use rusqlite::types::Type::{Blob, Integer};
+use rusqlite::{params, Connection, Error as RusqliteError};
+use std::collections::HashMap;
+use std::fs;
+use std::io::{Error, ErrorKind};
+use std::path::PathBuf;
+
+/// Default path where the database will be stored on disk
+pub const DEFAULT_DB_PATH: &str =
+    "/var/lib/parsec/kim-mappings/sqlite/sqlite-key-info-manager.sqlite3";
+
+/// The current serialization version of the KeyInfo object.
+pub const CURRENT_KEY_INFO_VERSION: u8 = 1;
+
+/// The current database schema version of the SQLiteKeyInfoManager.
+pub const CURRENT_SCHEMA_VERSION: u8 = 1;
+
+/// A key info manager storing key identity to key info mapping on files on disk
+#[derive(Debug)]
+pub struct SQLiteKeyInfoManager {
+    /// Internal mapping, used for non-modifying operations.
+    key_store: HashMap<KeyIdentity, KeyInfo>,
+    /// The file path where the SQLite database exists. This database holds
+    /// key identity to key info mappings.
+    database_path: PathBuf,
+}
+
+struct KeyInfoRecord {
+    key_identity: KeyIdentity,
+    key_info: KeyInfo,
+}
+
+/// TODO: Implement this until the interface TryFrom u8 to AuthType is implemented.
+fn i64_to_auth_type(auth_type: i64) -> Result<AuthType, String> {
+    match FromPrimitive::from_i64(auth_type) {
+        Some(auth_type) => Ok(auth_type),
+        None => Err(format!(
+            "Failed to get AuthType from authenticator_id.\nAuthenticator \"{}\" does not exist.",
+            auth_type
+        )),
+    }
+}
+
+/// SQLite-based `KeyInfoManager`
+///
+/// The `SQLiteKeyInfoManager` relies on access control mechanisms provided by the OS for
+/// the filesystem to ensure security of the database.
+impl SQLiteKeyInfoManager {
+    /// Creates an instance of the sqlite key info manager.
+    /// The SQLiteKeyInfoManager stores key info in the provided database_path file.
+    /// Uses rusqlite.
+    fn new(database_path: PathBuf) -> Result<SQLiteKeyInfoManager> {
+        // Create directory if it does not already exist
+        let mut directory_path = database_path.clone();
+        let _ = directory_path.pop();
+        fs::create_dir_all(&directory_path)?;
+        // Connect to or create database at set path
+        let conn = Connection::open(&database_path)?;
+        let mut key_store = HashMap::new();
+
+        // TODO: Implement kim_metadata table creation here using CURRENT_SCHEMA_VERSION value if
+        // key_mapping & kim_metadata tables do not exist.
+
+        // Create table key_mapping table if it does not already exist
+        let _ = conn.execute(
+            "
+            CREATE TABLE IF NOT EXISTS key_mapping (
+                authenticator_id      INTEGER NOT NULL,
+                application_name      TEXT NOT NULL,
+                key_name              TEXT NOT NULL,
+                provider_uuid         TEXT NOT NULL,
+                provider_name         TEXT NOT NULL,
+                key_info              BLOB NOT NULL,
+                key_info_version      INTEGER NOT NULL,
+                PRIMARY KEY (authenticator_id, application_name, key_name)
+            )
+            ",
+            [],
+        )?;
+
+        let mut stmt = conn.prepare("SELECT * FROM key_mapping")?;
+        let key_iter = stmt.query_map([], |row| {
+            let key_identity = KeyIdentity::new(
+                ApplicationIdentity::new(
+                    row.get("application_name")?,
+                    i64_to_auth_type(row.get("authenticator_id")?).map_err(|e| {
+                        format_error!("Failed to get AuthType from authenticator_id.", e);
+                        let error = Box::new(Error::new(ErrorKind::InvalidData, e));
+                        RusqliteError::FromSqlConversionFailure(64, Integer, error)
+                    })?,
+                ),
+                ProviderIdentity::new(row.get("provider_uuid")?, row.get("provider_name")?),
+                row.get("key_name")?,
+            );
+            let key_info_blob: Vec<u8> = row.get("key_info")?;
+
+            // TODO: Change this to (protobuf?) version once format has been decided.
+            let key_info = bincode::deserialize(&key_info_blob[..]).map_err(|e| {
+                format_error!("Error deserializing key info", e);
+                RusqliteError::FromSqlConversionFailure(key_info_blob.len(), Blob, e)
+            })?;
+
+            Ok(KeyInfoRecord {
+                key_identity,
+                key_info,
+            })
+        })?;
+
+        // Add keys to key_store cache
+        for key_info_record in key_iter {
+            let key_info_record = key_info_record?;
+            let _ = key_store.insert(key_info_record.key_identity, key_info_record.key_info);
+        }
+
+        if !crate::utils::GlobalConfig::log_error_details() {
+            info!(
+                "SQLiteKeyInfoManager - Found {} key info mapping records",
+                key_store.len()
+            );
+        }
+
+        Ok(SQLiteKeyInfoManager {
+            key_store,
+            database_path,
+        })
+    }
+
+    /// Saves the KeyIdentity and KeyInfo to the database.
+    /// Inserts a new record to the database `key_mapping` table.
+    fn save_mapping(
+        &self,
+        key_identity: &KeyIdentity,
+        key_info: &KeyInfo,
+    ) -> rusqlite::Result<(), RusqliteError> {
+        let conn = Connection::open(&self.database_path)?;
+
+        // TODO: Change this to (protobuf?) version once format has been decided.
+        let key_info_blob = bincode::serialize(&key_info).map_err(|e| {
+            format_error!("Error serializing key info", e);
+            RusqliteError::ToSqlConversionFailure(e)
+        })?;
+
+        // Insert the new key mapping, if a record does not exist.
+        // If one does exist, replace the existing record.
+        let _ = conn.execute(
+            "
+            REPLACE INTO
+                `key_mapping`
+                (`authenticator_id`, `application_name`, `provider_uuid`, `provider_name`, `key_name`, `key_info`, `key_info_version`)
+            VALUES
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7);
+            ",
+            params![
+                *key_identity.application().authenticator_id() as u8,
+                key_identity.application().name(),
+                key_identity.provider().uuid(),
+                key_identity.provider().name(),
+                key_identity.key_name(),
+                key_info_blob,
+                CURRENT_KEY_INFO_VERSION,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Removes the mapping record.
+    /// Will do nothing if the mapping record does not exist.
+    fn delete_mapping(&self, key_identity: &KeyIdentity) -> rusqlite::Result<(), RusqliteError> {
+        let conn = Connection::open(&self.database_path)?;
+
+        let _ = conn.execute(
+            "
+            DELETE FROM
+                `key_mapping`
+            WHERE
+                `authenticator_id` = ?1
+                AND `application_name` = ?2
+                AND `key_name` = ?3
+            ",
+            params![
+                *key_identity.application().authenticator_id() as u8,
+                key_identity.application().name(),
+                key_identity.key_name(),
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+impl ManageKeyInfo for SQLiteKeyInfoManager {
+    fn get(&self, key_identity: &KeyIdentity) -> Result<Option<&KeyInfo>, String> {
+        if let Some(key_info) = self.key_store.get(key_identity) {
+            Ok(Some(key_info))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_all(&self, provider_identity: ProviderIdentity) -> Result<Vec<KeyIdentity>, String> {
+        Ok(self
+            .key_store
+            .keys()
+            .filter(|key_identity| key_identity.belongs_to_provider(&provider_identity))
+            .cloned()
+            .collect())
+    }
+
+    fn insert(
+        &mut self,
+        key_identity: KeyIdentity,
+        key_info: KeyInfo,
+    ) -> Result<Option<KeyInfo>, String> {
+        if let Err(err) = self.save_mapping(&key_identity, &key_info) {
+            Err(err.to_string())
+        } else {
+            Ok(self.key_store.insert(key_identity, key_info))
+        }
+    }
+
+    fn remove(&mut self, key_identity: &KeyIdentity) -> Result<Option<KeyInfo>, String> {
+        if let Err(err) = self.delete_mapping(key_identity) {
+            Err(err.to_string())
+        } else if let Some(key_info) = self.key_store.remove(key_identity) {
+            Ok(Some(key_info))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn exists(&self, key_identity: &KeyIdentity) -> Result<bool, String> {
+        Ok(self.key_store.contains_key(key_identity))
+    }
+}
+
+/// SQLiteKeyInfoManager builder
+#[derive(Debug, Default)]
+pub struct SQLiteKeyInfoManagerBuilder {
+    database_path: Option<PathBuf>,
+}
+
+impl SQLiteKeyInfoManagerBuilder {
+    /// Create a new SQLiteKeyInfoManagerBuilder
+    pub fn new() -> SQLiteKeyInfoManagerBuilder {
+        SQLiteKeyInfoManagerBuilder {
+            database_path: None,
+        }
+    }
+
+    /// Add a mappings directory path to the builder
+    pub fn with_db_path(mut self, path: PathBuf) -> SQLiteKeyInfoManagerBuilder {
+        self.database_path = Some(path);
+        self
+    }
+
+    /// Build into a SQLiteKeyInfoManager
+    pub fn build(self) -> Result<SQLiteKeyInfoManager> {
+        SQLiteKeyInfoManager::new(
+            self.database_path
+                .unwrap_or_else(|| PathBuf::from(DEFAULT_DB_PATH)),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::{KeyIdentity, KeyInfo, ManageKeyInfo};
+    use super::SQLiteKeyInfoManager;
+    use crate::key_info_managers::{ApplicationIdentity, ProviderIdentity};
+    use crate::providers::core::Provider as CoreProvider;
+    #[cfg(feature = "mbed-crypto-provider")]
+    use crate::providers::mbed_crypto::Provider as MbedCryptoProvider;
+    use parsec_interface::operations::psa_algorithm::{
+        Algorithm, AsymmetricSignature, Hash, SignHash,
+    };
+    use parsec_interface::operations::psa_key_attributes::{
+        Attributes, Lifetime, Policy, Type, UsageFlags,
+    };
+    use parsec_interface::requests::AuthType;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn test_key_attributes() -> Attributes {
+        let mut usage_flags = Default::default();
+        usage_flags.set_sign_hash();
+        Attributes {
+            lifetime: Lifetime::Persistent,
+            key_type: Type::Derive,
+            bits: 1024,
+            policy: Policy {
+                usage_flags,
+                permitted_algorithms: Algorithm::AsymmetricSignature(
+                    AsymmetricSignature::RsaPkcs1v15Sign {
+                        hash_alg: SignHash::Specific(Hash::Sha256),
+                    },
+                ),
+            },
+        }
+    }
+
+    fn test_key_info() -> KeyInfo {
+        KeyInfo {
+            id: vec![0x11, 0x22, 0x33],
+            attributes: test_key_attributes(),
+        }
+    }
+
+    #[test]
+    fn insert_get_key_info() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/insert_get_key_info_mappings.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_identity = new_key_identity("insert_get_key_info".to_string());
+        let key_info = test_key_info();
+
+        assert!(manager.get(&key_identity).unwrap().is_none());
+
+        assert!(manager
+            .insert(key_identity.clone(), key_info.clone())
+            .unwrap()
+            .is_none());
+
+        let stored_key_info = manager
+            .get(&key_identity)
+            .unwrap()
+            .expect("Failed to get key info")
+            .clone();
+
+        assert_eq!(stored_key_info, key_info);
+        assert!(manager.remove(&key_identity).unwrap().is_some());
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn insert_remove_key() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/insert_remove_key_mappings.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_identity = new_key_identity("insert_remove_key".to_string());
+        let key_info = test_key_info();
+
+        let _ = manager.insert(key_identity.clone(), key_info).unwrap();
+
+        assert!(manager.remove(&key_identity).unwrap().is_some());
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn remove_unexisting_key() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/remove_unexisting_key_mappings.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_identity = new_key_identity("remove_unexisting_key".to_string());
+        assert_eq!(manager.remove(&key_identity).unwrap(), None);
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn exists() {
+        let path =
+            PathBuf::from(env!("OUT_DIR").to_owned() + "/kim/sqlite/exists_mappings.sqlite3");
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_identity = new_key_identity("exists".to_string());
+        let key_info = test_key_info();
+
+        assert!(!manager.exists(&key_identity).unwrap());
+
+        let _ = manager.insert(key_identity.clone(), key_info).unwrap();
+        assert!(manager.exists(&key_identity).unwrap());
+
+        let _ = manager.remove(&key_identity).unwrap();
+        assert!(!manager.exists(&key_identity).unwrap());
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn insert_overwrites() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/insert_overwrites_mappings.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_identity = new_key_identity("insert_overwrites".to_string());
+        let key_info_1 = test_key_info();
+        let key_info_2 = KeyInfo {
+            id: vec![0xaa, 0xbb, 0xcc],
+            attributes: test_key_attributes(),
+        };
+
+        let _ = manager.insert(key_identity.clone(), key_info_1).unwrap();
+        let _ = manager
+            .insert(key_identity.clone(), key_info_2.clone())
+            .unwrap();
+
+        let stored_key_info = manager
+            .get(&key_identity)
+            .unwrap()
+            .expect("Failed to get key info")
+            .clone();
+
+        assert_eq!(stored_key_info, key_info_2);
+        assert!(manager.remove(&key_identity).unwrap().is_some());
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn big_names_ascii() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/big_names_ascii_mappings.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let big_app_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
+        let big_key_name_ascii = "  Lorem ipsum dolor sit amet, ei suas viris sea, deleniti repudiare te qui. Natum paulo decore ut nec, ne propriae offendit adipisci has. Eius clita legere mel at, ei vis minimum tincidunt.".to_string();
+
+        let key_identity = KeyIdentity::new(
+            ApplicationIdentity::new(big_app_name_ascii, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            big_key_name_ascii,
+        );
+        let key_info = test_key_info();
+
+        let _ = manager
+            .insert(key_identity.clone(), key_info.clone())
+            .unwrap();
+        assert_eq!(manager.remove(&key_identity).unwrap().unwrap(), key_info);
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn big_names_emoticons() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/big_names_emoticons_mappings.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let big_app_name_emoticons = "😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮".to_string();
+        let big_key_name_emoticons = "😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮".to_string();
+
+        let key_identity = KeyIdentity::new(
+            ApplicationIdentity::new(big_app_name_emoticons, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            big_key_name_emoticons,
+        );
+        let key_info = test_key_info();
+
+        let _ = manager
+            .insert(key_identity.clone(), key_info.clone())
+            .unwrap();
+        assert_eq!(manager.remove(&key_identity).unwrap().unwrap(), key_info);
+        fs::remove_file(&path).unwrap();
+    }
+
+    // TODO:
+    // Add tests:
+    // - Add tests for namespaces (check keys are separated by):
+    //   - Application Name
+    //   - Authenticator
+    //   - Key Name
+    // - Check keys are not separated by:
+    //   - Provider Name
+    //   - Provider UUID
+
+    #[cfg(feature = "mbed-crypto-provider")]
+    #[test]
+    fn create_and_load() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/create_and_load_mappings.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+
+        let app_name1 = "😀 Application One 😀".to_string();
+        let key_name1 = "😀 Key One 😀".to_string();
+        let key_identity_1 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name1, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name1,
+        );
+        let key_info1 = test_key_info();
+
+        let app_name2 = "😇 Application Two 😇".to_string();
+        let key_name2 = "😇 Key Two 😇".to_string();
+        let key_identity_2 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name2, AuthType::NoAuth),
+            ProviderIdentity::new(
+                MbedCryptoProvider::PROVIDER_UUID.to_string(),
+                MbedCryptoProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name2,
+        );
+        let key_info2 = KeyInfo {
+            id: vec![0x12, 0x22, 0x32],
+            attributes: test_key_attributes(),
+        };
+
+        let app_name3 = "😈 Application Three 😈".to_string();
+        let key_name3 = "😈 Key Three 😈".to_string();
+        let key_identity_3 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name3, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name3,
+        );
+        let key_info3 = KeyInfo {
+            id: vec![0x13, 0x23, 0x33],
+            attributes: test_key_attributes(),
+        };
+        {
+            let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+            let _ = manager
+                .insert(key_identity_1.clone(), key_info1.clone())
+                .unwrap();
+            let _ = manager
+                .insert(key_identity_2.clone(), key_info2.clone())
+                .unwrap();
+            let _ = manager
+                .insert(key_identity_3.clone(), key_info3.clone())
+                .unwrap();
+        }
+        // The local hashmap is dropped when leaving the inner scope.
+        {
+            let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+            assert_eq!(manager.remove(&key_identity_1).unwrap().unwrap(), key_info1);
+            assert_eq!(manager.remove(&key_identity_2).unwrap().unwrap(), key_info2);
+            assert_eq!(manager.remove(&key_identity_3).unwrap().unwrap(), key_info3);
+        }
+
+        fs::remove_file(&path).unwrap();
+    }
+
+    fn new_key_identity(key_name: String) -> KeyIdentity {
+        KeyIdentity::new(
+            ApplicationIdentity::new("Testing Application 😎".to_string(), AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name,
+        )
+    }
+}

--- a/src/key_info_managers/sqlite_manager/mod.rs
+++ b/src/key_info_managers/sqlite_manager/mod.rs
@@ -288,18 +288,21 @@ mod test {
         Attributes, Lifetime, Policy, Type, UsageFlags,
     };
     use parsec_interface::requests::AuthType;
+    use rand::Rng;
     use std::fs;
     use std::path::PathBuf;
 
     fn test_key_attributes() -> Attributes {
-        let mut usage_flags = Default::default();
-        usage_flags.set_sign_hash();
         Attributes {
             lifetime: Lifetime::Persistent,
             key_type: Type::Derive,
             bits: 1024,
             policy: Policy {
-                usage_flags,
+                usage_flags: {
+                    let mut usage_flags = UsageFlags::default();
+                    let _ = usage_flags.set_sign_hash();
+                    usage_flags
+                },
                 permitted_algorithms: Algorithm::AsymmetricSignature(
                     AsymmetricSignature::RsaPkcs1v15Sign {
                         hash_alg: SignHash::Specific(Hash::Sha256),
@@ -312,6 +315,14 @@ mod test {
     fn test_key_info() -> KeyInfo {
         KeyInfo {
             id: vec![0x11, 0x22, 0x33],
+            attributes: test_key_attributes(),
+        }
+    }
+
+    fn test_key_info_with_random_id() -> KeyInfo {
+        let mut rng = rand::thread_rng();
+        KeyInfo {
+            id: vec![rng.gen(), rng.gen(), rng.gen()],
             attributes: test_key_attributes(),
         }
     }
@@ -482,15 +493,240 @@ mod test {
         fs::remove_file(&path).unwrap();
     }
 
-    // TODO:
-    // Add tests:
-    // - Add tests for namespaces (check keys are separated by):
-    //   - Application Name
-    //   - Authenticator
-    //   - Key Name
-    // - Check keys are not separated by:
-    //   - Provider Name
-    //   - Provider UUID
+    /// Test that keys with identical identities (aside from authenticator id)
+    /// produce separate entries.
+    #[test]
+    fn namespace_authenticator_id() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/namespace_authenticator_id.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_name = "key_name".to_string();
+        let app_name = "the_application".to_string();
+
+        let key_identity_1 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name.clone(), AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name.clone(),
+        );
+        let key_identity_2 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name, AuthType::Direct),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name,
+        );
+
+        let key_info_1 = test_key_info_with_random_id();
+        let key_info_2 = test_key_info_with_random_id();
+
+        let _ = manager
+            .insert(key_identity_1.clone(), key_info_1.clone())
+            .unwrap();
+        let _ = manager
+            .insert(key_identity_2.clone(), key_info_2.clone())
+            .unwrap();
+
+        assert_eq!(
+            manager.remove(&key_identity_1).unwrap().unwrap(),
+            key_info_1
+        );
+        assert_eq!(
+            manager.remove(&key_identity_2).unwrap().unwrap(),
+            key_info_2
+        );
+
+        fs::remove_file(&path).unwrap();
+    }
+
+    /// Test that keys with identical identities (aside from application name)
+    /// produce separate entries.
+    #[test]
+    fn namespace_application_name() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/namespace_application_name.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_name = "key_name".to_string();
+        let app_name_1 = "application_1".to_string();
+        let app_name_2 = "application_2".to_string();
+
+        let key_identity_1 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name_1, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name.clone(),
+        );
+        let key_identity_2 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name_2, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name,
+        );
+
+        let key_info_1 = test_key_info_with_random_id();
+        let key_info_2 = test_key_info_with_random_id();
+
+        let _ = manager
+            .insert(key_identity_1.clone(), key_info_1.clone())
+            .unwrap();
+        let _ = manager
+            .insert(key_identity_2.clone(), key_info_2.clone())
+            .unwrap();
+
+        assert_eq!(
+            manager.remove(&key_identity_1).unwrap().unwrap(),
+            key_info_1
+        );
+        assert_eq!(
+            manager.remove(&key_identity_2).unwrap().unwrap(),
+            key_info_2
+        );
+
+        fs::remove_file(&path).unwrap();
+    }
+
+    /// Test that keys with identical identities (aside from key name)
+    /// produce separate entries.
+    #[test]
+    fn namespace_key_name() {
+        let path =
+            PathBuf::from(env!("OUT_DIR").to_owned() + "/kim/sqlite/namespace_key_name.sqlite3");
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_name_1 = "key_1".to_string();
+        let key_name_2 = "key_2".to_string();
+        let app_name = "the_application".to_string();
+
+        let key_identity_1 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name.clone(), AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name_1,
+        );
+        let key_identity_2 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name_2,
+        );
+
+        let key_info_1 = test_key_info_with_random_id();
+        let key_info_2 = test_key_info_with_random_id();
+
+        let _ = manager
+            .insert(key_identity_1.clone(), key_info_1.clone())
+            .unwrap();
+        let _ = manager
+            .insert(key_identity_2.clone(), key_info_2.clone())
+            .unwrap();
+
+        assert_eq!(
+            manager.remove(&key_identity_1).unwrap().unwrap(),
+            key_info_1
+        );
+        assert_eq!(
+            manager.remove(&key_identity_2).unwrap().unwrap(),
+            key_info_2
+        );
+
+        fs::remove_file(&path).unwrap();
+    }
+
+    /// Test that keys with identical identities (aside from provider name)
+    /// produce the same entry.
+    #[test]
+    fn namespace_provider_name() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/namespace_provider_name.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_name = "key_name".to_string();
+        let app_name = "the_application".to_string();
+
+        let key_identity_1 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name.clone(), AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                "One provider name".to_string(),
+            ),
+            key_name.clone(),
+        );
+        let key_identity_2 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name, AuthType::NoAuth),
+            ProviderIdentity::new(
+                CoreProvider::PROVIDER_UUID.to_string(),
+                "Another provider name".to_string(),
+            ),
+            key_name,
+        );
+
+        let key_info = test_key_info_with_random_id();
+
+        let _ = manager.insert(key_identity_1, key_info.clone()).unwrap();
+
+        assert_eq!(manager.remove(&key_identity_2).unwrap().unwrap(), key_info);
+
+        fs::remove_file(&path).unwrap();
+    }
+
+    /// Test that keys with identical identities (aside from provider name)
+    /// produce the same entry.
+    #[test]
+    fn namespace_provider_uuid() {
+        let path = PathBuf::from(
+            env!("OUT_DIR").to_owned() + "/kim/sqlite/namespace_provider_uuid.sqlite3",
+        );
+        fs::remove_file(&path).unwrap_or_default();
+        let mut manager = SQLiteKeyInfoManager::new(path.clone()).unwrap();
+
+        let key_name = "key_name".to_string();
+        let app_name = "the_application".to_string();
+
+        let key_identity_1 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name.clone(), AuthType::NoAuth),
+            ProviderIdentity::new(
+                "some-random-uuid".to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name.clone(),
+        );
+        let key_identity_2 = KeyIdentity::new(
+            ApplicationIdentity::new(app_name, AuthType::NoAuth),
+            ProviderIdentity::new(
+                "some-random-uuid-that-isn't-the-same".to_string(),
+                CoreProvider::DEFAULT_PROVIDER_NAME.to_string(),
+            ),
+            key_name,
+        );
+
+        let key_info = test_key_info_with_random_id();
+
+        let _ = manager.insert(key_identity_1, key_info.clone()).unwrap();
+
+        assert_eq!(manager.remove(&key_identity_2).unwrap().unwrap(), key_info);
+
+        fs::remove_file(&path).unwrap();
+    }
 
     #[cfg(feature = "mbed-crypto-provider")]
     #[test]

--- a/src/providers/core/mod.rs
+++ b/src/providers/core/mod.rs
@@ -6,7 +6,7 @@
 //! aiding clients in discovering the capabilities offered by their underlying
 //! platform.
 use super::Provide;
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use derivative::Derivative;
 use log::{error, trace};
 use parsec_interface::operations::{
@@ -49,6 +49,14 @@ pub struct Provider {
     prov_list: Vec<Arc<dyn Provide + Send + Sync>>,
 }
 
+impl Provider {
+    /// The default provider name for cryptoauthlib provider
+    pub const DEFAULT_PROVIDER_NAME: &'static str = "core-provider";
+
+    /// The UUID for this provider
+    pub const PROVIDER_UUID: &'static str = "47049873-2a43-4845-9d72-831eab668784";
+}
+
 impl Provide for Provider {
     fn list_opcodes(&self, op: list_opcodes::Operation) -> Result<list_opcodes::Result> {
         trace!("list_opcodes ingress");
@@ -80,7 +88,7 @@ impl Provide for Provider {
 
     fn list_keys(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
         trace!("list_keys ingress");
@@ -93,7 +101,7 @@ impl Provide for Provider {
                 "unknown".to_string()
             };
             let mut result = provider
-                .list_keys(app_name.clone(), _op)
+                .list_keys(application_identity, _op)
                 .unwrap_or_else(|e| {
                     error!("list_keys failed on provider {} with {}", id, e);
                     list_keys::Result { keys: Vec::new() }
@@ -128,7 +136,11 @@ impl Provide for Provider {
         Ok(list_clients::Result { clients })
     }
 
-    fn delete_client(&self, op: delete_client::Operation) -> Result<delete_client::Result> {
+    fn delete_client(
+        &self,
+        application_identity: &ApplicationIdentity,
+        op: delete_client::Operation,
+    ) -> Result<delete_client::Result> {
         trace!("delete_client ingress");
 
         let client = op.client;
@@ -142,7 +154,10 @@ impl Provide for Provider {
             // Currently Parsec only stores keys, we delete all of them.
             let keys = provider
                 .list_keys(
-                    ApplicationName::from_name(client.clone()),
+                    &ApplicationIdentity::new(
+                        client.clone(),
+                        *application_identity.authenticator_id(),
+                    ),
                     list_keys::Operation {},
                 )
                 .unwrap_or_else(|e| {
@@ -154,7 +169,11 @@ impl Provide for Provider {
                 let key_name = key.name;
                 let _ = provider
                     .psa_destroy_key(
-                        ApplicationName::from_name(client.clone()),
+                        // TODO: Check auth type. Will need passing down when SQLite KIM is implemented.
+                        &ApplicationIdentity::new(
+                            client.clone(),
+                            *application_identity.authenticator_id(),
+                        ),
                         psa_destroy_key::Operation { key_name },
                     )
                     .unwrap_or_else(|e| {

--- a/src/providers/core/mod.rs
+++ b/src/providers/core/mod.rs
@@ -169,7 +169,6 @@ impl Provide for Provider {
                 let key_name = key.name;
                 let _ = provider
                     .psa_destroy_key(
-                        // TODO: Check auth type. Will need passing down when SQLite KIM is implemented.
                         &ApplicationIdentity::new(
                             client.clone(),
                             *application_identity.authenticator_id(),

--- a/src/providers/crypto_capability.rs
+++ b/src/providers/crypto_capability.rs
@@ -6,7 +6,7 @@
 //! https://parallaxsecond.github.io/parsec-book/parsec_client/operations/can_do_crypto.html
 //! https://parallaxsecond.github.io/parsec-book/parsec_client/operations/service_api_coverage.html
 
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use log::{info, trace};
 use parsec_interface::operations::can_do_crypto;
 use parsec_interface::operations::can_do_crypto::{CheckType, Operation};
@@ -24,11 +24,11 @@ pub trait CanDoCrypto {
     /// This method is called by Provide trait and doesn't need to be changed.
     fn can_do_crypto_main(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto_main in CanDoCrypto trait");
-        let _ = self.can_do_crypto_internal(app_name, op)?;
+        let _ = self.can_do_crypto_internal(application_identity, op)?;
 
         match op.check_type {
             CheckType::Generate => self.generate_check(op.attributes),
@@ -95,7 +95,7 @@ pub trait CanDoCrypto {
     /// This method should be re-implemented by providers.
     fn can_do_crypto_internal(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: Operation,
     ) -> Result<can_do_crypto::Result>;
 

--- a/src/providers/cryptoauthlib/asym_sign.rs
+++ b/src/providers/cryptoauthlib/asym_sign.rs
@@ -107,11 +107,9 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_identity = KeyIdentity::new(
-            application_identity.clone(),
-            self.provider_identity.clone(),
-            op.key_name.clone(),
-        );
+        let key_identity = self
+            .key_info_store
+            .get_key_identity(application_identity.clone(), op.key_name.clone());
         let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
@@ -136,11 +134,9 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_message::Operation,
     ) -> Result<psa_sign_message::Result> {
-        let key_identity = KeyIdentity::new(
-            application_identity.clone(),
-            self.provider_identity.clone(),
-            op.key_name.clone(),
-        );
+        let key_identity = self
+            .key_info_store
+            .get_key_identity(application_identity.clone(), op.key_name.clone());
         let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
@@ -166,11 +162,9 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_message::Operation,
     ) -> Result<psa_verify_message::Result> {
-        let key_identity = KeyIdentity::new(
-            application_identity.clone(),
-            self.provider_identity.clone(),
-            op.key_name.clone(),
-        );
+        let key_identity = self
+            .key_info_store
+            .get_key_identity(application_identity.clone(), op.key_name.clone());
         let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;

--- a/src/providers/cryptoauthlib/asym_sign.rs
+++ b/src/providers/cryptoauthlib/asym_sign.rs
@@ -1,15 +1,15 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use log::error;
 use parsec_interface::operations::psa_algorithm::{AsymmetricSignature, Hash, SignHash};
 use parsec_interface::operations::psa_key_attributes::{EccFamily, Type};
 use parsec_interface::operations::{
     psa_sign_hash, psa_sign_message, psa_verify_hash, psa_verify_message,
 };
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use rust_cryptoauthlib::AtcaStatus;
 
 impl Provider {
@@ -76,11 +76,15 @@ impl Provider {
 
     pub(super) fn psa_sign_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::CryptoAuthLib, op.key_name.clone());
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_identity = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
         if op.hash.len() != Hash::Sha256.hash_length() {
@@ -91,7 +95,7 @@ impl Provider {
             AsymmetricSignature::Ecdsa {
                 hash_alg: SignHash::Specific(Hash::Sha256),
             } => {
-                let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+                let key_id = self.key_info_store.get_key_id::<u8>(&key_identity)?;
                 self.ecdsa_hash_sign(key_id, &op.hash)
             }
             _ => Err(ResponseStatus::PsaErrorNotSupported),
@@ -100,13 +104,15 @@ impl Provider {
 
     pub(super) fn psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = self
-            .key_info_store
-            .get_key_triple(app_name, op.key_name.clone());
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_identity = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
         if op.hash.len() != Hash::Sha256.hash_length() {
@@ -117,7 +123,7 @@ impl Provider {
             AsymmetricSignature::Ecdsa {
                 hash_alg: SignHash::Specific(Hash::Sha256),
             } => {
-                let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+                let key_id = self.key_info_store.get_key_id::<u8>(&key_identity)?;
                 let verify_mode = self.ecdsa_verify_mode_get(key_id, key_attributes.key_type)?;
                 self.ecdsa_hash_verify(verify_mode, op.hash, op.signature)
             }
@@ -127,13 +133,15 @@ impl Provider {
 
     pub(super) fn psa_sign_message_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_message::Operation,
     ) -> Result<psa_sign_message::Result> {
-        let key_triple = self
-            .key_info_store
-            .get_key_triple(app_name, op.key_name.clone());
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_identity = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -141,7 +149,7 @@ impl Provider {
             AsymmetricSignature::Ecdsa {
                 hash_alg: SignHash::Specific(Hash::Sha256),
             } => {
-                let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+                let key_id = self.key_info_store.get_key_id::<u8>(&key_identity)?;
                 // Compute a hash
                 let hash = self.sha256(&op.message)?.hash;
                 // Sign computed hash
@@ -155,13 +163,15 @@ impl Provider {
 
     pub(super) fn psa_verify_message_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_message::Operation,
     ) -> Result<psa_verify_message::Result> {
-        let key_triple = self
-            .key_info_store
-            .get_key_triple(app_name, op.key_name.clone());
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_identity = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -169,7 +179,7 @@ impl Provider {
             AsymmetricSignature::Ecdsa {
                 hash_alg: SignHash::Specific(Hash::Sha256),
             } => {
-                let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
+                let key_id = self.key_info_store.get_key_id::<u8>(&key_identity)?;
                 // Calculate a hash of a message
                 let hash = self.sha256(&op.message)?.hash;
                 // Determine verify mode

--- a/src/providers/cryptoauthlib/key_management.rs
+++ b/src/providers/cryptoauthlib/key_management.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::key_slot::KeySlotStatus;
 use super::Provider;
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use log::{error, warn};
 use parsec_interface::operations::psa_key_attributes::{Attributes, EccFamily, Type};
 use parsec_interface::operations::{
@@ -15,11 +15,13 @@ use zeroize::Zeroizing;
 impl Provider {
     pub(super) fn psa_generate_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
-        let key_triple = self.key_info_store.get_key_triple(app_name, key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), key_name);
 
         self.key_info_store.does_not_exist(&key_triple)?;
 
@@ -75,11 +77,13 @@ impl Provider {
 
     pub(super) fn psa_destroy_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = self.key_info_store.get_key_triple(app_name, key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), key_name);
         let key_id = self.key_info_store.get_key_id::<u8>(&key_triple)?;
 
         match self.key_info_store.remove_key_info(&key_triple) {
@@ -104,11 +108,13 @@ impl Provider {
 
     pub(super) fn psa_import_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         let key_name = op.key_name;
-        let key_triple = self.key_info_store.get_key_triple(app_name, key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), key_name);
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let key_attributes = op.attributes;
@@ -172,10 +178,12 @@ impl Provider {
 
     pub(super) fn psa_export_public_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
-        let key_triple = self.key_info_store.get_key_triple(app_name, op.key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), op.key_name);
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         match key_attributes.key_type {
@@ -208,10 +216,12 @@ impl Provider {
 
     pub(super) fn psa_export_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
-        let key_triple = self.key_info_store.get_key_triple(app_name, op.key_name);
+        let key_triple = self
+            .key_info_store
+            .get_key_triple(application_identity.clone(), op.key_name);
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         if !key_attributes.is_exportable() {

--- a/src/providers/cryptoauthlib/key_slot.rs
+++ b/src/providers/cryptoauthlib/key_slot.rs
@@ -21,7 +21,7 @@ pub enum KeySlotStatus {
 #[derive(Copy, Clone, Debug)]
 /// Hardware slot information
 pub struct AteccKeySlot {
-    /// Diagnostic field. Number of key triples pointing at this slot
+    /// Diagnostic field. Number of key identities pointing at this slot
     pub ref_count: u8,
     /// Slot status
     pub status: KeySlotStatus,

--- a/src/providers/cryptoauthlib/key_slot_storage.rs
+++ b/src/providers/cryptoauthlib/key_slot_storage.rs
@@ -30,9 +30,9 @@ impl KeySlotStorage {
     ) -> Result<Option<String>, String> {
         let mut key_slots = self.storage.write().unwrap();
 
-        // Get CryptoAuthLibProvider mapping of key triple to key info and check
-        // (1) if the key info matches ATECC configuration - drop key triple if not
-        // (2) if there are no two key triples mapping to a single ATECC slot - warning only ATM
+        // Get CryptoAuthLibProvider mapping of KeyIdentity to key info and check
+        // (1) if the key info matches ATECC configuration - drop KeyIdentity if not
+        // (2) if there are no two key identities mapping to a single ATECC slot - warning only ATM
 
         // check (1)
         match key_slots[key_id as usize].key_attr_vs_config(key_id, key_attr, None) {

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -5,9 +5,10 @@
 //! This provider implements Parsec operations using CryptoAuthentication
 //! Library backed by the ATECCx08 cryptochip.
 use super::Provide;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::{KeyInfoManagerClient, KeyTriple};
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::{KeyIdentity, KeyInfoManagerClient};
 use crate::providers::cryptoauthlib::key_slot_storage::KeySlotStorage;
+use crate::providers::ProviderIdentity;
 use derivative::Derivative;
 use log::{error, trace, warn};
 use parsec_interface::operations::list_providers::ProviderInfo;
@@ -39,8 +40,8 @@ pub struct Provider {
     #[derivative(Debug = "ignore")]
     device: rust_cryptoauthlib::AteccDevice,
     provider_id: ProviderId,
-    // The name of the provider set in the config.
-    provider_name: String,
+    // The identity of the provider including uuid & name.
+    provider_identity: ProviderIdentity,
     #[derivative(Debug = "ignore")]
     key_info_store: KeyInfoManagerClient,
     key_slots: KeySlotStorage,
@@ -82,7 +83,10 @@ impl Provider {
         cryptoauthlib_provider = Provider {
             device,
             provider_id: ProviderId::CryptoAuthLib,
-            provider_name,
+            provider_identity: ProviderIdentity {
+                name: provider_name,
+                uuid: String::from(Self::PROVIDER_UUID),
+            },
             key_info_store,
             key_slots: KeySlotStorage::new(),
             supported_opcodes: HashSet::new(),
@@ -110,7 +114,7 @@ impl Provider {
         // Validate key info store against hardware configuration.
         // Delete invalid entries or invalid mappings.
         // Mark the slots free/busy appropriately.
-        let mut to_remove: Vec<KeyTriple> = Vec::new();
+        let mut to_remove: Vec<KeyIdentity> = Vec::new();
         match cryptoauthlib_provider.key_info_store.get_all() {
             Ok(key_triples) => {
                 for key_triple in key_triples.iter().cloned() {
@@ -253,11 +257,11 @@ impl Provide for Provider {
 
     fn list_keys(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
         Ok(list_keys::Result {
-            keys: self.key_info_store.list_keys(&app_name)?,
+            keys: self.key_info_store.list_keys(application_identity)?,
         })
     }
 
@@ -267,7 +271,7 @@ impl Provide for Provider {
                 .key_info_store
                 .list_clients()?
                 .into_iter()
-                .map(|app_name| app_name.to_string())
+                .map(|application_identity| application_identity.name().clone())
                 .collect(),
         })
     }
@@ -310,144 +314,144 @@ impl Provide for Provider {
 
     fn psa_generate_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         trace!("psa_generate_key ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaGenerateKey) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_generate_key_internal(app_name, op)
+            self.psa_generate_key_internal(application_identity, op)
         }
     }
 
     fn psa_destroy_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         trace!("psa_destroy_key ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaDestroyKey) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_destroy_key_internal(app_name, op)
+            self.psa_destroy_key_internal(application_identity, op)
         }
     }
 
     fn psa_import_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         trace!("psa_import_key ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaImportKey) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_import_key_internal(app_name, op)
+            self.psa_import_key_internal(application_identity, op)
         }
     }
 
     fn psa_sign_hash(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
         trace!("psa_sign_hash ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaSignHash) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_sign_hash_internal(app_name, op)
+            self.psa_sign_hash_internal(application_identity, op)
         }
     }
 
     fn psa_verify_hash(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
         trace!("psa_verify_hash ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaVerifyHash) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_verify_hash_internal(app_name, op)
+            self.psa_verify_hash_internal(application_identity, op)
         }
     }
 
     fn psa_sign_message(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_message::Operation,
     ) -> Result<psa_sign_message::Result> {
         trace!("psa_sign_message ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaSignMessage) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_sign_message_internal(app_name, op)
+            self.psa_sign_message_internal(application_identity, op)
         }
     }
 
     fn psa_verify_message(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_message::Operation,
     ) -> Result<psa_verify_message::Result> {
         trace!("psa_verify_message ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaVerifyMessage) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_verify_message_internal(app_name, op)
+            self.psa_verify_message_internal(application_identity, op)
         }
     }
 
     fn psa_export_public_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         trace!("psa_export_public_key ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaExportPublicKey) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_export_public_key_internal(app_name, op)
+            self.psa_export_public_key_internal(application_identity, op)
         }
     }
 
     fn psa_export_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
         trace!("psa_export_key ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaExportKey) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_export_key_internal(app_name, op)
+            self.psa_export_key_internal(application_identity, op)
         }
     }
 
     fn psa_aead_encrypt(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_aead_encrypt::Operation,
     ) -> Result<psa_aead_encrypt::Result> {
         trace!("psa_aead_encrypt ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaAeadEncrypt) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_aead_encrypt_internal(app_name, op)
+            self.psa_aead_encrypt_internal(application_identity, op)
         }
     }
 
     fn psa_aead_decrypt(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_aead_decrypt::Operation,
     ) -> Result<psa_aead_decrypt::Result> {
         trace!("psa_aead_decrypt ingress");
         if !self.supported_opcodes.contains(&Opcode::PsaAeadDecrypt) {
             Err(ResponseStatus::PsaErrorNotSupported)
         } else {
-            self.psa_aead_decrypt_internal(app_name, op)
+            self.psa_aead_decrypt_internal(application_identity, op)
         }
     }
 }

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -116,47 +116,47 @@ impl Provider {
         // Mark the slots free/busy appropriately.
         let mut to_remove: Vec<KeyIdentity> = Vec::new();
         match cryptoauthlib_provider.key_info_store.get_all() {
-            Ok(key_triples) => {
-                for key_triple in key_triples.iter().cloned() {
+            Ok(key_identities) => {
+                for key_identity in key_identities.iter().cloned() {
                     match cryptoauthlib_provider
                         .key_info_store
-                        .does_not_exist(&key_triple)
+                        .does_not_exist(&key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {
-                            warn!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...",
-                                key_triple,
+                            warn!("Error getting the Key ID for KeyIdentity:\n{}\n(error: {}), continuing...",
+                                key_identity,
                                 err
                             );
-                            to_remove.push(key_triple.clone());
+                            to_remove.push(key_identity.clone());
                             continue;
                         }
                     };
                     let key_info_id = match cryptoauthlib_provider
                         .key_info_store
-                        .get_key_id::<u8>(&key_triple)
+                        .get_key_id::<u8>(&key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {
                             warn!(
-                                "Could not get key info id for key triple {:?} because {}",
-                                key_triple, err
+                                "Could not get key info id for KeyIdentity {:?} because {}",
+                                key_identity, err
                             );
-                            to_remove.push(key_triple.clone());
+                            to_remove.push(key_identity.clone());
                             continue;
                         }
                     };
                     let key_info_attributes = match cryptoauthlib_provider
                         .key_info_store
-                        .get_key_attributes(&key_triple)
+                        .get_key_attributes(&key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {
                             warn!(
-                                "Could not get key attributes for key triple {:?} because {}",
-                                key_triple, err
+                                "Could not get key attributes for KeyIdentity {:?} because {}",
+                                key_identity, err
                             );
-                            to_remove.push(key_triple.clone());
+                            to_remove.push(key_identity.clone());
                             continue;
                         }
                     };
@@ -165,10 +165,12 @@ impl Provider {
                         .key_validate_and_mark_busy(key_info_id, &key_info_attributes)
                     {
                         Ok(None) => (),
-                        Ok(Some(warning)) => warn!("{} for key triple {:?}", warning, key_triple),
+                        Ok(Some(warning)) => {
+                            warn!("{} for KeyIdentity {:?}", warning, key_identity)
+                        }
                         Err(err) => {
-                            warn!("{} for key triple {:?}", err, key_triple);
-                            to_remove.push(key_triple.clone());
+                            warn!("{} for KeyIdentity {:?}", err, key_identity);
+                            to_remove.push(key_identity.clone());
                             continue;
                         }
                     }
@@ -179,10 +181,10 @@ impl Provider {
                 return None;
             }
         };
-        for key_triple in to_remove.iter() {
+        for key_identity in to_remove.iter() {
             if let Err(err) = cryptoauthlib_provider
                 .key_info_store
-                .remove_key_info(key_triple)
+                .remove_key_info(key_identity)
             {
                 error!("Key Info Manager error: {}", err);
                 return None;

--- a/src/providers/mbed_crypto/aead.rs
+++ b/src/providers/mbed_crypto/aead.rs
@@ -1,22 +1,26 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::{psa_aead_decrypt, psa_aead_encrypt};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use psa_crypto::operations::aead;
 use psa_crypto::types::key;
 
 impl Provider {
     pub(super) fn psa_aead_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_aead_encrypt::Operation,
     ) -> Result<psa_aead_encrypt::Result> {
         let key_name = op.key_name.clone();
 
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let _guard = self
             .key_handle_mutex
@@ -54,10 +58,14 @@ impl Provider {
 
     pub(super) fn psa_aead_decrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_aead_decrypt::Operation,
     ) -> Result<psa_aead_decrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         let _guard = self

--- a/src/providers/mbed_crypto/aead.rs
+++ b/src/providers/mbed_crypto/aead.rs
@@ -16,12 +16,12 @@ impl Provider {
     ) -> Result<psa_aead_encrypt::Result> {
         let key_name = op.key_name.clone();
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
         let _guard = self
             .key_handle_mutex
             .lock()
@@ -61,12 +61,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_aead_decrypt::Operation,
     ) -> Result<psa_aead_decrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/asym_encryption.rs
+++ b/src/providers/mbed_crypto/asym_encryption.rs
@@ -16,12 +16,12 @@ impl Provider {
     ) -> Result<psa_asymmetric_encrypt::Result> {
         let key_name = op.key_name.clone();
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
         let _guard = self
             .key_handle_mutex
             .lock()
@@ -55,12 +55,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/asym_encryption.rs
+++ b/src/providers/mbed_crypto/asym_encryption.rs
@@ -1,22 +1,26 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use psa_crypto::operations::asym_encryption;
 use psa_crypto::types::key;
 
 impl Provider {
     pub(super) fn psa_asymmetric_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
         let key_name = op.key_name.clone();
 
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let _guard = self
             .key_handle_mutex
@@ -48,10 +52,14 @@ impl Provider {
 
     pub(super) fn psa_asymmetric_decrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         let _guard = self

--- a/src/providers/mbed_crypto/asym_sign.rs
+++ b/src/providers/mbed_crypto/asym_sign.rs
@@ -17,12 +17,12 @@ impl Provider {
         let key_name = op.key_name;
         let hash = op.hash;
         let alg = op.alg;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex
@@ -58,12 +58,12 @@ impl Provider {
         let hash = op.hash;
         let alg = op.alg;
         let signature = op.signature;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/capability_discovery.rs
+++ b/src/providers/mbed_crypto/capability_discovery.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Provider;
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use crate::providers::crypto_capability::CanDoCrypto;
 use log::{info, trace};
 use parsec_interface::operations::can_do_crypto;
@@ -13,7 +13,7 @@ use parsec_interface::requests::Result;
 impl CanDoCrypto for Provider {
     fn can_do_crypto_internal(
         &self,
-        _app_name: ApplicationName,
+        _app_identity: &ApplicationIdentity,
         op: can_do_crypto::Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto_internal");

--- a/src/providers/mbed_crypto/key_agreement.rs
+++ b/src/providers/mbed_crypto/key_agreement.rs
@@ -1,10 +1,10 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::psa_raw_key_agreement;
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use parsec_interface::secrecy::Secret;
 use psa_crypto::operations::key_agreement;
 use psa_crypto::types::key;
@@ -12,12 +12,16 @@ use psa_crypto::types::key;
 impl Provider {
     pub(super) fn psa_raw_key_agreement(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_raw_key_agreement::Operation,
     ) -> Result<psa_raw_key_agreement::Result> {
         let key_name = op.private_key_name.clone();
 
-        let key_triple = KeyTriple::new(app_name, ProviderId::MbedCrypto, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/key_agreement.rs
+++ b/src/providers/mbed_crypto/key_agreement.rs
@@ -17,12 +17,12 @@ impl Provider {
     ) -> Result<psa_raw_key_agreement::Result> {
         let key_name = op.private_key_name.clone();
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
         let _guard = self
             .key_handle_mutex
             .lock()

--- a/src/providers/mbed_crypto/key_management.rs
+++ b/src/providers/mbed_crypto/key_management.rs
@@ -39,13 +39,13 @@ impl Provider {
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
 
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let key_id = create_key_id(&self.id_counter)?;
 
@@ -58,7 +58,7 @@ impl Provider {
             Ok(key) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     // Safe as this thread should be the only one accessing this key yet.
                     if unsafe { psa_crypto_key_management::destroy(key) }.is_err() {
@@ -85,12 +85,12 @@ impl Provider {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_data = op.data;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let key_id = create_key_id(&self.id_counter)?;
 
@@ -107,7 +107,7 @@ impl Provider {
             Ok(key) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     // Safe as this thread should be the only one accessing this key yet.
                     if unsafe { psa_crypto_key_management::destroy(key) }.is_err() {
@@ -132,12 +132,12 @@ impl Provider {
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex
@@ -163,12 +163,12 @@ impl Provider {
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex
@@ -194,14 +194,14 @@ impl Provider {
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
 
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let _ = self.key_info_store.remove_key_info(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let _ = self.key_info_store.remove_key_info(&key_identity)?;
 
         let _guard = self
             .key_handle_mutex

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -6,8 +6,8 @@
 use super::Provide;
 use crate::authenticators::ApplicationIdentity;
 use crate::key_info_managers::{KeyIdentity, KeyInfoManagerClient};
-use crate::providers::ProviderIdentity;
 use crate::providers::crypto_capability::CanDoCrypto;
+use crate::providers::ProviderIdentity;
 use derivative::Derivative;
 use log::{error, trace};
 use parsec_interface::operations::{
@@ -335,11 +335,11 @@ impl Provide for Provider {
 
     fn can_do_crypto(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: can_do_crypto::Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto ingress");
-        self.can_do_crypto_main(app_name, op)
+        self.can_do_crypto_main(application_identity, op)
     }
 }
 

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -107,20 +107,20 @@ impl Provider {
         let mut max_key_id: key::psa_key_id_t = key::PSA_KEY_ID_USER_MIN;
         {
             let mut to_remove: Vec<KeyIdentity> = Vec::new();
-            // Go through all MbedCryptoProvider key triple to key info mappings and check if they are still
+            // Go through all MbedCryptoProvider key identities to key info mappings and check if they are still
             // present.
             // Delete those who are not present and add to the local_store the ones present.
             match mbed_crypto_provider.key_info_store.get_all() {
-                Ok(key_triples) => {
-                    for key_triple in key_triples.iter().cloned() {
+                Ok(key_identities) => {
+                    for key_identity in key_identities.iter().cloned() {
                         let key_id = match mbed_crypto_provider
                             .key_info_store
-                            .get_key_id(&key_triple)
+                            .get_key_id(&key_identity)
                         {
                             Ok(key_id) => key_id,
                             Err(response_status) => {
-                                error!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...", key_triple, response_status);
-                                to_remove.push(key_triple.clone());
+                                error!("Error getting the Key ID for KeyIdentity:\n{}\n(error: {}), continuing...", key_identity, response_status);
+                                to_remove.push(key_identity.clone());
                                 continue;
                             }
                         };
@@ -131,7 +131,9 @@ impl Provider {
                                     max_key_id = key_id;
                                 }
                             }
-                            Err(status::Error::InvalidHandle) => to_remove.push(key_triple.clone()),
+                            Err(status::Error::InvalidHandle) => {
+                                to_remove.push(key_identity.clone())
+                            }
                             Err(e) => {
                                 format_error!("Failed to open persistent Mbed Crypto key", e);
                                 return None;
@@ -143,10 +145,10 @@ impl Provider {
                     return None;
                 }
             };
-            for key_triple in to_remove.iter() {
+            for key_identity in to_remove.iter() {
                 if mbed_crypto_provider
                     .key_info_store
-                    .remove_key_info(key_triple)
+                    .remove_key_info(key_identity)
                     .is_err()
                 {
                     return None;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -9,6 +9,8 @@
 use log::trace;
 use parsec_interface::requests::Opcode;
 use std::collections::HashSet;
+use std::convert::TryFrom;
+use std::fmt;
 
 pub mod core;
 
@@ -31,7 +33,7 @@ pub mod cryptoauthlib;
 #[cfg(feature = "trusted-service-provider")]
 pub mod trusted_service;
 
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use parsec_interface::operations::{
     attest_key, can_do_crypto, delete_client, list_authenticators, list_clients, list_keys,
     list_opcodes, list_providers, ping, prepare_key_attestation, psa_aead_decrypt,
@@ -41,6 +43,67 @@ use parsec_interface::operations::{
     psa_verify_hash, psa_verify_message,
 };
 use parsec_interface::requests::{ResponseStatus, Result};
+
+use parsec_interface::requests::ProviderId;
+
+/// The ProviderIdentity struct specifies a unique uuid-name
+/// combination to form a unique provider identity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProviderIdentity {
+    /// The uuid of the provider
+    uuid: String,
+    /// The name of the provider set in the config, defaults to a suitable name.
+    name: String,
+}
+
+impl fmt::Display for ProviderIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ProviderIdentity: [uuid=\"{}\", name=\"{}\"]",
+            self.uuid, self.name
+        )
+    }
+}
+
+impl ProviderIdentity {
+    /// Creates a new instance of ProviderIdentity.
+    pub fn new(uuid: String, name: String) -> ProviderIdentity {
+        ProviderIdentity { uuid, name }
+    }
+
+    /// Get the uuid of the provider
+    pub fn uuid(&self) -> &String {
+        &self.uuid
+    }
+
+    /// Get the name of the provider
+    pub fn name(&self) -> &String {
+        &self.uuid
+    }
+}
+
+impl TryFrom<ProviderIdentity> for ProviderId {
+    type Error = String;
+
+    fn try_from(provider_identity: ProviderIdentity) -> ::std::result::Result<Self, Self::Error> {
+        let provider_id = match provider_identity.uuid.as_str() {
+            #[cfg(feature = "cryptoauthlib-provider")]
+            crate::providers::cryptoauthlib::Provider::PROVIDER_UUID => Ok(ProviderId::CryptoAuthLib),
+            #[cfg(feature = "mbed-crypto-provider")]
+            crate::providers::mbed_crypto::Provider::PROVIDER_UUID => Ok(ProviderId::MbedCrypto),
+            #[cfg(feature = "pkcs11-provider")]
+            crate::providers::pkcs11::Provider::PROVIDER_UUID => Ok(ProviderId::Pkcs11),
+            #[cfg(feature = "tpm-provider")]
+            crate::providers::tpm::Provider::PROVIDER_UUID => Ok(ProviderId::Tpm),
+            #[cfg(feature = "trusted-service-provider")]
+            crate::providers::trusted_service::Provider::PROVIDER_UUID => Ok(ProviderId::TrustedService),
+            _ => Err(format!("Cannot convert from ProviderIdentity to ProviderId.\nProvider \"{}\" is not recognised.\nCould be it does not exist, or Parsec was not compiled with the required provider feature flags.", provider_identity.uuid)),
+        }?;
+
+        Ok(provider_id)
+    }
+}
 
 /// Provider interface for servicing client operations
 ///
@@ -79,7 +142,7 @@ pub trait Provide {
     /// Lists all keys belonging to the application.
     fn list_keys(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result>;
 
@@ -87,7 +150,11 @@ pub trait Provide {
     fn list_clients(&self, _op: list_clients::Operation) -> Result<list_clients::Result>;
 
     /// Delete all data a client has in the service..
-    fn delete_client(&self, _op: delete_client::Operation) -> Result<delete_client::Result> {
+    fn delete_client(
+        &self,
+        _application_identity: &ApplicationIdentity,
+        _op: delete_client::Operation,
+    ) -> Result<delete_client::Result> {
         trace!("delete_client ingress");
         Err(ResponseStatus::PsaErrorNotSupported)
     }
@@ -116,7 +183,7 @@ pub trait Provide {
     /// 4. try to delete the key created. If failed, log it and return the error from 3.
     fn psa_generate_key(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         trace!("psa_generate_key ingress");
@@ -136,7 +203,7 @@ pub trait Provide {
     /// 4. try to delete the key imported. If failed, log it and return the error from 3.
     fn psa_import_key(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         trace!("psa_import_key ingress");
@@ -146,7 +213,7 @@ pub trait Provide {
     /// Execute an ExportPublicKey operation.
     fn psa_export_public_key(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         trace!("psa_export_public_key ingress");
@@ -156,7 +223,7 @@ pub trait Provide {
     /// Execute an ExportKey operation.
     fn psa_export_key(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
         trace!("psa_export_key ingress");
@@ -175,7 +242,7 @@ pub trait Provide {
     /// 3. try to destroy the key
     fn psa_destroy_key(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         trace!("psa_destroy_key ingress");
@@ -186,7 +253,7 @@ pub trait Provide {
     /// hash it.
     fn psa_sign_hash(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
         trace!("psa_sign_hash ingress");
@@ -196,7 +263,7 @@ pub trait Provide {
     /// Execute a VerifyHash operation.
     fn psa_verify_hash(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
         trace!("psa_verify_hash ingress");
@@ -206,7 +273,7 @@ pub trait Provide {
     /// Execute an AsymmetricEncrypt operation.
     fn psa_asymmetric_encrypt(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
         trace!("psa_asymmetric_encrypt ingress");
@@ -216,7 +283,7 @@ pub trait Provide {
     /// Execute an AsymmetricDecrypt operation.
     fn psa_asymmetric_decrypt(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
         trace!("psa_asymmetric_decrypt ingress");
@@ -226,7 +293,7 @@ pub trait Provide {
     /// Execute an AeadEncrypt operation.
     fn psa_aead_encrypt(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_aead_encrypt::Operation,
     ) -> Result<psa_aead_encrypt::Result> {
         trace!("psa_aead_encrypt ingress");
@@ -236,7 +303,7 @@ pub trait Provide {
     /// Execute an AeadDecrypt operation.
     fn psa_aead_decrypt(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_aead_decrypt::Operation,
     ) -> Result<psa_aead_decrypt::Result> {
         trace!("psa_aead_decrypt ingress");
@@ -264,7 +331,7 @@ pub trait Provide {
     /// Execute a RawKeyAgreement operation.
     fn psa_raw_key_agreement(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_raw_key_agreement::Operation,
     ) -> Result<psa_raw_key_agreement::Result> {
         trace!("psa_raw_key_agreement ingress");
@@ -283,7 +350,7 @@ pub trait Provide {
     /// Sign a message with a private key.
     fn psa_sign_message(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_sign_message::Operation,
     ) -> Result<psa_sign_message::Result> {
         trace!("psa_sign_message ingress");
@@ -293,7 +360,7 @@ pub trait Provide {
     /// Verify the signature of a message using a public key.
     fn psa_verify_message(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: psa_verify_message::Operation,
     ) -> Result<psa_verify_message::Result> {
         trace!("psa_verify_message ingress");
@@ -303,7 +370,7 @@ pub trait Provide {
     ///Check if the crypto operation is supported by provider.
     fn can_do_crypto(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: can_do_crypto::Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto main ingress");
@@ -313,7 +380,7 @@ pub trait Provide {
     /// Prepare a key attestation operation.
     fn prepare_key_attestation(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: prepare_key_attestation::Operation,
     ) -> Result<prepare_key_attestation::Result> {
         trace!("prepare_key_attestation ingress");
@@ -323,7 +390,7 @@ pub trait Provide {
     /// Attest a key.
     fn attest_key(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         _op: attest_key::Operation,
     ) -> Result<attest_key::Result> {
         trace!("attest_key ingress");

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -79,7 +79,7 @@ impl ProviderIdentity {
 
     /// Get the name of the provider
     pub fn name(&self) -> &String {
-        &self.uuid
+        &self.name
     }
 }
 

--- a/src/providers/pkcs11/asym_encryption.rs
+++ b/src/providers/pkcs11/asym_encryption.rs
@@ -18,13 +18,13 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -49,13 +49,13 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -80,12 +80,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -93,7 +93,7 @@ impl Provider {
         let salt_buff = op.salt.as_ref().map(|salt| salt.as_slice());
         let buffer_size = key_attributes.asymmetric_encrypt_output_size(alg)?;
         let mut ciphertext = vec![0u8; buffer_size];
-        let pub_key_id = self.move_pub_key_to_psa_crypto(&key_triple)?;
+        let pub_key_id = self.move_pub_key_to_psa_crypto(&key_identity)?;
 
         info!("Encrypting plaintext with PSA Crypto");
         let res = match psa_crypto::operations::asym_encryption::encrypt(

--- a/src/providers/pkcs11/asym_encryption.rs
+++ b/src/providers/pkcs11/asym_encryption.rs
@@ -3,22 +3,26 @@
 use super::utils::to_response_status;
 use super::KeyPairType;
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use cryptoki::types::mechanism::Mechanism;
 use log::{info, trace};
 use parsec_interface::operations::psa_algorithm::Algorithm;
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use std::convert::TryFrom;
 
 impl Provider {
     pub(super) fn psa_asymmetric_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
@@ -42,10 +46,14 @@ impl Provider {
 
     pub(super) fn psa_asymmetric_decrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
@@ -69,10 +77,14 @@ impl Provider {
 
     pub(super) fn software_psa_asymmetric_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         op.validate(key_attributes)?;

--- a/src/providers/pkcs11/asym_sign.rs
+++ b/src/providers/pkcs11/asym_sign.rs
@@ -3,23 +3,27 @@
 use super::utils::to_response_status;
 use super::Provider;
 use super::{utils, KeyPairType};
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use cryptoki::types::mechanism::Mechanism;
 use log::{info, trace};
 use parsec_interface::operations::psa_algorithm::Algorithm;
 use parsec_interface::operations::psa_key_attributes::Type;
 use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use std::convert::TryFrom;
 
 impl Provider {
     pub(super) fn psa_sign_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
@@ -52,10 +56,14 @@ impl Provider {
 
     pub(super) fn psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
@@ -87,10 +95,14 @@ impl Provider {
 
     pub(super) fn software_psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
 
         op.validate(key_attributes)?;

--- a/src/providers/pkcs11/asym_sign.rs
+++ b/src/providers/pkcs11/asym_sign.rs
@@ -19,14 +19,14 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
 
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -59,13 +59,13 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
@@ -98,16 +98,16 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
 
-        let pub_key_id = self.move_pub_key_to_psa_crypto(&key_triple)?;
+        let pub_key_id = self.move_pub_key_to_psa_crypto(&key_identity)?;
 
         info!("Verifying signature with PSA Crypto");
         let res = match psa_crypto::operations::asym_signature::verify_hash(

--- a/src/providers/pkcs11/capability_discovery.rs
+++ b/src/providers/pkcs11/capability_discovery.rs
@@ -3,7 +3,7 @@
 
 #![allow(trivial_numeric_casts)]
 use super::{utils, Provider};
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use crate::providers::crypto_capability::CanDoCrypto;
 use crate::providers::pkcs11::to_response_status;
 use cryptoki::types::mechanism::{Mechanism, MechanismInfo, MechanismType};
@@ -19,7 +19,7 @@ use std::convert::TryFrom;
 impl CanDoCrypto for Provider {
     fn can_do_crypto_internal(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         op: can_do_crypto::Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto_internal for PKCS11 provider");

--- a/src/providers/pkcs11/key_management.rs
+++ b/src/providers/pkcs11/key_management.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::utils::to_response_status;
 use super::{utils, KeyPairType, Provider};
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use cryptoki::types::mechanism::{Mechanism, MechanismType};
 use cryptoki::types::object::{Attribute, AttributeType, KeyType, ObjectClass, ObjectHandle};
 use cryptoki::types::session::Session;
@@ -12,7 +12,7 @@ use parsec_interface::operations::psa_key_attributes::{EccFamily, Id, Lifetime, 
 use parsec_interface::operations::{
     psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
 };
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
 use picky_asn1::wrapper::{IntegerAsn1, OctetStringAsn1};
 use picky_asn1_x509::RSAPublicKey;
@@ -47,13 +47,13 @@ impl Provider {
         }
     }
 
-    pub(super) fn move_pub_key_to_psa_crypto(&self, key_triple: &KeyTriple) -> Result<Id> {
+    pub(super) fn move_pub_key_to_psa_crypto(&self, key_triple: &KeyIdentity) -> Result<Id> {
         info!("Attempting to export public key");
         let export_operation = psa_export_public_key::Operation {
             key_name: key_triple.key_name().to_owned(),
         };
         let psa_export_public_key::Result { data } =
-            self.psa_export_public_key_internal(key_triple.app_name().clone(), export_operation)?;
+            self.psa_export_public_key_internal(key_triple.application(), export_operation)?;
 
         info!("Importing public key into PSA Crypto");
         let mut attributes = self.key_info_store.get_key_attributes(&key_triple)?;
@@ -84,7 +84,7 @@ impl Provider {
 
     pub(super) fn psa_generate_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         if op.attributes.key_type.is_public_key() {
@@ -100,7 +100,11 @@ impl Provider {
             return Err(ResponseStatus::PsaErrorNotPermitted);
         }
 
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let session = self.new_session()?;
@@ -175,7 +179,7 @@ impl Provider {
 
     pub(super) fn psa_import_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         let key_name = op.key_name;
@@ -190,7 +194,11 @@ impl Provider {
             return Err(ResponseStatus::PsaErrorInvalidArgument);
         }
 
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let session = self.new_session()?;
@@ -354,11 +362,15 @@ impl Provider {
 
     pub(super) fn psa_export_public_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let session = self.new_session()?;
@@ -443,11 +455,15 @@ impl Provider {
 
     pub(super) fn psa_destroy_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::Pkcs11, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         let _ = self.key_info_store.remove_key_info(&key_triple)?;

--- a/src/providers/pkcs11/key_management.rs
+++ b/src/providers/pkcs11/key_management.rs
@@ -47,16 +47,16 @@ impl Provider {
         }
     }
 
-    pub(super) fn move_pub_key_to_psa_crypto(&self, key_triple: &KeyIdentity) -> Result<Id> {
+    pub(super) fn move_pub_key_to_psa_crypto(&self, key_identity: &KeyIdentity) -> Result<Id> {
         info!("Attempting to export public key");
         let export_operation = psa_export_public_key::Operation {
-            key_name: key_triple.key_name().to_owned(),
+            key_name: key_identity.key_name().to_owned(),
         };
         let psa_export_public_key::Result { data } =
-            self.psa_export_public_key_internal(key_triple.application(), export_operation)?;
+            self.psa_export_public_key_internal(key_identity.application(), export_operation)?;
 
         info!("Importing public key into PSA Crypto");
-        let mut attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let mut attributes = self.key_info_store.get_key_attributes(&key_identity)?;
         attributes.lifetime = Lifetime::Volatile;
         attributes.key_type = match attributes.key_type {
             Type::RsaKeyPair | Type::RsaPublicKey => Type::RsaPublicKey,
@@ -100,12 +100,12 @@ impl Provider {
             return Err(ResponseStatus::PsaErrorNotPermitted);
         }
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let session = self.new_session()?;
 
@@ -156,7 +156,7 @@ impl Provider {
             Ok((public, private)) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     format_error!("Failed to insert the mappings, deleting the key", e);
                     if let Err(e) = session.destroy_object(public) {
@@ -194,12 +194,12 @@ impl Provider {
             return Err(ResponseStatus::PsaErrorInvalidArgument);
         }
 
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let session = self.new_session()?;
 
@@ -240,7 +240,7 @@ impl Provider {
             Ok(key) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     format_error!("Failed to insert the mappings, deleting the key.", e);
                     if let Err(e) = session.destroy_object(key) {
@@ -366,13 +366,13 @@ impl Provider {
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
         let session = self.new_session()?;
 
         let key = self.find_key(&session, key_id, KeyPairType::PublicKey)?;
@@ -459,14 +459,14 @@ impl Provider {
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
-        let _ = self.key_info_store.remove_key_info(&key_triple)?;
+        let _ = self.key_info_store.remove_key_info(&key_identity)?;
 
         let session = self.new_session()?;
 

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -61,6 +61,8 @@ const SUPPORTED_OPCODES: [Opcode; 9] = [
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Provider {
+    // The name of the provider set in the config.
+    provider_name: String,
     #[derivative(Debug = "ignore")]
     key_info_store: KeyInfoManagerClient,
     local_ids: RwLock<LocalIdStore>,
@@ -73,11 +75,18 @@ pub struct Provider {
 }
 
 impl Provider {
+    /// The default provider name for pkcs11 provider
+    pub const DEFAULT_PROVIDER_NAME: &'static str = "pkcs11-provider";
+
+    /// The UUID for this provider
+    pub const PROVIDER_UUID: &'static str = "30e39502-eba6-4d60-a4af-c518b7f5e38f";
+
     /// Creates and initialise a new instance of Pkcs11Provider.
     /// Checks if there are not more keys stored in the Key Info Manager than in the PKCS 11 library
     /// and if there are, delete them. Adds Key IDs currently in use in the local IDs store.
     /// Returns `None` if the initialisation failed.
     fn new(
+        provider_name: String,
         key_info_store: KeyInfoManagerClient,
         backend: Pkcs11,
         slot_number: Slot,
@@ -95,6 +104,7 @@ impl Provider {
 
         #[allow(clippy::mutex_atomic)]
         let pkcs11_provider = Provider {
+            provider_name,
             key_info_store,
             local_ids: RwLock::new(HashSet::new()),
             backend,
@@ -221,7 +231,7 @@ impl Provide for Provider {
         Ok((
             ProviderInfo {
                 // Assigned UUID for this provider: 30e39502-eba6-4d60-a4af-c518b7f5e38f
-                uuid: Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f")
+                uuid: Uuid::parse_str(Provider::PROVIDER_UUID)
                     .or(Err(ResponseStatus::InvalidEncoding))?,
                 description: String::from(
                     "PKCS #11 provider, interfacing with a PKCS #11 library.",
@@ -361,6 +371,7 @@ impl Provide for Provider {
 #[derive(Default, Derivative)]
 #[derivative(Debug)]
 pub struct ProviderBuilder {
+    provider_name: Option<String>,
     #[derivative(Debug = "ignore")]
     key_info_store: Option<KeyInfoManagerClient>,
     pkcs11_library_path: Option<String>,
@@ -374,6 +385,7 @@ impl ProviderBuilder {
     /// Create a new Pkcs11Provider builder
     pub fn new() -> ProviderBuilder {
         ProviderBuilder {
+            provider_name: None,
             key_info_store: None,
             pkcs11_library_path: None,
             slot_number: None,
@@ -381,6 +393,13 @@ impl ProviderBuilder {
             software_public_operations: None,
             allow_export: None,
         }
+    }
+
+    /// Add a provider name
+    pub fn with_provider_name(mut self, provider_name: String) -> ProviderBuilder {
+        self.provider_name = Some(provider_name);
+
+        self
     }
 
     /// Add a KeyInfo manager
@@ -488,6 +507,9 @@ impl ProviderBuilder {
         };
 
         Ok(Provider::new(
+            self.provider_name.ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::InvalidData, "missing provider name")
+            })?,
             self.key_info_store
                 .ok_or_else(|| Error::new(ErrorKind::InvalidData, "missing key info store"))?,
             backend,

--- a/src/providers/tpm/asym_encryption.rs
+++ b/src/providers/tpm/asym_encryption.rs
@@ -1,20 +1,24 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::{utils, Provider};
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
-use parsec_interface::requests::{ProviderId, Result};
+use parsec_interface::requests::Result;
 use std::convert::TryInto;
 use std::ops::Deref;
 
 impl Provider {
     pub(super) fn psa_asymmetric_encrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let password_context = self.get_key_ctx(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
@@ -63,10 +67,14 @@ impl Provider {
 
     pub(super) fn psa_asymmetric_decrypt_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let password_context = self.get_key_ctx(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;

--- a/src/providers/tpm/asym_encryption.rs
+++ b/src/providers/tpm/asym_encryption.rs
@@ -14,14 +14,14 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
 
-        let password_context = self.get_key_ctx(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context = self.get_key_ctx(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         let mut esapi_context = self
             .esapi_context
@@ -70,14 +70,14 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
 
-        let password_context = self.get_key_ctx(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context = self.get_key_ctx(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         let mut esapi_context = self
             .esapi_context

--- a/src/providers/tpm/asym_sign.rs
+++ b/src/providers/tpm/asym_sign.rs
@@ -16,14 +16,14 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
 
-        let password_context = self.get_key_ctx(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context = self.get_key_ctx(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         let mut esapi_context = self
             .esapi_context
@@ -75,14 +75,14 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
 
-        let password_context = self.get_key_ctx(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context = self.get_key_ctx(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         let mut esapi_context = self
             .esapi_context

--- a/src/providers/tpm/asym_sign.rs
+++ b/src/providers/tpm/asym_sign.rs
@@ -1,22 +1,26 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::{utils, Provider};
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use log::error;
 use parsec_interface::operations::psa_algorithm::*;
 use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use std::convert::TryFrom;
 use tss_esapi::structures::{Auth, Digest};
 
 impl Provider {
     pub(super) fn psa_sign_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let password_context = self.get_key_ctx(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
@@ -68,10 +72,14 @@ impl Provider {
 
     pub(super) fn psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
 
         let password_context = self.get_key_ctx(&key_triple)?;
         let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;

--- a/src/providers/tpm/capability_discovery.rs
+++ b/src/providers/tpm/capability_discovery.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{utils, Provider};
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use crate::providers::crypto_capability::CanDoCrypto;
 use log::{info, trace};
 use parsec_interface::operations::can_do_crypto;
@@ -13,7 +13,7 @@ use parsec_interface::requests::Result;
 impl CanDoCrypto for Provider {
     fn can_do_crypto_internal(
         &self,
-        _app_name: ApplicationName,
+        _application_identity: &ApplicationIdentity,
         op: can_do_crypto::Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto_internal for TPM provider");

--- a/src/providers/tpm/key_attestation.rs
+++ b/src/providers/tpm/key_attestation.rs
@@ -22,7 +22,11 @@ impl Provider {
             prepare_key_attestation::Operation::ActivateCredential {
                 attested_key_name,
                 attesting_key_name,
-            } => self.prepare_activate_credential(application_identity, attested_key_name, attesting_key_name),
+            } => self.prepare_activate_credential(
+                application_identity,
+                attested_key_name,
+                attesting_key_name,
+            ),
             _ => {
                 error!("Key attestation mechanism is not supported");
                 Err(ResponseStatus::PsaErrorNotSupported)

--- a/src/providers/tpm/key_management.rs
+++ b/src/providers/tpm/key_management.rs
@@ -5,14 +5,14 @@ use super::utils;
 use super::utils::LegacyPasswordContext;
 use super::utils::PasswordContext;
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use log::error;
 use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::operations::{
     psa_destroy_key, psa_export_public_key, psa_generate_key, psa_import_key,
 };
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
 use std::convert::TryInto;
 
@@ -20,17 +20,17 @@ const AUTH_VAL_LEN: usize = 32;
 
 impl Provider {
     #[allow(deprecated)]
-    pub(super) fn get_key_ctx(&self, key_triple: &KeyTriple) -> Result<PasswordContext> {
+    pub(super) fn get_key_ctx(&self, key_identity: &KeyIdentity) -> Result<PasswordContext> {
         // Try to deserialize into the new format
         self.key_info_store
-            .get_key_id::<PasswordContext>(key_triple)
+            .get_key_id::<PasswordContext>(key_identity)
             .or_else(|e| {
                 // If it failed, check if it was a deserialization error
                 if let ResponseStatus::InvalidEncoding = e {
                     // Try to deserialize into legacy format
                     let legacy_ctx = self
                         .key_info_store
-                        .get_key_id::<LegacyPasswordContext>(key_triple)?;
+                        .get_key_id::<LegacyPasswordContext>(key_identity)?;
 
                     // Try to migrate the key context to the new format
                     let mut esapi_context = self
@@ -54,9 +54,9 @@ impl Provider {
                     );
 
                     // Grab key attributes and replace legacy entry with new one
-                    let attributes = self.key_info_store.get_key_attributes(key_triple)?;
+                    let attributes = self.key_info_store.get_key_attributes(key_identity)?;
                     let _ = self.key_info_store.replace_key_info(
-                        key_triple.clone(),
+                        key_identity.clone(),
                         &password_ctx,
                         attributes,
                     )?;
@@ -69,14 +69,18 @@ impl Provider {
 
     pub(super) fn psa_generate_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
         let attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, key_name);
+        let key_identity = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
 
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         if op.attributes.key_type.is_public_key() {
             error!("A public key type can not be generated.");
@@ -98,7 +102,7 @@ impl Provider {
         let auth_value = auth_value.unwrap();
 
         self.key_info_store.insert_key_info(
-            key_triple,
+            key_identity,
             &PasswordContext::new(key_material, auth_value.value().to_vec()),
             attributes,
         )?;
@@ -108,7 +112,7 @@ impl Provider {
 
     pub(super) fn psa_import_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         match op.attributes.key_type {
@@ -124,9 +128,13 @@ impl Provider {
 
         let key_name = op.key_name;
         let attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, key_name);
+        let key_identity = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_data = op.data;
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
         let mut esapi_context = self
             .esapi_context
             .lock()
@@ -143,7 +151,7 @@ impl Provider {
             })?;
 
         self.key_info_store.insert_key_info(
-            key_triple,
+            key_identity,
             &PasswordContext::new(key_material, Vec::new()),
             attributes,
         )?;
@@ -153,14 +161,18 @@ impl Provider {
 
     pub(super) fn psa_export_public_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, key_name);
+        let key_identity = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
 
-        let password_context = self.get_key_ctx(&key_triple)?;
-        let key_attributes = self.key_info_store.get_key_attributes(&key_triple)?;
+        let password_context = self.get_key_ctx(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         Ok(psa_export_public_key::Result {
             data: utils::pub_key_to_bytes(
@@ -173,13 +185,17 @@ impl Provider {
 
     pub(super) fn psa_destroy_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::Tpm, key_name);
+        let key_identity = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
 
-        let _ = self.key_info_store.remove_key_info(&key_triple)?;
+        let _ = self.key_info_store.remove_key_info(&key_identity)?;
 
         Ok(psa_destroy_key::Result {})
     }

--- a/src/providers/tpm/mod.rs
+++ b/src/providers/tpm/mod.rs
@@ -5,9 +5,10 @@
 //! Provider allowing clients to use hardware or software TPM 2.0 implementations
 //! for their Parsec operations.
 use super::Provide;
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use crate::key_info_managers::KeyInfoManagerClient;
 use crate::providers::crypto_capability::CanDoCrypto;
+use crate::providers::ProviderIdentity;
 use derivative::Derivative;
 use log::{info, trace};
 use parsec_interface::operations::{
@@ -63,8 +64,8 @@ const AUTH_HEX_PREFIX: &str = "hex:";
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Provider {
-    // The name of the provider set in the config.
-    provider_name: String,
+    // The identity of the provider including uuid & name.
+    provider_identity: ProviderIdentity,
 
     // The Mutex is needed both because interior mutability is needed to the ESAPI Context
     // structure that is shared between threads and because two threads are not allowed the same
@@ -90,7 +91,10 @@ impl Provider {
         esapi_context: tss_esapi::TransientKeyContext,
     ) -> Provider {
         Provider {
-            provider_name,
+            provider_identity: ProviderIdentity {
+                name: provider_name,
+                uuid: String::from(Self::PROVIDER_UUID),
+            },
             esapi_context: Mutex::new(esapi_context),
             key_info_store,
         }
@@ -114,12 +118,12 @@ impl Provide for Provider {
 
     fn list_keys(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         _op: list_keys::Operation,
     ) -> Result<list_keys::Result> {
         trace!("list_keys ingress");
         Ok(list_keys::Result {
-            keys: self.key_info_store.list_keys(&app_name)?,
+            keys: self.key_info_store.list_keys(application_identity)?,
         })
     }
 
@@ -130,110 +134,110 @@ impl Provide for Provider {
                 .key_info_store
                 .list_clients()?
                 .into_iter()
-                .map(|app_name| app_name.to_string())
+                .map(|application_identity| application_identity.name().clone())
                 .collect(),
         })
     }
 
     fn psa_generate_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         trace!("psa_generate_key ingress");
-        self.psa_generate_key_internal(app_name, op)
+        self.psa_generate_key_internal(application_identity, op)
     }
 
     fn psa_import_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         trace!("psa_import_key ingress");
-        self.psa_import_key_internal(app_name, op)
+        self.psa_import_key_internal(application_identity, op)
     }
 
     fn psa_export_public_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         trace!("psa_export_public_key ingress");
-        self.psa_export_public_key_internal(app_name, op)
+        self.psa_export_public_key_internal(application_identity, op)
     }
 
     fn psa_destroy_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         trace!("psa_destroy_key ingress");
-        self.psa_destroy_key_internal(app_name, op)
+        self.psa_destroy_key_internal(application_identity, op)
     }
 
     fn psa_sign_hash(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
         trace!("psa_sign_hash ingress");
-        self.psa_sign_hash_internal(app_name, op)
+        self.psa_sign_hash_internal(application_identity, op)
     }
 
     fn psa_verify_hash(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
         trace!("psa_verify_hash ingress");
-        self.psa_verify_hash_internal(app_name, op)
+        self.psa_verify_hash_internal(application_identity, op)
     }
 
     fn psa_asymmetric_encrypt(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_encrypt::Operation,
     ) -> Result<psa_asymmetric_encrypt::Result> {
         trace!("psa_asymmetric_encrypt ingress");
-        self.psa_asymmetric_encrypt_internal(app_name, op)
+        self.psa_asymmetric_encrypt_internal(application_identity, op)
     }
 
     fn psa_asymmetric_decrypt(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_asymmetric_decrypt::Operation,
     ) -> Result<psa_asymmetric_decrypt::Result> {
         trace!("psa_asymmetric_decrypt ingress");
-        self.psa_asymmetric_decrypt_internal(app_name, op)
+        self.psa_asymmetric_decrypt_internal(application_identity, op)
     }
 
     /// Check if the crypto operation is supported by TPM provider
     /// by using CanDoCrypto trait.
     fn can_do_crypto(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: can_do_crypto::Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto TPM ingress");
-        self.can_do_crypto_main(app_name, op)
+        self.can_do_crypto_main(application_identity, op)
     }
 
     fn prepare_key_attestation(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: prepare_key_attestation::Operation,
     ) -> Result<prepare_key_attestation::Result> {
         trace!("prepare_key_attestation ingress");
-        self.prepare_key_attestation_internal(app_name, op)
+        self.prepare_key_attestation_internal(application_identity, op)
     }
 
     fn attest_key(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: attest_key::Operation,
     ) -> Result<attest_key::Result> {
         trace!("attest_key ingress");
-        self.attest_key_internal(app_name, op)
+        self.attest_key_internal(application_identity, op)
     }
 }
 

--- a/src/providers/trusted_service/asym_sign.rs
+++ b/src/providers/trusted_service/asym_sign.rs
@@ -1,18 +1,22 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
-use parsec_interface::requests::{ProviderId, Result};
+use parsec_interface::requests::Result;
 
 impl Provider {
     pub(super) fn psa_sign_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         Ok(psa_sign_hash::Result {
@@ -25,10 +29,14 @@ impl Provider {
 
     pub(super) fn psa_verify_hash_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, op.key_name.clone());
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            op.key_name.clone(),
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         self.context

--- a/src/providers/trusted_service/asym_sign.rs
+++ b/src/providers/trusted_service/asym_sign.rs
@@ -12,12 +12,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_sign_hash::Operation,
     ) -> Result<psa_sign_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         Ok(psa_sign_hash::Result {
             signature: self
@@ -32,12 +32,12 @@ impl Provider {
         application_identity: &ApplicationIdentity,
         op: psa_verify_hash::Operation,
     ) -> Result<psa_verify_hash::Result> {
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             op.key_name.clone(),
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         self.context
             .verify_hash(key_id, op.hash.to_vec(), op.signature.to_vec(), op.alg)?;

--- a/src/providers/trusted_service/capability_discovery.rs
+++ b/src/providers/trusted_service/capability_discovery.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Provider;
-use crate::authenticators::ApplicationName;
+use crate::authenticators::ApplicationIdentity;
 use crate::providers::crypto_capability::CanDoCrypto;
 use log::{info, trace};
 use parsec_interface::operations::can_do_crypto;
@@ -13,7 +13,7 @@ use parsec_interface::requests::Result;
 impl CanDoCrypto for Provider {
     fn can_do_crypto_internal(
         &self,
-        _app_name: ApplicationName,
+        _app_identity: &ApplicationIdentity,
         op: can_do_crypto::Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto_internal");

--- a/src/providers/trusted_service/key_management.rs
+++ b/src/providers/trusted_service/key_management.rs
@@ -36,12 +36,12 @@ impl Provider {
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let key_id = create_key_id(&self.id_counter)?;
 
@@ -49,7 +49,7 @@ impl Provider {
             Ok(_) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     if self.context.destroy_key(key_id).is_err() {
                         error!("Failed to destroy the previously generated key.");
@@ -75,12 +75,12 @@ impl Provider {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_data = op.data;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        self.key_info_store.does_not_exist(&key_triple)?;
+        self.key_info_store.does_not_exist(&key_identity)?;
 
         let key_id = create_key_id(&self.id_counter)?;
 
@@ -91,7 +91,7 @@ impl Provider {
             Ok(_) => {
                 if let Err(e) =
                     self.key_info_store
-                        .insert_key_info(key_triple, &key_id, key_attributes)
+                        .insert_key_info(key_identity, &key_id, key_attributes)
                 {
                     if self.context.destroy_key(key_id).is_err() {
                         error!("Failed to destroy the previously generated key.");
@@ -114,12 +114,12 @@ impl Provider {
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         match self.context.export_public_key(key_id) {
             Ok(pub_key) => Ok(psa_export_public_key::Result {
@@ -138,12 +138,12 @@ impl Provider {
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
 
         match self.context.export_key(key_id) {
             Ok(key) => Ok(psa_export_key::Result {
@@ -162,13 +162,13 @@ impl Provider {
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyIdentity::new(
+        let key_identity = KeyIdentity::new(
             application_identity.clone(),
             self.provider_identity.clone(),
             key_name,
         );
-        let key_id = self.key_info_store.get_key_id(&key_triple)?;
-        let _ = self.key_info_store.remove_key_info(&key_triple)?;
+        let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let _ = self.key_info_store.remove_key_info(&key_identity)?;
 
         match self.context.destroy_key(key_id) {
             Ok(()) => Ok(psa_destroy_key::Result {}),

--- a/src/providers/trusted_service/key_management.rs
+++ b/src/providers/trusted_service/key_management.rs
@@ -1,13 +1,13 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::Provider;
-use crate::authenticators::ApplicationName;
-use crate::key_info_managers::KeyTriple;
+use crate::authenticators::ApplicationIdentity;
+use crate::key_info_managers::KeyIdentity;
 use log::error;
 use parsec_interface::operations::{
     psa_destroy_key, psa_export_key, psa_export_public_key, psa_generate_key, psa_import_key,
 };
-use parsec_interface::requests::{ProviderId, ResponseStatus, Result};
+use parsec_interface::requests::{ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
 use parsec_interface::secrecy::Secret;
 use psa_crypto::types::key::PSA_KEY_ID_USER_MAX;
@@ -31,12 +31,16 @@ pub fn create_key_id(max_current_id: &AtomicU32) -> Result<u32> {
 impl Provider {
     pub(super) fn psa_generate_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_generate_key::Operation,
     ) -> Result<psa_generate_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let key_id = create_key_id(&self.id_counter)?;
@@ -65,13 +69,17 @@ impl Provider {
 
     pub(super) fn psa_import_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_import_key::Operation,
     ) -> Result<psa_import_key::Result> {
         let key_name = op.key_name;
         let key_attributes = op.attributes;
         let key_data = op.data;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         self.key_info_store.does_not_exist(&key_triple)?;
 
         let key_id = create_key_id(&self.id_counter)?;
@@ -102,11 +110,15 @@ impl Provider {
 
     pub(super) fn psa_export_public_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_public_key::Operation,
     ) -> Result<psa_export_public_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         match self.context.export_public_key(key_id) {
@@ -122,11 +134,15 @@ impl Provider {
 
     pub(super) fn psa_export_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_export_key::Operation,
     ) -> Result<psa_export_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
 
         match self.context.export_key(key_id) {
@@ -142,11 +158,15 @@ impl Provider {
 
     pub(super) fn psa_destroy_key_internal(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: psa_destroy_key::Operation,
     ) -> Result<psa_destroy_key::Result> {
         let key_name = op.key_name;
-        let key_triple = KeyTriple::new(app_name, ProviderId::TrustedService, key_name);
+        let key_triple = KeyIdentity::new(
+            application_identity.clone(),
+            self.provider_identity.clone(),
+            key_name,
+        );
         let key_id = self.key_info_store.get_key_id(&key_triple)?;
         let _ = self.key_info_store.remove_key_info(&key_triple)?;
 

--- a/src/providers/trusted_service/mod.rs
+++ b/src/providers/trusted_service/mod.rs
@@ -233,11 +233,11 @@ impl Provide for Provider {
 
     fn can_do_crypto(
         &self,
-        app_name: ApplicationName,
+        application_identity: &ApplicationIdentity,
         op: can_do_crypto::Operation,
     ) -> Result<can_do_crypto::Result> {
         trace!("can_do_crypto ingress");
-        self.can_do_crypto_main(app_name, op)
+        self.can_do_crypto_main(application_identity, op)
     }
 }
 

--- a/src/providers/trusted_service/mod.rs
+++ b/src/providers/trusted_service/mod.rs
@@ -83,17 +83,17 @@ impl Provider {
         let mut max_key_id: key::psa_key_id_t = key::PSA_KEY_ID_USER_MIN;
         {
             let mut to_remove: Vec<KeyIdentity> = Vec::new();
-            // Go through all TrustedServiceProvider key triples to key info mappings and check if they are still
+            // Go through all TrustedServiceProvider key identities to key info mappings and check if they are still
             // present.
             // Delete those who are not present and add to the local_store the ones present.
             match ts_provider.key_info_store.get_all() {
-                Ok(key_triples) => {
-                    for key_triple in key_triples.iter().cloned() {
-                        let key_id = match ts_provider.key_info_store.get_key_id(&key_triple) {
+                Ok(key_identities) => {
+                    for key_identity in key_identities.iter().cloned() {
+                        let key_id = match ts_provider.key_info_store.get_key_id(&key_identity) {
                             Ok(key_id) => key_id,
                             Err(response_status) => {
-                                error!("Error getting the Key ID for triple:\n{}\n(error: {}), continuing...", key_triple, response_status);
-                                to_remove.push(key_triple.clone());
+                                error!("Error getting the Key ID for KeyIdentity:\n{}\n(error: {}), continuing...", key_identity, response_status);
+                                to_remove.push(key_identity.clone());
                                 continue;
                             }
                         };
@@ -108,8 +108,8 @@ impl Provider {
                     return Err(std::io::Error::new(std::io::ErrorKind::Other, string).into());
                 }
             };
-            for key_triple in to_remove.iter() {
-                if let Err(string) = ts_provider.key_info_store.remove_key_info(key_triple) {
+            for key_identity in to_remove.iter() {
+                if let Err(string) = ts_provider.key_info_store.remove_key_info(key_identity) {
                     return Err(std::io::Error::new(std::io::ErrorKind::Other, string).into());
                 }
             }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -2,9 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Structures for the Parsec configuration file
 
+#[cfg(feature = "cryptoauthlib-provider")]
+use crate::providers::cryptoauthlib::Provider as CryptoAuthLibProvider;
+#[cfg(feature = "mbed-crypto-provider")]
+use crate::providers::mbed_crypto::Provider as MbedCryptoProvider;
+#[cfg(feature = "pkcs11-provider")]
+use crate::providers::pkcs11::Provider as Pkcs11Provider;
+#[cfg(feature = "tpm-provider")]
+use crate::providers::tpm::Provider as TpmProvider;
+#[cfg(feature = "trusted-service-provider")]
+use crate::providers::trusted_service::Provider as TrustedServiceProvider;
+#[cfg(not(all(
+    feature = "mbed-crypto-provider",
+    feature = "pkcs11-provider",
+    feature = "tpm-provider",
+    feature = "cryptoauthlib-provider",
+    feature = "trusted-service-provider"
+)))]
+use log::error;
 use log::LevelFilter;
 use parsec_interface::requests::ProviderId;
 use serde::Deserialize;
+use std::io::Error;
+#[cfg(not(all(
+    feature = "mbed-crypto-provider",
+    feature = "pkcs11-provider",
+    feature = "tpm-provider",
+    feature = "cryptoauthlib-provider",
+    feature = "trusted-service-provider"
+)))]
+use std::io::ErrorKind;
 use zeroize::Zeroize;
 
 /// Core settings
@@ -108,11 +135,15 @@ pub struct KeyInfoManagerConfig {
 pub enum ProviderConfig {
     /// Mbed Crypto provider configuration
     MbedCrypto {
+        /// The name of the provider
+        name: Option<String>,
         /// Name of the Key Info Manager to use
         key_info_manager: String,
     },
     /// PKCS 11 provider configuration
     Pkcs11 {
+        /// The name of the provider
+        name: Option<String>,
         /// Name of the Key Info Manager to use
         key_info_manager: String,
         /// Path of the PKCS 11 library
@@ -128,6 +159,8 @@ pub enum ProviderConfig {
     },
     /// TPM provider configuration
     Tpm {
+        /// The name of the provider
+        name: Option<String>,
         /// Name of the Key Info Manager to use
         key_info_manager: String,
         /// TCTI to use with the provider
@@ -142,6 +175,8 @@ pub enum ProviderConfig {
     },
     /// Microchip CryptoAuthentication Library provider configuration
     CryptoAuthLib {
+        /// The name of the provider
+        name: Option<String>,
         /// Name of the Key Info Manager to use
         key_info_manager: String,
         /// ATECC Device type
@@ -163,6 +198,8 @@ pub enum ProviderConfig {
     },
     /// Trusted Service provider configuration
     TrustedService {
+        /// The name of the provider
+        name: Option<String>,
         /// Name of Key Info Manager to use
         key_info_manager: String,
     },
@@ -202,6 +239,43 @@ impl ProviderConfig {
             ProviderConfig::Tpm { .. } => ProviderId::Tpm,
             ProviderConfig::CryptoAuthLib { .. } => ProviderId::CryptoAuthLib,
             ProviderConfig::TrustedService { .. } => ProviderId::TrustedService,
+        }
+    }
+    /// Get the name of the Provider
+    /// If there is not one set, use the default.
+    pub fn provider_name(&self) -> Result<String, Error> {
+        match *self {
+            #[cfg(feature = "mbed-crypto-provider")]
+            ProviderConfig::MbedCrypto { ref name, .. } => Ok(name
+                .clone()
+                .unwrap_or_else(|| String::from(MbedCryptoProvider::DEFAULT_PROVIDER_NAME))),
+            #[cfg(feature = "pkcs11-provider")]
+            ProviderConfig::Pkcs11 { ref name, .. } => Ok(name
+                .clone()
+                .unwrap_or_else(|| String::from(Pkcs11Provider::DEFAULT_PROVIDER_NAME))),
+            #[cfg(feature = "tpm-provider")]
+            ProviderConfig::Tpm { ref name, .. } => Ok(name
+                .clone()
+                .unwrap_or_else(|| String::from(TpmProvider::DEFAULT_PROVIDER_NAME))),
+            #[cfg(feature = "cryptoauthlib-provider")]
+            ProviderConfig::CryptoAuthLib { ref name, .. } => Ok(name
+                .clone()
+                .unwrap_or_else(|| String::from(CryptoAuthLibProvider::DEFAULT_PROVIDER_NAME))),
+            #[cfg(feature = "trusted-service-provider")]
+            ProviderConfig::TrustedService { ref name, .. } => Ok(name
+                .clone()
+                .unwrap_or_else(|| String::from(TrustedServiceProvider::DEFAULT_PROVIDER_NAME))),
+            #[cfg(not(all(
+                feature = "mbed-crypto-provider",
+                feature = "pkcs11-provider",
+                feature = "tpm-provider",
+                feature = "cryptoauthlib-provider",
+                feature = "trusted-service-provider"
+            )))]
+            _ => {
+                error!("Provider chosen in the configuration was not compiled in Parsec binary.");
+                Err(Error::new(ErrorKind::InvalidData, "provider not compiled"))
+            }
         }
     }
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -111,6 +111,8 @@ impl Admin {
 pub enum KeyInfoManagerType {
     /// KeyInfoManager storing the mappings on disk
     OnDisk,
+    /// KeyInfoManager for storing mappings within a SQLite database on disk.
+    SQLite,
 }
 
 /// KeyInfoManager configuration
@@ -120,8 +122,10 @@ pub struct KeyInfoManagerConfig {
     pub name: String,
     /// Type of the KeyInfoManager
     pub manager_type: KeyInfoManagerType,
-    /// Path used to store the mappings
+    /// Path used to store the OnDiskKeyInfoManager mappings
     pub store_path: Option<String>,
+    /// File path where the SQLite database should be stored when using SQLiteKeyInfoManager
+    pub sqlite_db_path: Option<String>,
 }
 
 /// Provider configuration structure

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,16 @@ pub mod cli;
 pub mod config;
 mod global_config;
 mod service_builder;
+#[cfg(all(
+    feature = "mbed-crypto-provider",
+    feature = "pkcs11-provider",
+    feature = "tpm-provider",
+    feature = "cryptoauthlib-provider",
+    feature = "trusted-service-provider",
+    feature = "direct-authenticator"
+))]
+#[cfg(test)]
+mod tests;
 
 pub use global_config::GlobalConfig;
 pub use service_builder::ServiceBuilder;

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -26,6 +26,7 @@ use parsec_interface::operations_protobuf::ProtobufConverter;
 use parsec_interface::requests::AuthType;
 use parsec_interface::requests::{BodyType, ProviderId};
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
 use std::sync::Arc;
 use std::time::Duration;
@@ -208,17 +209,21 @@ fn build_providers(
     configs: &[ProviderConfig],
     kim_factorys: HashMap<String, KeyInfoManagerFactory>,
 ) -> Result<Vec<(ProviderId, Provider)>> {
-    let mut list = Vec::new();
+    let mut providers = Vec::new();
+    let mut provider_names = HashSet::new();
     for config in configs {
+        // Check for duplicate providers.
         let provider_id = config.provider_id();
-        if list.iter().any(|(id, _)| *id == provider_id) {
-            error!("Parsec currently only supports one instance of each provider type, but {} was supplied twice. Please check your config.toml file.", provider_id);
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "only one provider per type is supported",
-            )
-            .into());
+
+        // Check for duplicate provider names.
+        let provider_name = config.provider_name()?;
+        if provider_names.contains(&provider_name) {
+            error!("Duplicate provider names found.\n{} was found twice.\nThe \'[[provider]] name config option can be used to differentiate between providers of the same type.\nPlease check your config.toml file.", provider_name);
+            return Err(
+                Error::new(ErrorKind::InvalidData, "duplicate provider names found").into(),
+            );
         }
+        let _ = provider_names.insert(provider_name.clone());
 
         let kim_factory = match kim_factorys.get(config.key_info_manager()) {
             Some(kim_factory) => kim_factory,
@@ -249,10 +254,10 @@ fn build_providers(
                 return Err(Error::new(ErrorKind::Other, "failed to create provider").into());
             }
         };
-        let _ = list.push((provider_id, provider));
+        let _ = providers.push((provider_id, provider));
     }
 
-    Ok(list)
+    Ok(providers)
 }
 
 // This cfg_attr is used to allow the fact that key_info_manager is not used when there is no
@@ -280,6 +285,7 @@ unsafe fn get_provider(
             Ok(Some(Arc::new(
                 MbedCryptoProviderBuilder::new()
                     .with_key_info_store(kim_factory.build_client(ProviderId::MbedCrypto))
+                    .with_provider_name(config.provider_name()?)
                     .build()?,
             )))
         }
@@ -296,6 +302,7 @@ unsafe fn get_provider(
             Ok(Some(Arc::new(
                 Pkcs11ProviderBuilder::new()
                     .with_key_info_store(kim_factory.build_client(ProviderId::Pkcs11))
+                    .with_provider_name(config.provider_name()?)
                     .with_pkcs11_library_path(library_path.clone())
                     .with_slot_number(*slot_number)
                     .with_user_pin(user_pin.clone())
@@ -337,6 +344,7 @@ unsafe fn get_provider(
             let mut builder = TpmProviderBuilder::new()
                 .with_key_info_store(kim_factory.build_client(ProviderId::Tpm))
                 .with_tcti(tcti)
+                .with_provider_name(config.provider_name()?)
                 .with_owner_hierarchy_auth(owner_hierarchy_auth.clone());
             if endorsement_hierarchy_auth.is_some() {
                 builder = builder.with_endorsement_hierarchy_auth(
@@ -361,6 +369,7 @@ unsafe fn get_provider(
             Ok(Some(Arc::new(
                 CryptoAuthLibProviderBuilder::new()
                     .with_key_info_store(kim_factory.build_client(ProviderId::CryptoAuthLib))
+                    .with_provider_name(config.provider_name()?)
                     .with_device_type(device_type.to_string())
                     .with_iface_type(iface_type.to_string())
                     .with_wake_delay(*wake_delay)
@@ -378,6 +387,7 @@ unsafe fn get_provider(
             Ok(Some(Arc::new(
                 TrustedServiceProviderBuilder::new()
                     .with_key_info_store(kim_factory.build_client(ProviderId::TrustedService))
+                    .with_provider_name(config.provider_name()?)
                     .build()?,
             )))
         }

--- a/src/utils/tests/config/providers_different_type.toml
+++ b/src/utils/tests/config/providers_different_type.toml
@@ -1,0 +1,25 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+provider_type = "MbedCrypto"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/config/providers_different_type_same_name.toml
+++ b/src/utils/tests/config/providers_different_type_same_name.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+name="a-name"
+provider_type = "MbedCrypto"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+name="a-name"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/config/providers_same_type_default_name.toml
+++ b/src/utils/tests/config/providers_same_type_default_name.toml
@@ -1,0 +1,25 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/config/providers_same_type_different_name.toml
+++ b/src/utils/tests/config/providers_same_type_different_name.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+name="trusted-service-provider-0"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+name="trusted-service-provider-1"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/config/providers_same_type_same_name.toml
+++ b/src/utils/tests/config/providers_same_type_same_name.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
+
+[[provider]]
+name="a-name"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"
+
+[[provider]]
+name="a-name"
+provider_type = "TrustedService"
+key_info_manager = "on-disk-manager"

--- a/src/utils/tests/mod.rs
+++ b/src/utils/tests/mod.rs
@@ -1,0 +1,107 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! Static config tests to see if the service starts with different configurations.
+
+use crate::utils::config::ServiceConfig;
+use crate::utils::ServiceBuilder;
+use anyhow::anyhow;
+use log::error;
+use std::env;
+use std::io::Error;
+use std::io::ErrorKind;
+
+const CONFIG_TOMLS_FOLDER: &str = "src/utils/tests/config";
+
+fn config_to_toml(file_name: String) -> ServiceConfig {
+    let mut new_config_path = env::current_dir() // this is the root of the crate for tests
+        .unwrap();
+    new_config_path.push(CONFIG_TOMLS_FOLDER);
+    new_config_path.push(file_name.clone());
+    if !new_config_path.exists() {
+        error!("Configuration file {} does not exist", file_name);
+        panic!();
+    }
+
+    let config_file = ::std::fs::read_to_string(new_config_path.clone())
+        .map_err(|e| {
+            error!(
+                "Failed to read config file from path: {:#?}\nError: {:#?}",
+                new_config_path, e
+            );
+            panic!();
+        })
+        .unwrap();
+    toml::from_str(&config_file)
+        .map_err(|e| {
+            error!("Failed to parse service configuration ({})", e);
+            panic!();
+        })
+        .unwrap()
+}
+
+/// Check that the service throws an error when two providers of the same type are started,
+/// without setting a name (therefore they have the same default name).
+#[test]
+fn providers_same_type_default_name() {
+    let config_path: String = "providers_same_type_default_name.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let expected_error = anyhow!(Error::new(
+        ErrorKind::InvalidData,
+        "duplicate provider names found"
+    ));
+
+    let err = ServiceBuilder::build_service(&config).unwrap_err();
+    assert_eq!(format!("{:#?}", err), format!("{:#?}", expected_error));
+}
+
+/// Check that the service starts when two providers of the same type have different names.
+#[test]
+fn providers_same_type_different_name() {
+    let config_path: String = "providers_same_type_different_name.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let _ = ServiceBuilder::build_service(&config).unwrap();
+}
+
+/// Check that the service throws an error when two providers of the same type explicitly
+/// set the same name.
+#[test]
+fn providers_same_type_same_name() {
+    let config_path: String = "providers_same_type_same_name.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let expected_error = anyhow!(Error::new(
+        ErrorKind::InvalidData,
+        "duplicate provider names found"
+    ));
+
+    let err = ServiceBuilder::build_service(&config).unwrap_err();
+    assert_eq!(format!("{:#?}", err), format!("{:#?}", expected_error));
+}
+
+/// Check that the service throws an error when two providers of different types explicitly
+/// set the same name.
+#[test]
+fn providers_different_type_same_name() {
+    let config_path: String = "providers_different_type_same_name.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let expected_error = anyhow!(Error::new(
+        ErrorKind::InvalidData,
+        "duplicate provider names found"
+    ));
+
+    let err = ServiceBuilder::build_service(&config).unwrap_err();
+    assert_eq!(format!("{:#?}", err), format!("{:#?}", expected_error));
+}
+
+/// Check that the service starts when two providers of different types are declared.
+/// (Different default provider names)
+#[test]
+fn providers_different_type() {
+    let config_path: String = "providers_different_type.toml".to_string();
+    let config = config_to_toml(config_path);
+
+    let _ = ServiceBuilder::build_service(&config).unwrap();
+}


### PR DESCRIPTION
I've taken the `feature-sqlite-kim` branch from the main repo, rebased it on top of our current `main` and this is the result. The PR is fairly large, but luckily it is broken up in a number of commits, that should help in reviewing.

During the rebase I had to make a number of changes - most notably, I had to update the implementations of `CanDoCrypto`, `PrepareKeyAttestation`, and `AttestKey` to use the new KIM client interface, and to use `ApplicationIdentity` instead of `ApplicationName`. The changes have been folded into the original commits.