### PR TITLE
Validate hash sign operation before execution.

### DIFF
--- a/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/asym_sign_verify.rs
@@ -335,7 +335,6 @@ fn sign_hash_bad_format_rsa_sha256() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(any(feature = "mbed-crypto-provider", feature = "trusted-service-provider")))]
 #[test]
 fn sign_hash_bad_format_ecdsa_sha256() -> Result<()> {
     let key_name = auto_test_keyname!();
@@ -536,7 +535,6 @@ fn verify_hash_bad_format_rsa() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(any(feature = "trusted-service-provider", feature = "mbed-crypto-provider")))]
 #[test]
 fn verify_hash_bad_format_ecc() -> Result<()> {
     let key_name = auto_test_keyname!();

--- a/src/providers/trusted_service/asym_sign.rs
+++ b/src/providers/trusted_service/asym_sign.rs
@@ -18,6 +18,8 @@ impl Provider {
             op.key_name.clone(),
         );
         let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
+        op.validate(key_attributes)?;
 
         Ok(psa_sign_hash::Result {
             signature: self
@@ -38,6 +40,8 @@ impl Provider {
             op.key_name.clone(),
         );
         let key_id = self.key_info_store.get_key_id(&key_identity)?;
+        let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
+        op.validate(key_attributes)?;
 
         self.context
             .verify_hash(key_id, op.hash.to_vec(), op.signature.to_vec(), op.alg)?;


### PR DESCRIPTION
The backend implementations should ideally perform all the hash length checks. Mbed Crypto doesn't implement the hash length checks on its side. This PR adds the changes required to validate the hash signing operation done for mbed-crypto and trusted services providers.

Fixes [#107](https://github.com/parallaxsecond/parsec-interface-rs/issues/107)

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>