### PR TITLE
Bump SQLite dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.2"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+checksum = "d2cafc7c74096c336d9d27145f7ebd4f4b6f95ba16aa5a282387267e6925cb58"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1394,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.25.3"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
+checksum = "4ba4d3462c8b2e4d7f4fcfcf2b296dc6b65404fbbc7b63daa37fd485c149daf7"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ anyhow = "1.0.38"
 rust-cryptoauthlib = { version = "0.4.4", optional = true }
 spiffe = { version = "0.2.0", optional = true }
 prost = { version = "0.8.0", optional = true }
-rusqlite = { version = "0.25.3", features = ["bundled"] }
+rusqlite = { version = "0.26.3", features = ["bundled"] }
 num-traits = "0.2.14"
 
 [dev-dependencies]


### PR DESCRIPTION
Moving on from version 0.25.3 of `rusqlite` due to RUSTSEC-2021-0128.
See https://rustsec.org/advisories/RUSTSEC-2021-0128 .

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>