### PR TITLE
Send back PsaErrorInvalidPadding when needed

### DIFF
--- a/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
@@ -266,8 +266,31 @@ fn asym_encrypt_decrypt_rsa_pkcs_different_keys() {
     let ciphertext = client
         .asymmetric_encrypt_message_with_rsapkcs1v15(key_name_1, PLAINTEXT_MESSAGE.to_vec())
         .unwrap();
-    let res = client
+    let _res = client
         .asymmetric_decrypt_message_with_rsapkcs1v15(key_name_2, ciphertext)
+        .unwrap_err();
+}
+
+#[test]
+fn asym_decrypt_wrong_padding() {
+    let key_name = auto_test_keyname!();
+    let mut client = TestClient::new();
+
+    if !client.is_operation_supported(Opcode::PsaAsymmetricEncrypt)
+        || !client.is_operation_supported(Opcode::PsaAsymmetricDecrypt)
+    {
+        return;
+    }
+
+    client
+        .generate_rsa_encryption_keys_rsapkcs1v15crypt(key_name.clone())
+        .unwrap();
+    let mut ciphertext = client
+        .asymmetric_encrypt_message_with_rsapkcs1v15(key_name.clone(), PLAINTEXT_MESSAGE.to_vec())
+        .unwrap();
+    ciphertext[20] ^= 0x1;
+    let res = client
+        .asymmetric_decrypt_message_with_rsapkcs1v15(key_name, ciphertext)
         .unwrap_err();
     assert_eq!(res, ResponseStatus::PsaErrorInvalidPadding);
 }

--- a/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
@@ -266,9 +266,10 @@ fn asym_encrypt_decrypt_rsa_pkcs_different_keys() {
     let ciphertext = client
         .asymmetric_encrypt_message_with_rsapkcs1v15(key_name_1, PLAINTEXT_MESSAGE.to_vec())
         .unwrap();
-    let _res = client
+    let res = client
         .asymmetric_decrypt_message_with_rsapkcs1v15(key_name_2, ciphertext)
         .unwrap_err();
+    assert_eq!(res, ResponseStatus::PsaErrorInvalidPadding);
 }
 
 #[test]

--- a/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_encryption.rs
@@ -271,6 +271,10 @@ fn asym_encrypt_decrypt_rsa_pkcs_different_keys() {
         .unwrap_err();
 }
 
+// Test is disabled for PKCS11 provider since SoftHSMv2 does not
+// properly notify users of invalid padding.
+// See https://github.com/opendnssec/SoftHSMv2/issues/678
+#[cfg(not(feature = "pkcs11-provider"))]
 #[test]
 fn asym_decrypt_wrong_padding() {
     let key_name = auto_test_keyname!();

--- a/src/providers/tpm/asym_encryption.rs
+++ b/src/providers/tpm/asym_encryption.rs
@@ -3,10 +3,12 @@
 use super::{utils, Provider};
 use crate::authenticators::ApplicationIdentity;
 use crate::key_info_managers::KeyIdentity;
+use parsec_interface::operations::psa_algorithm::{Algorithm, AsymmetricEncryption};
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
-use parsec_interface::requests::Result;
+use parsec_interface::requests::{ResponseStatus, Result};
 use std::convert::TryInto;
 use std::ops::Deref;
+use tss_esapi::{constants::Tss2ResponseCodeKind, Error};
 
 impl Provider {
     pub(super) fn psa_asymmetric_encrypt_internal(
@@ -114,6 +116,22 @@ impl Provider {
                 plaintext: plaintext.value().to_vec().into(),
             }),
             Err(tss_error) => {
+                // If the algorithm is RSA with PKCS#1 v1.5 padding and we get TPM_RC_VALUE back,
+                // it means the padding has been deemed invalid and we should let the caller know
+                // about that. This allows clients to mitigate attacks that leverage padding
+                // oracles a la Bleichenbacher.
+                // See https://cryptosense.com/blog/why-pkcs1v1-5-encryption-should-be-put-out-of-our-misery
+                // for more details.
+                if let Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaPkcs1v15Crypt) =
+                    key_attributes.policy.permitted_algorithms
+                {
+                    if let Error::Tss2Error(e) = tss_error {
+                        if Some(Tss2ResponseCodeKind::Value) == e.kind() {
+                            format_error!("Wrong plaintext padding", tss_error);
+                            return Err(ResponseStatus::PsaErrorInvalidPadding);
+                        }
+                    }
+                }
                 let error = utils::to_response_status(tss_error);
                 format_error!("Encryption failed", tss_error);
                 Err(error)


### PR DESCRIPTION
This fixes #619

When we get a response code indicating an invalid padding from either a
TPM or a PKCS11 backend, we now convert that to PsaErrorInvalidPadding
so that clients can perform any mitigations they wish.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>