### PR TITLE
Make SQLite KIM default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
       # When running the container built on the CI
       # run: CONTAINER_TAG=parsec-service-test-all ./fuzz.sh test
 
-  sqlite-kim:
-    name: SQLiteKIM E2E tests on all providers
+  on-disk-kim:
+    name: OnDiskKIM E2E tests on all providers
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -128,9 +128,9 @@ jobs:
       #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
       - name: Run the container to execute the test script
         run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh sqlite-kim
+          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh sqlite-kim
+      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
 
   cross-compilation:
     # Currently only the Mbed Crypto, PKCS 11, and TPM providers are tested as the other ones need to cross-compile other libraries.

--- a/ci.sh
+++ b/ci.sh
@@ -42,7 +42,7 @@ where PROVIDER_NAME can be one of:
     - cryptoauthlib
     - all
     - coverage
-    - sqlite-kim
+    - on-disk-kim
 "
 }
 
@@ -106,6 +106,25 @@ run_key_mappings_tests() {
     RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml key_mappings
 }
 
+setup_mappings() {
+    # Add the Docker image's mappings in this Parsec service for the key mappings
+    # test.
+    # The key mappings test in e2e_tests/tests/per_provider/key_mappings.rs will try
+    # to use the key generated via the generate-keys.sh script in the test image.
+    cp -r /tmp/mappings/ .
+    # Add the fake mappings for the key mappings test as well. The test will check that
+    # those keys have successfully been deleted.
+    # TODO: add fake mappings for the Trusted Service and CryptoAuthLib providers.
+    cp -r $(pwd)/e2e_tests/fake_mappings/* mappings
+    # As Mbed Crypto saves its keys on the current directory we need to move them
+    # as well.
+    if [ "$PROVIDER_NAME" = "mbed-crypto" ]; then
+        cp /tmp/*.psa_its .
+    fi
+
+    reload_service
+}
+
 # Parse arguments
 NO_CARGO_CLEAN=
 NO_STRESS_TEST=
@@ -119,20 +138,21 @@ while [ "$#" -gt 0 ]; do
         --no-stress-test )
             NO_STRESS_TEST="True"
         ;;
-        mbed-crypto | pkcs11 | tpm | trusted-service | cryptoauthlib | all | cargo-check | sqlite-kim)
+        mbed-crypto | pkcs11 | tpm | trusted-service | cryptoauthlib | all | cargo-check | on-disk-kim)
             if [ -n "$PROVIDER_NAME" ]; then
                 error_msg "Only one provider name must be given"
             fi
             PROVIDER_NAME=$1
 
-            # Copy provider specific config, unless CI is running `cargo-check` or `sqlite-kim` CI
-            if [ "$PROVIDER_NAME" != "cargo-check" ] && [ "$PROVIDER_NAME" != "sqlite-kim" ]; then
+            # Copy provider specific config, unless CI is running `cargo-check` or `on-disk-kim` CI
+            if [ "$PROVIDER_NAME" != "cargo-check" ] && [ "$PROVIDER_NAME" != "on-disk-kim" ]; then
                 cp $(pwd)/e2e_tests/provider_cfg/$1/config.toml $CONFIG_PATH
-            elif [ "$PROVIDER_NAME" = "sqlite-kim" ]; then
-                cp $(pwd)/e2e_tests/provider_cfg/all/sqlite-kim-all-providers.toml $CONFIG_PATH
+            elif [ "$PROVIDER_NAME" = "on-disk-kim" ]; then
+                PROVIDER_NAME=all
+                cp $(pwd)/e2e_tests/provider_cfg/all/on-disk-kim-all-providers.toml $CONFIG_PATH
             fi
 
-            if [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "cargo-check" ] || [ "$PROVIDER_NAME" = "sqlite-kim" ]; then
+            if [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "cargo-check" ]; then
                 FEATURES="--features=all-providers,all-authenticators"
                 TEST_FEATURES="--features=all-providers"
             else
@@ -157,7 +177,7 @@ fi
 
 trap cleanup EXIT
 
-if [ "$PROVIDER_NAME" = "tpm" ] || [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "coverage" ] || [ "$PROVIDER_NAME" = "sqlite-kim" ]; then
+if [ "$PROVIDER_NAME" = "tpm" ] || [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "coverage" ]; then
 	# Copy the NVChip for previously stored state. This is needed for the key mappings test.
     cp /tmp/NVChip .
     # Start and configure TPM server
@@ -179,7 +199,7 @@ if [ "$PROVIDER_NAME" = "tpm" ] || [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_
     popd
 fi
 
-if [ "$PROVIDER_NAME" = "pkcs11" ] || [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "coverage" ] || [ "$PROVIDER_NAME" = "sqlite-kim" ]; then
+if [ "$PROVIDER_NAME" = "pkcs11" ] || [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "coverage" ]; then
     pushd e2e_tests
     # This command suppose that the slot created by the container will be the first one that appears
     # when printing all the available slots.
@@ -234,7 +254,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
     exit 0
 fi
 
-if [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "sqlite-kim" ]; then
+if [ "$PROVIDER_NAME" = "all" ]; then
     # Start SPIRE server and agent
     pushd /tmp/spire-0.11.1
     ./bin/spire-server run -config conf/server/server.conf &
@@ -250,22 +270,6 @@ if [ "$PROVIDER_NAME" = "all" ] || [ "$PROVIDER_NAME" = "sqlite-kim" ]; then
 		    -spiffeID spiffe://example.org/parsec-client-2 -selector unix:uid:$(id -u parsec-client-2)
     sleep 5
     popd
-fi
-
-# Test the SQLite KIM
-if [ "$PROVIDER_NAME" = "sqlite-kim" ]; then
-    echo "Start Parsec for end-to-end tests with sqlite-kim"
-    RUST_LOG=info RUST_BACKTRACE=1 cargo run --release $FEATURES -- --config $CONFIG_PATH &
-    # Sleep time needed to make sure Parsec is ready before launching the tests.
-    wait_for_service
-
-    echo "Execute all-providers sqlite-kim normal tests"
-    RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml all_providers::normal
-
-    echo "Shutdown Parsec"
-    stop_service
-
-    exit 0
 fi
 
 echo "Build test"
@@ -326,21 +330,6 @@ RUST_BACKTRACE=1 cargo test $FEATURES
 # Removing any mappings left over from integration tests
 rm -rf mappings/
 
-# Add the Docker image's mappings in this Parsec service for the key mappings
-# test.
-# The key mappings test in e2e_tests/tests/per_provider/key_mappings.rs will try
-# to use the key generated via the generate-keys.sh script in the test image.
-cp -r /tmp/mappings/ .
-# Add the fake mappings for the key mappings test as well. The test will check that
-# those keys have successfully been deleted.
-# TODO: add fake mappings for the Trusted Service and CryptoAuthLib providers.
-cp -r $(pwd)/e2e_tests/fake_mappings/* mappings
-# As Mbed Crypto saves its keys on the current directory we need to move them
-# as well.
-if [ "$PROVIDER_NAME" = "mbed-crypto" ]; then
-    cp /tmp/*.psa_its .
-fi
-
 echo "Start Parsec for end-to-end tests"
 RUST_LOG=info RUST_BACKTRACE=1 cargo run --release $FEATURES -- --config $CONFIG_PATH &
 # Sleep time needed to make sure Parsec is ready before launching the tests.
@@ -349,6 +338,9 @@ wait_for_service
 if [ "$PROVIDER_NAME" = "all" ]; then
     echo "Execute all-providers normal tests"
     RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml all_providers::normal
+
+    echo "Execute all-providers cross tests"
+    RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml all_providers::cross
 
     echo "Execute all-providers multi-tenancy tests"
     # Needed because parsec-client-1 and 2 write to those locations owned by root
@@ -360,6 +352,7 @@ if [ "$PROVIDER_NAME" = "all" ]; then
     su -c "PATH=\"/home/parsec-client-1/.cargo/bin:${PATH}\";RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml --target-dir /home/parsec-client-1 all_providers::multitenancy::client1_before" parsec-client-1
     su -c "PATH=\"/home/parsec-client-2/.cargo/bin:${PATH}\";RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml --target-dir /home/parsec-client-2 all_providers::multitenancy::client2" parsec-client-2
     su -c "PATH=\"/home/parsec-client-1/.cargo/bin:${PATH}\";RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml --target-dir /home/parsec-client-1 all_providers::multitenancy::client1_after" parsec-client-1
+
     # Change the authentication method
     sed -i 's/^\(auth_type\s*=\s*\).*$/\1\"UnixPeerCredentials\"/' $CONFIG_PATH
     reload_service
@@ -380,6 +373,8 @@ if [ "$PROVIDER_NAME" = "all" ]; then
     echo "Execute all-providers config tests"
     RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml all_providers::config -- --test-threads=1
 else
+    setup_mappings
+
     # Per provider tests
     run_normal_tests
     run_old_e2e_tests

--- a/config.toml
+++ b/config.toml
@@ -84,12 +84,24 @@ auth_type = "UnixPeerCredentials"
 # Defined as an array of tables: https://github.com/toml-lang/toml#user-content-array-of-tables
 [[key_manager]]
 # (Required) Name of the key info manager. Used to tie providers to the manager supporting them.
-name = "on-disk-manager"
+name = "sqlite-manager"
 
 # (Required) Type of key info manager to be used.
-manager_type = "OnDisk"
+# Possible values: "SQLite", "OnDisk"
+# NOTE: The SQLite KIM is now the recommended type, with the OnDisk KIM to be deprecated at some
+# point in the future.
+manager_type = "SQLite"
 
-# Path to the location where the mapping will be persisted (in this case, the filesystem path)
+# Path to the location where the database will be persisted
+#store_path = "/var/lib/parsec/kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+
+# Example of OnDisk Key Info Manager configuration
+#[[key_manager]]
+# (Required) Name of the key info manager.
+#name = "on-disk-manager"
+# (Required) Type of key info manager to be used.
+#manager_type = "OnDisk"
+# Path to the location where the mappings will be persisted (in this case, the filesystem path)
 #store_path = "/var/lib/parsec/mappings"
 
 # (Required) Provider configurations.
@@ -120,7 +132,7 @@ provider_type = "MbedCrypto"
 # Crypto library by default within the working directory of the service, NOT in the same location
 # as the mappings mentioned previously. If you want the keys to be persisted across reboots, ensure
 # that the working directory is not temporary.
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 
 # Example of a PKCS 11 provider configuration
 #[[provider]]
@@ -134,7 +146,7 @@ key_info_manager = "on-disk-manager"
 # (Optional) The name of the provider
 # name = "pkcs11-provider"
 #provider_type = "Pkcs11"
-#key_info_manager = "on-disk-manager"
+#key_info_manager = "sqlite-manager"
 # (Required for this provider) Path to the location of the dynamic library loaded by this provider.
 # For the PKCS 11 provider, this library implements the PKCS 11 API on the target platform.
 #library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
@@ -164,7 +176,7 @@ key_info_manager = "on-disk-manager"
 # (Optional) The name of the provider
 # name = "tpm-provider"
 #provider_type = "Tpm"
-#key_info_manager = "on-disk-manager"
+#key_info_manager = "sqlite-manager"
 # (Required) TPM TCTI device to use with this provider. The string can include configuration values - if no
 # configuration value is given, the defaults are used. Options are:
 # - "device": uses a TPM device available as a file node; path can be given as a configuration string,
@@ -207,7 +219,7 @@ key_info_manager = "on-disk-manager"
 # (Optional) The name of the provider
 # name = "cryptoauthlib-provider"
 #provider_type = "CryptoAuthLib"
-#key_info_manager = "on-disk-manager"
+#key_info_manager = "sqlite-manager"
 ##########
 # (Required) Interface for ATCA device
 #   Supported values: "i2c", "test-interface"
@@ -271,4 +283,4 @@ key_info_manager = "on-disk-manager"
 #provider_type = "TrustedService"
 
 # (Required) Name of key info manager that will support this provider.
-#key_info_manager = "on-disk-manager"
+#key_info_manager = "sqlite-manager"

--- a/config.toml
+++ b/config.toml
@@ -144,7 +144,7 @@ key_info_manager = "sqlite-manager"
 # ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
 # ⚠
 # (Optional) The name of the provider
-# name = "pkcs11-provider"
+#name = "pkcs11-provider"
 #provider_type = "Pkcs11"
 #key_info_manager = "sqlite-manager"
 # (Required for this provider) Path to the location of the dynamic library loaded by this provider.
@@ -174,7 +174,7 @@ key_info_manager = "sqlite-manager"
 # ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
 # ⚠
 # (Optional) The name of the provider
-# name = "tpm-provider"
+#name = "tpm-provider"
 #provider_type = "Tpm"
 #key_info_manager = "sqlite-manager"
 # (Required) TPM TCTI device to use with this provider. The string can include configuration values - if no
@@ -217,7 +217,7 @@ key_info_manager = "sqlite-manager"
 # ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
 # ⚠
 # (Optional) The name of the provider
-# name = "cryptoauthlib-provider"
+#name = "cryptoauthlib-provider"
 #provider_type = "CryptoAuthLib"
 #key_info_manager = "sqlite-manager"
 ##########
@@ -278,7 +278,7 @@ key_info_manager = "sqlite-manager"
 # ⚠ WARNING: Changing provider name after use will lead to loss of existing keys.
 # ⚠
 # (Optional) The name of the provider
-# name = "trusted-service-provider"
+#name = "trusted-service-provider"
 # (Required) Type of provider.
 #provider_type = "TrustedService"
 

--- a/e2e_tests/provider_cfg/all/config.toml
+++ b/e2e_tests/provider_cfg/all/config.toml
@@ -18,23 +18,23 @@ admins = [ { name = "list_clients test" }, { name = "1000" }, { name = "client1"
 #workload_endpoint="unix:///tmp/agent.sock"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "MbedCrypto"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 
 [[provider]]
 provider_type = "Tpm"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "tpm_pass"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
@@ -42,7 +42,7 @@ user_pin = "123456"
 
 [[provider]]
 provider_type = "CryptoAuthLib"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 device_type = "always-success"
 iface_type = "test-interface"
 # wake_delay = 1500

--- a/e2e_tests/provider_cfg/all/on-disk-kim-all-providers.toml
+++ b/e2e_tests/provider_cfg/all/on-disk-kim-all-providers.toml
@@ -18,23 +18,23 @@ admins = [ { name = "list_clients test" }, { name = "1000" }, { name = "client1"
 #workload_endpoint="unix:///tmp/agent.sock"
 
 [[key_manager]]
-name = "sqlite-manager"
-manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "./mappings"
 
 [[provider]]
 provider_type = "MbedCrypto"
-key_info_manager = "sqlite-manager"
+key_info_manager = "on-disk-manager"
 
 [[provider]]
 provider_type = "Tpm"
-key_info_manager = "sqlite-manager"
+key_info_manager = "on-disk-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "tpm_pass"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "sqlite-manager"
+key_info_manager = "on-disk-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
@@ -42,7 +42,7 @@ user_pin = "123456"
 
 [[provider]]
 provider_type = "CryptoAuthLib"
-key_info_manager = "sqlite-manager"
+key_info_manager = "on-disk-manager"
 device_type = "always-success"
 iface_type = "test-interface"
 # wake_delay = 1500

--- a/e2e_tests/tests/all_providers/config/tomls/allow_export.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/allow_export.toml
@@ -12,13 +12,13 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
@@ -12,23 +12,23 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "MbedCrypto"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 
 [[provider]]
 provider_type = "Tpm"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "tpm_pass"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
@@ -36,7 +36,7 @@ user_pin = "123456"
 
 [[provider]]
 provider_type = "CryptoAuthLib"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 device_type = "always-success"
 iface_type = "test-interface"
 wake_delay = 1500

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
@@ -12,13 +12,13 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
@@ -26,17 +26,17 @@ user_pin = "123456"
 
 [[provider]]
 provider_type = "MbedCrypto"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 
 [[provider]]
 provider_type = "Tpm"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "tpm_pass"
 
 [[provider]]
 provider_type = "CryptoAuthLib"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 device_type = "always-success"
 iface_type = "test-interface"
 wake_delay = 1500

--- a/e2e_tests/tests/all_providers/config/tomls/no_endorsement_auth.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_endorsement_auth.toml
@@ -18,12 +18,12 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Tpm"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 tcti = "mssim:host=127.0.0.1,port=2321"
 owner_hierarchy_auth = "hex:74706d5f70617373" # "tpm_pass" in hex

--- a/e2e_tests/tests/all_providers/config/tomls/no_slot_number.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_slot_number.toml
@@ -18,13 +18,13 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # Slot number not entered, it should be automatically chosen by the service.

--- a/e2e_tests/tests/all_providers/config/tomls/no_tpm_support.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_tpm_support.toml
@@ -12,17 +12,17 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "MbedCrypto"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 
 [[provider]]
 provider_type = "Tpm"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 # There shoudn't be a real TPM available on the CI
 tcti = "device"
 owner_hierarchy_auth = ""
@@ -30,7 +30,7 @@ skip_if_no_tpm = true
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number

--- a/e2e_tests/tests/all_providers/config/tomls/no_user_pin.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_user_pin.toml
@@ -18,13 +18,13 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 # The service should start without the user pin
 #user_pin = "123456"

--- a/e2e_tests/tests/all_providers/config/tomls/pkcs11_software.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/pkcs11_software.toml
@@ -18,13 +18,13 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 software_public_operations = true

--- a/e2e_tests/tests/all_providers/config/tomls/ts_pkcs11_cross.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/ts_pkcs11_cross.toml
@@ -18,17 +18,17 @@ socket_path = "/tmp/parsec.sock"
 auth_type = "Direct"
 
 [[key_manager]]
-name = "on-disk-manager"
-manager_type = "OnDisk"
-store_path = "./mappings"
+name = "sqlite-manager"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "TrustedService"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 
 [[provider]]
 provider_type = "Pkcs11"
-key_info_manager = "on-disk-manager"
+key_info_manager = "sqlite-manager"
 library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
 user_pin = "123456"
 software_public_operations = true

--- a/e2e_tests/tests/all_providers/config/tomls/various_field_check.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/various_field_check.toml
@@ -20,8 +20,8 @@ auth_type = "Direct"
 
 [[key_manager]]
 name = "I-want-to-speak-to-the-manager"
-manager_type = "OnDisk"
-store_path = "/tmp/the-mappings"
+manager_type = "SQLite"
+database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "MbedCrypto"

--- a/e2e_tests/tests/all_providers/cross.rs
+++ b/e2e_tests/tests/all_providers/cross.rs
@@ -15,6 +15,8 @@ const PLAINTEXT_MESSAGE: [u8; 32] = [
 ];
 
 pub fn setup_sign(provider: ProviderId, key_name: String) -> (TestClient, Vec<u8>, Vec<u8>) {
+    let key_name = get_key_name(key_name, provider);
+
     let mut client = TestClient::new();
     client.set_provider(provider);
     client.generate_rsa_sign_key(key_name.clone()).unwrap();
@@ -29,6 +31,8 @@ pub fn setup_sign(provider: ProviderId, key_name: String) -> (TestClient, Vec<u8
 }
 
 pub fn setup_sign_ecc(provider: ProviderId, key_name: String) -> (TestClient, Vec<u8>, Vec<u8>) {
+    let key_name = get_key_name(key_name, provider);
+
     let mut client = TestClient::new();
     client.set_provider(provider);
     client
@@ -45,6 +49,8 @@ pub fn setup_sign_ecc(provider: ProviderId, key_name: String) -> (TestClient, Ve
 }
 
 fn setup_asym_encr(provider: ProviderId, key_name: String) -> (TestClient, Vec<u8>) {
+    let key_name = get_key_name(key_name, provider);
+
     let mut client = TestClient::new();
     client.set_provider(provider);
     client
@@ -63,6 +69,8 @@ pub fn import_and_verify(
     pub_key: Vec<u8>,
     signature: Vec<u8>,
 ) {
+    let key_name = get_key_name(key_name, provider);
+
     client.set_provider(provider);
     client
         .import_rsa_public_key(key_name.clone(), pub_key)
@@ -79,6 +87,8 @@ pub fn import_and_verify_ecc(
     pub_key: Vec<u8>,
     signature: Vec<u8>,
 ) {
+    let key_name = get_key_name(key_name, provider);
+
     client.set_provider(provider);
     client
         .import_ecc_public_secp_r1_ecdsa_sha256_key(key_name.clone(), pub_key)
@@ -94,6 +104,8 @@ fn import_and_encrypt(
     key_name: String,
     pub_key: Vec<u8>,
 ) -> Result<Vec<u8>> {
+    let key_name = get_key_name(key_name, provider);
+
     client.set_provider(provider);
     client
         .import_rsa_public_key_for_encryption(key_name.clone(), pub_key)
@@ -107,8 +119,14 @@ fn verify_encrypt(
     key_name: String,
     ciphertext: Vec<u8>,
 ) -> Result<Vec<u8>> {
+    let key_name = get_key_name(key_name, provider);
+
     client.set_provider(provider);
     client.asymmetric_decrypt_message_with_rsapkcs1v15(key_name, ciphertext)
+}
+
+pub fn get_key_name(base_name: String, provider: ProviderId) -> String {
+    format!("{}-{}", provider, base_name)
 }
 
 #[test]


### PR DESCRIPTION
Making the SQLite KIM default for testing and configuration examples.
The change to testing involves replacing the on-disk KIM for
configuration tests, enabling cross tests and multitenancy tests for the
SQLite KIM, and making SQLite tests the default for `all-providers`.
Changes were needed for cross-provider tests now that key names cannot
be reused across providers, to generate unique key names at the test
level.

Fixes #531 