### PR TITLE
Fix Hugues' email address

### DIFF
--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -37,7 +37,7 @@
 
     [people.hug-dev]
     Name = "Hugues de Valon"
-    Email = "hugues.devalon@arm.com"
+    Email = "hugues.de-valon@einride.tech"
     GitHub = "hug-dev"
 
     [people.ionut-arm]


### PR DESCRIPTION
Signed-off-by: Hugues de Valon <hugues.de-valon@einride.tech>