### PR TITLE
Fix `cargo-audit` TOML config

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -22,9 +22,6 @@ show_tree = true # Show inverse dependency trees along with advisories
 [target]
 os = "linux" # Ignore advisories for operating systems other than this one
 
-[packages]
-source = "all" # "all", "public" or "local"
-
 [yanked]
 enabled = true # Warn for yanked crates in Cargo.lock
 update_index = true # Auto-update the crates.io index 


### PR DESCRIPTION
For the motivation to make this change, see [this](https://github.com/parallaxsecond/parsec/actions/runs/2374951502) run.