### PR TITLE
Change dependency revision for TSS crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,18 +340,18 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "enumflags2"
-version = "0.6.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8d82922337cd23a15f88b70d8e4ef5f11da38dd7cdb55e84dd5de99695da0"
+checksum = "a25c90b056b3f84111cf183cbeddef0d3a0bbe9a674f057e1a1533c315f24def"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.6.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
+checksum = "144ec79496cbab6f84fa125dc67be9264aef22eb8a28da8454d9c33f15108da4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -800,9 +800,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mbox"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3ae5479d6f010bca840f945a5ca2f3c343a74cccc98fcd13d62e176cf22361"
+checksum = "0f88d5c34d63aad11aa4321ef55ccb064af58b3ad8091079ae22bf83e5eb75d6"
 dependencies = [
  "libc",
  "rustc_version",
@@ -1109,6 +1109,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "petgraph"
@@ -1490,9 +1499,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver",
 ]
@@ -1551,18 +1560,21 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
 
 [[package]]
 name = "semver-parser"
-version = "0.7.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1894,8 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "7.0.0-alpha.1"
-source = "git+https://github.com/parallaxsecond/rust-tss-esapi.git?rev=62fb9b7b05b1e607518ae127406f3b85991205b9#62fb9b7b05b1e607518ae127406f3b85991205b9"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d038d648f74f57bc15d5c385e5fd8281b1228f268fc09ce1ca80d0772e6f9a55"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -1913,8 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi-sys"
-version = "0.2.0"
-source = "git+https://github.com/parallaxsecond/rust-tss-esapi.git?rev=62fb9b7b05b1e607518ae127406f3b85991205b9#62fb9b7b05b1e607518ae127406f3b85991205b9"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2f37914ec4d494d145cfa18bb8429498b238d63c47a08b89d09c1ec2545ff0"
 dependencies = [
  "pkg-config",
  "target-lexicon",
@@ -1925,6 +1939,12 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,18 +90,14 @@ dependencies = [
  "bitflags",
  "cexpr 0.4.0",
  "clang-sys",
- "clap",
- "env_logger 0.8.4",
  "lazy_static",
  "lazycell",
- "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex 0.1.1",
- "which 3.1.1",
 ]
 
 [[package]]
@@ -124,7 +120,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.1.0",
- "which 4.2.2",
+ "which",
 ]
 
 [[package]]
@@ -1303,7 +1299,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 4.2.2",
+ "which",
 ]
 
 [[package]]
@@ -1349,11 +1345,11 @@ dependencies = [
 
 [[package]]
 name = "psa-crypto-sys"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132bd26d57c55c7ae89114422ad0d95472a0620e99ed49ce00a418011535c9be"
+checksum = "d4d15edb7b3a473ea58bd77673c297229224c20068b8d6a1658f05e38f686b92"
 dependencies = [
- "bindgen 0.57.0",
+ "bindgen 0.59.2",
  "cc",
  "cmake",
  "walkdir",
@@ -2117,15 +2113,6 @@ checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "cryptoki"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dcf151ec0f80b3798687640a731829fee41723e5850eb75bc860c106f2dbfc2"
+checksum = "2a393de6688192bc237c6c948493aebccbede43e0cc239a74e14f34dfb400c43"
 dependencies = [
  "cryptoki-sys",
  "derivative",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "cryptoki-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a426b46cbf8e98cea0209767e5c601199369c593d83466ffbc541ac4e0a15f52"
+checksum = "aec220169d3b1705b54bce57e459873828e5c3bf0e25b96e5f2142acbbb71dda"
 dependencies = [
  "libloading",
  "target-lexicon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,8 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "parsec-interface"
-version = "0.25.0"
-source = "git+https://github.com/parallaxsecond/parsec-interface-rs?rev=9173f06b46ce583983b0df36a51fcb268ea818cd#9173f06b46ce583983b0df36a51fcb268ea818cd"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ad975a39f98e38b5897402887862df08b083fcfc7bdc209145b2f9851b165a"
 dependencies = [
  "bincode",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.5.8"
 serde = { version = "1.0.123", features = ["derive"] }
 env_logger = "0.8.3"
 log = { version = "0.4.14", features = ["serde"] }
-cryptoki = { version = "0.2.0", optional = true, features = ["psa-crypto-conversions"] }
+cryptoki = { version = "0.2.1", optional = true, features = ["psa-crypto-conversions"] }
 picky-asn1-der = { version = "<=0.2.4", optional = true }
 picky-asn1 = { version = ">=0.3.1, <=0.3.1", optional = true }
 tss-esapi = { version = "7.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.14", features = ["serde"] }
 cryptoki = { version = "0.2.0", optional = true, features = ["psa-crypto-conversions"] }
 picky-asn1-der = { version = "<=0.2.4", optional = true }
 picky-asn1 = { version = ">=0.3.1, <=0.3.1", optional = true }
-tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi.git", rev = "62fb9b7b05b1e607518ae127406f3b85991205b9", optional = true }
+tss-esapi = { version = "7.0.0", optional = true }
 bincode = "1.3.1"
 structopt = "0.3.21"
 derivative = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "parsec"
 path = "src/bin/main.rs"
 
 [dependencies]
-parsec-interface = { git = "https://github.com/parallaxsecond/parsec-interface-rs", rev = "9173f06b46ce583983b0df36a51fcb268ea818cd" }
+parsec-interface = "0.26.0"
 rand = { version = "0.8.3", features = ["small_rng"], optional = true }
 base64 = "0.13.0"
 uuid = "0.8.2"


### PR DESCRIPTION
Updating to the latest version of the TSS crate to verify that everything still works. Only a draft PR for now as 7.0.0 of the TSS crate has not been released.

- [x] There currently seems to be an issue with the legacy Rust compiler support. Needs to be rectified in the TSS crate. ( see https://github.com/parallaxsecond/parsec/runs/4869272668?check_suite_focus=true )

Fixes #567 