### PR TITLE
Updates for Release Candidate 2

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,6 @@
 [advisories]
-ignore = []
+ignore = ["RUSTSEC-2020-0159", # Issue has been documented here: https://github.com/parallaxsecond/parsec/security/advisories/GHSA-45w3-v3g4-54pm
+          "RUSTSEC-2020-0071"] # Issue has been documented here: https://github.com/parallaxsecond/parsec/security/advisories/GHSA-45w3-v3g4-54pm
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
 
@@ -19,7 +20,6 @@ show_tree = true # Show inverse dependency trees along with advisories
 
 # Target Configuration
 [target]
-arch = "x86_64" # Ignore advisories for CPU architectures other than this one
 os = "linux" # Ignore advisories for operating systems other than this one
 
 [packages]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,9 +416,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -441,15 +441,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -458,15 +458,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -475,21 +475,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ pkcs11-provider = ["cryptoki", "picky-asn1-der", "picky-asn1", "picky-asn1-x509"
 tpm-provider = ["tss-esapi", "picky-asn1-der", "picky-asn1", "picky-asn1-x509", "hex"]
 cryptoauthlib-provider = ["rust-cryptoauthlib"]
 trusted-service-provider = ["psa-crypto", "bindgen", "prost-build", "prost"]
-all-providers = ["tpm-provider", "pkcs11-provider", "mbed-crypto-provider", "cryptoauthlib-provider", "trusted-service-provider"]
+all-providers = ["tpm-provider", "pkcs11-provider", "mbed-crypto-provider", "trusted-service-provider"]
 
 # Authenticators
 direct-authenticator = []

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,10 +9,23 @@ disclosure of security problems are greatly appreciated and your contributions w
 Currently only the most recent version of the Parsec service is eligible for patching. This could
 change in the future.
 
-| Version         | Supported |
-|-----------------|-----------|
-| 0.7.0           | ✅       |
-| 0.6.0 and lower | ❌       |
+| Version          | Supported |
+|------------------|-----------|
+| 0.7.0 and higher | ✅       |
+| 0.6.0 and lower  | ❌       |
+
+## Our disclosure policy
+
+All security vulnerabilities affecting the Parsec service - including those reported using the steps
+highlighted below, those discovered during routine testing, and those found in our dependency tree
+either through `cargo-audit` or otherwise - will receive [security
+advisories](https://github.com/parallaxsecond/parsec/security/advisories) in a timely manner. The
+advisories should include sufficient information about the cause, effect, and possible mitigations
+for the vulnerability. If any information is missing, or you would like to raise a question about
+the advisories, please open an issue in [our repo](https://github.com/parallaxsecond/parsec).
+
+Efforts to mitigate for the reported vulnerabilities will be tracked using Github issues linked to
+the corresponding advisories.
 
 ## Reporting a vulnerability
 

--- a/e2e_tests/docker_image/parsec-service-test-cross-compile.Dockerfile
+++ b/e2e_tests/docker_image/parsec-service-test-cross-compile.Dockerfile
@@ -2,6 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM ghcr.io/parallaxsecond/parsec-service-test-all
 
+# Install aarch64-none-linux-gnu cross compilation toolchain
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz?revision=61c3be5d-5175-4db6-9030-b565aae9f766 -O aarch64-gcc.tar.xz
+RUN tar --strip-components=1 -C /usr/ -xvf aarch64-gcc.tar.xz
+RUN rm aarch64-gcc.tar.xz
+
+# Install Trusted Services lib compiled for aarch64
+# Setup git config for patching dependencies
+RUN git config --global user.email "some@email.com"
+RUN git config --global user.name "Parsec Team"
+RUN git clone https://git.trustedfirmware.org/TS/trusted-services.git --branch integration \
+    && cd trusted-services \
+    && git reset --hard 389b50624f25dae860bbbf8b16f75b32f1589c8d
+# Install correct python dependencies
+RUN pip3 install -r trusted-services/requirements.txt
+RUN cd trusted-services/deployments/libts/arm-linux/ \
+    && cmake . \
+    && make \
+    && cp libts.so* /usr/local/lib/
+RUN rm -rf trusted-services
+
 # Install cross-compilers
 RUN apt install -y gcc-multilib
 RUN apt install -y gcc-arm-linux-gnueabihf

--- a/e2e_tests/provider_cfg/all/config.toml
+++ b/e2e_tests/provider_cfg/all/config.toml
@@ -40,11 +40,13 @@ user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
 # slot_number
 
-[[provider]]
-provider_type = "CryptoAuthLib"
-key_info_manager = "sqlite-manager"
-device_type = "always-success"
-iface_type = "test-interface"
+
+# CAL provider and hardware abstraction crate are unmaintained; See #585
+# [[provider]]
+# provider_type = "CryptoAuthLib"
+# key_info_manager = "sqlite-manager"
+# device_type = "always-success"
+# iface_type = "test-interface"
 # wake_delay = 1500
 # rx_retries = 20
 # # i2c parameters for i2c-pseudo proxy

--- a/e2e_tests/provider_cfg/all/on-disk-kim-all-providers.toml
+++ b/e2e_tests/provider_cfg/all/on-disk-kim-all-providers.toml
@@ -40,11 +40,12 @@ user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
 # slot_number
 
-[[provider]]
-provider_type = "CryptoAuthLib"
-key_info_manager = "on-disk-manager"
-device_type = "always-success"
-iface_type = "test-interface"
+# CAL provider and hardware abstraction crate are unmaintained; See #585
+# [[provider]]
+# provider_type = "CryptoAuthLib"
+# key_info_manager = "on-disk-manager"
+# device_type = "always-success"
+# iface_type = "test-interface"
 # wake_delay = 1500
 # rx_retries = 20
 # # i2c parameters for i2c-pseudo proxy

--- a/e2e_tests/tests/all_providers/config/mod.rs
+++ b/e2e_tests/tests/all_providers/config/mod.rs
@@ -62,7 +62,8 @@ fn list_providers() {
             Uuid::parse_str("1c1139dc-ad7c-47dc-ad6b-db6fdb466552").unwrap(), // Mbed crypto provider
             Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap(), // Tpm provider
             Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap(), // Pkcs11 provider
-            Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap(), // CryptoAuthLib provider
+            // CAL provider and hardware abstraction crate are unmaintained; See #585
+            // Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap(), // CryptoAuthLib provider
             Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
         ]
     );
@@ -78,7 +79,8 @@ fn list_providers() {
             Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap(), // Pkcs11 provider
             Uuid::parse_str("1c1139dc-ad7c-47dc-ad6b-db6fdb466552").unwrap(), // Mbed crypto provider
             Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap(), // Tpm provider
-            Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap(), // CryptoAuthLib provider
+            // CAL provider and hardware abstraction crate are unmaintained; See #585
+            // Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap(), // CryptoAuthLib provider
             Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap(), // Core provider
         ]
     );

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
@@ -34,14 +34,15 @@ user_pin = "123456"
 # The slot_number mandatory field is going to replace the following line with a valid number
 # slot_number
 
-[[provider]]
-provider_type = "CryptoAuthLib"
-key_info_manager = "sqlite-manager"
-device_type = "always-success"
-iface_type = "test-interface"
-wake_delay = 1500
-rx_retries = 20
-# i2c parameters for i2c-pseudo proxy
-slave_address = 0xc0
-bus = 1
-baud = 400000
+# CAL provider and hardware abstraction crate are unmaintained; See #585
+# [[provider]]
+# provider_type = "CryptoAuthLib"
+# key_info_manager = "sqlite-manager"
+# device_type = "always-success"
+# iface_type = "test-interface"
+# wake_delay = 1500
+# rx_retries = 20
+# # i2c parameters for i2c-pseudo proxy
+# slave_address = 0xc0
+# bus = 1
+# baud = 400000

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
@@ -34,14 +34,15 @@ key_info_manager = "sqlite-manager"
 tcti = "mssim"
 owner_hierarchy_auth = "tpm_pass"
 
-[[provider]]
-provider_type = "CryptoAuthLib"
-key_info_manager = "sqlite-manager"
-device_type = "always-success"
-iface_type = "test-interface"
-wake_delay = 1500
-rx_retries = 20
-# i2c parameters for i2c-pseudo proxy
-slave_address = 0xc0
-bus = 1
-baud = 400000
+# CAL provider and hardware abstraction crate are unmaintained; See #585
+# [[provider]]
+# provider_type = "CryptoAuthLib"
+# key_info_manager = "sqlite-manager"
+# device_type = "always-success"
+# iface_type = "test-interface"
+# wake_delay = 1500
+# rx_retries = 20
+# # i2c parameters for i2c-pseudo proxy
+# slave_address = 0xc0
+# bus = 1
+# baud = 400000

--- a/e2e_tests/tests/all_providers/normal.rs
+++ b/e2e_tests/tests/all_providers/normal.rs
@@ -15,7 +15,7 @@ use std::iter::FromIterator;
 fn list_providers() {
     let mut client = TestClient::new();
     let providers = client.list_providers().expect("list providers failed");
-    assert_eq!(providers.len(), 5);
+    assert_eq!(providers.len(), 4);
     let uuids: HashSet<Uuid> = providers.iter().map(|p| p.uuid).collect();
     // Core provider
     assert!(uuids.contains(&Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap()));
@@ -25,8 +25,9 @@ fn list_providers() {
     assert!(uuids.contains(&Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap()));
     // TPM provider
     assert!(uuids.contains(&Uuid::parse_str("1e4954a4-ff21-46d3-ab0c-661eeb667e1d").unwrap()));
-    // CryptoAuthLib provider
-    assert!(uuids.contains(&Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap()));
+    // CAL provider and hardware abstraction crate are unmaintained; See #585
+    // // CryptoAuthLib provider
+    // assert!(uuids.contains(&Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap()));
 }
 
 #[test]
@@ -45,12 +46,13 @@ fn list_providers_order_respected() {
         providers[2].uuid,
         Uuid::parse_str("30e39502-eba6-4d60-a4af-c518b7f5e38f").unwrap()
     );
+    // CAL provider and hardware abstraction crate are unmaintained; See #585
+    // assert_eq!(
+    //     providers[3].uuid,
+    //     Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap()
+    // );
     assert_eq!(
         providers[3].uuid,
-        Uuid::parse_str("b8ba81e2-e9f7-4bdd-b096-a29d0019960c").unwrap()
-    );
-    assert_eq!(
-        providers[4].uuid,
         Uuid::parse_str("47049873-2a43-4845-9d72-831eab668784").unwrap()
     );
 }
@@ -101,9 +103,10 @@ fn list_opcodes() {
 
     let core_provider_opcodes = HashSet::from_iter(core_opcodes);
 
-    let mut crypto_providers_cal = HashSet::new();
-    // Not that much to be tested with test-interface
-    let _ = crypto_providers_cal.insert(Opcode::PsaGenerateRandom);
+    // CAL provider and hardware abstraction crate are unmaintained; See #585
+    // let mut crypto_providers_cal = HashSet::new();
+    // // Not that much to be tested with test-interface
+    // let _ = crypto_providers_cal.insert(Opcode::PsaGenerateRandom);
 
     let mut crypto_providers_tpm = HashSet::from_iter(common_opcodes.clone());
     let _ = crypto_providers_tpm.insert(Opcode::CanDoCrypto);
@@ -139,12 +142,13 @@ fn list_opcodes() {
             .expect("list providers failed"),
         crypto_providers_mbed_crypto
     );
-    assert_eq!(
-        client
-            .list_opcodes(ProviderId::CryptoAuthLib)
-            .expect("list providers failed"),
-        crypto_providers_cal
-    );
+    // CAL provider and hardware abstraction crate are unmaintained; See #585
+    // assert_eq!(
+    //     client
+    //         .list_opcodes(ProviderId::CryptoAuthLib)
+    //         .expect("list providers failed"),
+    //     crypto_providers_cal
+    // );
 }
 
 #[cfg(feature = "testing")]

--- a/e2e_tests/tests/per_provider/normal_tests/import_key.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/import_key.rs
@@ -127,9 +127,8 @@ fn create_and_import_rsa_key() -> Result<()> {
         return Ok(());
     }
 
-    let status;
     client.generate_rsa_sign_key(key_name.clone())?;
-    status = client
+    let status = client
         .import_rsa_public_key(key_name, KEY_DATA.to_vec())
         .expect_err("Key should have already existed");
     assert_eq!(status, ResponseStatus::PsaErrorAlreadyExists);

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -65,9 +65,6 @@ impl Provider {
         atca_iface: rust_cryptoauthlib::AtcaIfaceCfg,
         access_key_file_name: Option<String>,
     ) -> Option<Provider> {
-        // This will be returned when everything succeedes
-        let mut cryptoauthlib_provider: Provider;
-
         // First define communication channel with the device then set it up
         let device = match rust_cryptoauthlib::setup_atecc_device(atca_iface) {
             Ok(dev) => dev,
@@ -83,7 +80,7 @@ impl Provider {
             return None;
         }
 
-        cryptoauthlib_provider = Provider {
+        let mut cryptoauthlib_provider = Provider {
             device,
             provider_id: ProviderId::CryptoAuthLib,
             provider_identity: ProviderIdentity {
@@ -120,10 +117,10 @@ impl Provider {
         let mut to_remove: Vec<KeyIdentity> = Vec::new();
         match cryptoauthlib_provider.key_info_store.get_all() {
             Ok(key_identities) => {
-                for key_identity in key_identities.iter().cloned() {
+                for key_identity in key_identities.iter() {
                     match cryptoauthlib_provider
                         .key_info_store
-                        .does_not_exist(&key_identity)
+                        .does_not_exist(key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {
@@ -137,7 +134,7 @@ impl Provider {
                     };
                     let key_info_id = match cryptoauthlib_provider
                         .key_info_store
-                        .get_key_id::<u8>(&key_identity)
+                        .get_key_id::<u8>(key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {
@@ -151,7 +148,7 @@ impl Provider {
                     };
                     let key_info_attributes = match cryptoauthlib_provider
                         .key_info_store
-                        .get_key_attributes(&key_identity)
+                        .get_key_attributes(key_identity)
                     {
                         Ok(x) => x,
                         Err(err) => {

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -115,10 +115,10 @@ impl Provider {
             // Delete those who are not present and add to the local_store the ones present.
             match mbed_crypto_provider.key_info_store.get_all() {
                 Ok(key_identities) => {
-                    for key_identity in key_identities.iter().cloned() {
+                    for key_identity in key_identities.iter() {
                         let key_id = match mbed_crypto_provider
                             .key_info_store
-                            .get_key_id(&key_identity)
+                            .get_key_id(key_identity)
                         {
                             Ok(key_id) => key_id,
                             Err(response_status) => {

--- a/src/providers/trusted_service/mod.rs
+++ b/src/providers/trusted_service/mod.rs
@@ -95,8 +95,8 @@ impl Provider {
             // Delete those who are not present and add to the local_store the ones present.
             match ts_provider.key_info_store.get_all() {
                 Ok(key_identities) => {
-                    for key_identity in key_identities.iter().cloned() {
-                        let key_id = match ts_provider.key_info_store.get_key_id(&key_identity) {
+                    for key_identity in key_identities.iter() {
+                        let key_id = match ts_provider.key_info_store.get_key_id(key_identity) {
                             Ok(key_id) => key_id,
                             Err(response_status) => {
                                 error!("Error getting the Key ID for KeyIdentity:\n{}\n(error: {}), continuing...", key_identity, response_status);

--- a/test/cross-compile.sh
+++ b/test/cross-compile.sh
@@ -22,7 +22,9 @@ cargo build --features "pkcs11-provider, mbed-crypto-provider, tpm-provider, uni
 
 export SYSROOT=/tmp/aarch64-linux-gnu
 export RUSTFLAGS="-lcrypto -L/tmp/aarch64-linux-gnu/lib"
-cargo build --features "pkcs11-provider, mbed-crypto-provider, tpm-provider, unix-peer-credentials-authenticator, direct-authenticator" --target aarch64-unknown-linux-gnu
+# Pull in the TS code
+git submodule update --init
+cargo build --features "pkcs11-provider, mbed-crypto-provider, tpm-provider, trusted-service-provider, unix-peer-credentials-authenticator, direct-authenticator" --target aarch64-unknown-linux-gnu
 
 # This is needed because for some reason the i686/i386 libs aren't picked up if we don't toss them around just before...
 apt install -y libc6-dev-i386-amd64-cross


### PR DESCRIPTION
This commit makes a few cargo-audit-related changes:
* updates the lock file with newer, un-yanked versions of
futures-... crates
* Updates the cargo audit config file to ignore the
`chrono` and `time` issues.
* Updates the security policy to lay out our approach to
handling vulnerability reports.
* Remove the `cryptoauthlib-provider` from `all-providers`
* Add cross-compilation testing for the TS provider (for `aarch64-linux-gnu`)