### PR TITLE
Add systemd hardening options

### DIFF
--- a/systemd-daemon/parsec.service
+++ b/systemd-daemon/parsec.service
@@ -5,6 +5,15 @@ Documentation=https://parallaxsecond.github.io/parsec-book/parsec_service/instal
 [Service]
 WorkingDirectory=/home/parsec/
 ExecStart=/usr/libexec/parsec/parsec --config /etc/parsec/config.toml
+# Systemd hardening
+ProtectSystem=full
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictRealtime=true
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Add the options suggested by the openSUSE maintainers (see #569 ) for
systemd hardening.

Fixes #569 - I'll continue to look through the [systemd option list](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) to see if anything else would make sense here.

cc @ggardet

