### PR TITLE
Kim file permissions

### DIFF
--- a/src/key_info_managers/sqlite_manager/mod.rs
+++ b/src/key_info_managers/sqlite_manager/mod.rs
@@ -16,12 +16,18 @@ use rusqlite::types::Type::{Blob, Integer};
 use rusqlite::{params, Connection, Error as RusqliteError};
 use std::collections::HashMap;
 use std::fs;
+use std::fs::Permissions;
 use std::io::{Error, ErrorKind};
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 /// Default path where the database will be stored on disk
 pub const DEFAULT_DB_PATH: &str =
     "/var/lib/parsec/kim-mappings/sqlite/sqlite-key-info-manager.sqlite3";
+
+///File permissions for sqlite database
+///Should only be visible to parsec user
+pub const FILE_PERMISSION: u32 = 0o600;
 
 /// The current serialization version of the Attributes object.
 pub const CURRENT_KEY_ATTRIBUTES_VERSION: u8 = 1;
@@ -268,6 +274,9 @@ impl SQLiteKeyInfoManager {
                 key_store.len()
             );
         }
+
+        let permissions = Permissions::from_mode(FILE_PERMISSION);
+        fs::set_permissions(database_path.clone(), permissions)?;
 
         Ok(SQLiteKeyInfoManager {
             key_store,


### PR DESCRIPTION
Closes #598. 

The current key info manager files are not having any permissions set on them. This MR adds suitable permissions to directories and files of the KIM and also adds unit tests to verify if the permissions set are correct.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>