### PR TITLE
Change default socket path for E2E tests

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ This file aims to acknowledge the specific contributors referred to in the "Cont
 * Edmund Grimley Evans (@egrimley-arm)
 * Matt Davis (@MattDavis00)
 * Mohamed Omar Asaker (@mohamedasaker-arm)
+* Gowtham Suresh Kumar (@gowthamsk-arm)

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -17,6 +17,7 @@ log = "0.4.14"
 rand = "0.7.3"
 env_logger = "0.8.3"
 stdext = "0.3.1"
+tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi.git", rev = "62fb9b7b05b1e607518ae127406f3b85991205b9", optional = true }
 
 [dev-dependencies]
 ring = "0.16.20"
@@ -27,12 +28,11 @@ num_cpus = "1.13.0"
 picky-asn1-der = "0.2.4"
 picky-asn1 = "0.3.1"
 sha2 = "0.9.3"
-tss-esapi = { git = "https://github.com/parallaxsecond/rust-tss-esapi.git", rev = "62fb9b7b05b1e607518ae127406f3b85991205b9" }
 serial_test = "0.5.1"
 
 [features]
 mbed-crypto-provider = []
-tpm-provider = []
+tpm-provider = ["tss-esapi"]
 pkcs11-provider = []
 cryptoauthlib-provider = []
 trusted-service-provider = []

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -54,6 +54,10 @@ use parsec_client::core::interface::operations::psa_key_attributes::{
 use parsec_client::core::interface::requests::{Opcode, ProviderId, ResponseStatus, Result};
 use parsec_client::error::Error;
 use std::collections::HashSet;
+use std::env;
+use std::sync::Once;
+
+static INIT: Once = Once::new();
 
 /// Client structure automatically choosing a provider and high-level operation functions.
 #[derive(Debug)]
@@ -81,6 +85,13 @@ impl TestClient {
         {
             env_logger::try_init();
         }
+
+        INIT.call_once(|| {
+            //Check if the environment variable is set, if not use default path
+            if Err(env::VarError::NotPresent) == env::var("PARSEC_SERVICE_ENDPOINT") {
+                env::set_var("PARSEC_SERVICE_ENDPOINT", "unix:/tmp/parsec.sock");
+            }
+        });
 
         TestClient {
             basic_client: BasicClient::new(Some(String::from("root"))).unwrap(),


### PR DESCRIPTION
Fixes: #463 

This MR will allow the users to run the e2e tests without mandatorily setting the socket path environment variable. If unset a default path /tmp/parsec.sock will be used. 

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>