### PR TITLE
build and share docker image across jobs

### DIFF
--- a/.github/actions/load_docker/action.yml
+++ b/.github/actions/load_docker/action.yml
@@ -1,0 +1,22 @@
+name: "Load docker image"
+description: "Load docker image"
+inputs:
+   image-name:
+      required: true
+      description: "Docker image name"
+   image-path:
+      required: true
+      description: "Path to save the docker image"
+# ...name, description and inputs as above
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - name: Download artifact
+      uses: actions/download-artifact@v3
+      with:
+          name: ${{ inputs.image-name }}
+          path: ${{ inputs.image-path }}
+    - name: Load image
+      run: docker load --input ${{ inputs.image-path }}/${{ inputs.image-name }}.tar
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      # Use the following step when updating the `parsec-service-test-all` image
     - name: Build the docker container
       run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
     - name: Export the docker container
@@ -23,13 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         # run:
         #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec
@@ -42,13 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         # run:
         #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cargo-check
@@ -60,13 +55,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         # run:
         #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
@@ -78,13 +71,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         # Not running stress tests because they fail, presumably because of the same issue as #264
         # run:
@@ -97,13 +88,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         # run:
         #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh tpm
@@ -115,13 +104,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         # run:
         #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh trusted-service
@@ -133,13 +120,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
         # run:
@@ -152,13 +137,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the fuzz test script
         # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
         # run: ./fuzz.sh test
@@ -170,13 +153,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         # run:
         #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
@@ -189,13 +170,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Load Docker
+        uses: ./.github/actions/load_docker
         with:
-          name: parsec-service-test-all
-          path: /tmp
-      - name: Load docker image
-        run:  docker load --input /tmp/parsec-service-test-all.tar
+          image-name: "parsec-service-test-all"
+          image-path: "/tmp"
       - name: Run the container to execute the test script
         run:
           docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-cross-compile /tmp/parsec/test/cross-compile.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,18 @@ name: Continuous Integration
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  DOCKER_IMAGE: 'parsec-service-test-all'
+  # DOCKER_IMAGE: 'ghcr.io/parallaxsecond/parsec-service-test-all'
+
 jobs:
-  build-and-export-docker:
+  build-and-export-test-all-docker:
     runs-on: ubuntu-latest
+    # If DOCKER_IMAGE is 'parsec-service-test-all' or any local image,
+    # the following condition must evaluate true to execute this job
+    # Else it must evaluate false to NOT execute this job
+    # Unfortunately, env.DOCKER_IMAGE cannot be used here as the `env` context is not recognize at this level.
+    if: ${{ true }} # env.DOCKER_IMAGE == 'parsec-service-test-all'
     steps:
     - uses: actions/checkout@v3
     - name: Build the docker container
@@ -20,149 +29,154 @@ jobs:
   all-providers:
     name: Various tests targeting a Parsec image with all providers included
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        # run:
-        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec
-        #   ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh all
-      # When running the container built on the CI
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh all
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh all
 
   build-all-providers:
     name: Cargo check all-providers (current Rust stable & old compiler)
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        # run:
-        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cargo-check
-      # When running the container built on the CI
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cargo-check
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh cargo-check
 
   mbed-crypto-provider:
     name: Integration tests using Mbed Crypto provider
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        # run:
-        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
-      # When running the container built on the CI
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh mbed-crypto
 
   pkcs11-provider:
     name: Integration tests using PKCS 11 provider
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        # Not running stress tests because they fail, presumably because of the same issue as #264
-        # run:
-        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
-      # When running the container built on the CI
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh pkcs11 --no-stress-test
 
   tpm-provider:
     name: Integration tests using TPM provider
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        # run:
-        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh tpm
-      # When running the container built on the CI
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh tpm
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh tpm
 
   trusted-service-provider:
     name: Integration tests using Crypto Trusted Service provider
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        # run:
-        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh trusted-service
-        # When running the container built on the CI
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh trusted-service
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh trusted-service
 
   cryptoauthlib-provider:
     name: Integration tests using CryptoAuthentication Library provider
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
-        # run:
-        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
-      # When running the container built on the CI
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
 
   fuzz-test-checker:
     name: Check that the fuzz testing framework is still working
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
-      - name: Run the fuzz test script
+      - name: Run the container to execute the test script
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh
         # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
-        # run: ./fuzz.sh test
-      # When running the container built on the CI
+      - name: Run the fuzz test script From Container
+        # When running the container built on the CI
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         run: CONTAINER_TAG=parsec-service-test-all ./fuzz.sh test
+      - name: Run the fuzz test script
+        if: ${{ env.DOCKER_IMAGE != 'parsec-service-test-all' }}
+        run: ./fuzz.sh test
 
   on-disk-kim:
     name: OnDiskKIM E2E tests on all providers
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
     steps:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
+        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        # run:
-        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
-      # When running the container built on the CI
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh on-disk-kim
 
   cross-compilation:
     # Currently only the Mbed Crypto, PKCS 11, and TPM providers are tested as the other ones need to cross-compile other libraries.
@@ -173,7 +187,7 @@ jobs:
       - name: Load Docker
         uses: ./.github/actions/load_docker
         with:
-          image-name: "parsec-service-test-all"
+          image-name: "${{ env.DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     # If TEST_ALL_DOCKER_IMAGE is 'parsec-service-test-all' or any local image,
     # the following condition must evaluate true to execute this job
     # Else it must evaluate false to NOT execute this job
-    # Unfortunately, env.TEST_ALL_DOCKER_IMAGE cannot be used here as the `env` context is not recognize at this level.
+    # Unfortunately, env.TEST_ALL_DOCKER_IMAGE cannot be used here as the `env` context is not recognized at this level.
     if: ${{ false }} # env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all'
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,134 +3,185 @@ name: Continuous Integration
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
+  build-and-export-docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      # Use the following step when updating the `parsec-service-test-all` image
+    - name: Build the docker container
+      run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+    - name: Export the docker container
+      run: docker save parsec-service-test-all > /tmp/parsec-service-test-all.tar
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: parsec-service-test-all
+        path: /tmp/parsec-service-test-all.tar
+
   all-providers:
     name: Various tests targeting a Parsec image with all providers included
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
-        run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec
-          ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh all
+        # run:
+        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec
+        #   ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh all
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh all
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh all
 
   build-all-providers:
     name: Cargo check all-providers (current Rust stable & old compiler)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
-        run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cargo-check
+        # run:
+        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cargo-check
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cargo-check
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cargo-check
 
   mbed-crypto-provider:
     name: Integration tests using Mbed Crypto provider
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
-        run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
+        # run:
+        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh mbed-crypto
 
   pkcs11-provider:
     name: Integration tests using PKCS 11 provider
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
         # Not running stress tests because they fail, presumably because of the same issue as #264
-        run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
+        # run:
+        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh pkcs11 --no-stress-test
 
   tpm-provider:
     name: Integration tests using TPM provider
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
-        run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh tpm
+        # run:
+        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh tpm
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh tpm
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh tpm
 
   trusted-service-provider:
     name: Integration tests using Crypto Trusted Service provider
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
-        run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh trusted-service
+        # run:
+        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh trusted-service
         # When running the container built on the CI
-        # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh trusted-service
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh trusted-service
 
   cryptoauthlib-provider:
     name: Integration tests using CryptoAuthentication Library provider
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
         # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
-        run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
+        # run:
+        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
 
   fuzz-test-checker:
     name: Check that the fuzz testing framework is still working
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the fuzz test script
         # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
-        run: ./fuzz.sh test
+        # run: ./fuzz.sh test
       # When running the container built on the CI
-      # run: CONTAINER_TAG=parsec-service-test-all ./fuzz.sh test
+        run: CONTAINER_TAG=parsec-service-test-all ./fuzz.sh test
 
   on-disk-kim:
     name: OnDiskKIM E2E tests on all providers
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-all` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-all -f parsec-service-test-all.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
-        run:
-          docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
+        # run:
+        #   docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
       # When running the container built on the CI
-      # run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t parsec-service-test-all /tmp/parsec/ci.sh on-disk-kim
 
   cross-compilation:
     # Currently only the Mbed Crypto, PKCS 11, and TPM providers are tested as the other ones need to cross-compile other libraries.
@@ -138,9 +189,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Use the following step when updating the `parsec-service-test-cross-compile` image
-      # - name: Build the container
-      #   run: pushd e2e_tests/docker_image && docker build -t parsec-service-test-cross-compile -f parsec-service-test-cross-compile.Dockerfile . && popd
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: parsec-service-test-all
+          path: /tmp
+      - name: Load docker image
+        run:  docker load --input /tmp/parsec-service-test-all.tar
       - name: Run the container to execute the test script
         run:
           docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-cross-compile /tmp/parsec/test/cross-compile.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,6 @@ jobs:
         with:
           image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
-      - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh
         # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
       - name: Run the fuzz test script From Container
         # When running the container built on the CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: Continuous Integration
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  TEST_ALL_DOCKER_IMAGE: 'parsec-service-test-all'
-  # TEST_ALL_DOCKER_IMAGE: 'ghcr.io/parallaxsecond/parsec-service-test-all'
+  # TEST_ALL_DOCKER_IMAGE: 'parsec-service-test-all'
+  TEST_ALL_DOCKER_IMAGE: 'ghcr.io/parallaxsecond/parsec-service-test-all'
 
 jobs:
   build-and-export-test-all-docker:
@@ -13,7 +13,7 @@ jobs:
     # the following condition must evaluate true to execute this job
     # Else it must evaluate false to NOT execute this job
     # Unfortunately, env.TEST_ALL_DOCKER_IMAGE cannot be used here as the `env` context is not recognize at this level.
-    if: ${{ true }} # env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all'
+    if: ${{ false }} # env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all'
     steps:
     - uses: actions/checkout@v3
     - name: Build the docker container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,17 @@ name: Continuous Integration
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  DOCKER_IMAGE: 'parsec-service-test-all'
-  # DOCKER_IMAGE: 'ghcr.io/parallaxsecond/parsec-service-test-all'
+  TEST_ALL_DOCKER_IMAGE: 'parsec-service-test-all'
+  # TEST_ALL_DOCKER_IMAGE: 'ghcr.io/parallaxsecond/parsec-service-test-all'
 
 jobs:
   build-and-export-test-all-docker:
     runs-on: ubuntu-latest
-    # If DOCKER_IMAGE is 'parsec-service-test-all' or any local image,
+    # If TEST_ALL_DOCKER_IMAGE is 'parsec-service-test-all' or any local image,
     # the following condition must evaluate true to execute this job
     # Else it must evaluate false to NOT execute this job
-    # Unfortunately, env.DOCKER_IMAGE cannot be used here as the `env` context is not recognize at this level.
-    if: ${{ true }} # env.DOCKER_IMAGE == 'parsec-service-test-all'
+    # Unfortunately, env.TEST_ALL_DOCKER_IMAGE cannot be used here as the `env` context is not recognize at this level.
+    if: ${{ true }} # env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all'
     steps:
     - uses: actions/checkout@v3
     - name: Build the docker container
@@ -35,12 +35,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh all
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh all
 
   build-all-providers:
     name: Cargo check all-providers (current Rust stable & old compiler)
@@ -51,12 +51,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh cargo-check
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh cargo-check
 
   mbed-crypto-provider:
     name: Integration tests using Mbed Crypto provider
@@ -67,12 +67,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh mbed-crypto
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh mbed-crypto
 
   pkcs11-provider:
     name: Integration tests using PKCS 11 provider
@@ -83,12 +83,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh pkcs11 --no-stress-test
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh pkcs11 --no-stress-test
 
   tpm-provider:
     name: Integration tests using TPM provider
@@ -99,12 +99,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh tpm
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh tpm
 
   trusted-service-provider:
     name: Integration tests using Crypto Trusted Service provider
@@ -115,12 +115,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh trusted-service
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh trusted-service
 
   cryptoauthlib-provider:
     name: Integration tests using CryptoAuthentication Library provider
@@ -131,12 +131,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
 
   fuzz-test-checker:
     name: Check that the fuzz testing framework is still working
@@ -147,19 +147,19 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh
         # Not running stress tests because rust-cryptoauthlib test-interface does not support required calls
       - name: Run the fuzz test script From Container
         # When running the container built on the CI
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         run: CONTAINER_TAG=parsec-service-test-all ./fuzz.sh test
       - name: Run the fuzz test script
-        if: ${{ env.DOCKER_IMAGE != 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE != 'parsec-service-test-all' }}
         run: ./fuzz.sh test
 
   on-disk-kim:
@@ -171,12 +171,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Load Docker
         uses: ./.github/actions/load_docker
-        if: ${{ env.DOCKER_IMAGE == 'parsec-service-test-all' }}
+        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
         with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
+          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
           image-path: "/tmp"
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.DOCKER_IMAGE }} /tmp/parsec/ci.sh on-disk-kim
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh on-disk-kim
 
   cross-compilation:
     # Currently only the Mbed Crypto, PKCS 11, and TPM providers are tested as the other ones need to cross-compile other libraries.
@@ -184,11 +184,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        with:
-          image-name: "${{ env.DOCKER_IMAGE }}"
-          image-path: "/tmp"
       - name: Run the container to execute the test script
         run:
           docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-cross-compile /tmp/parsec/test/cross-compile.sh


### PR DESCRIPTION
The motive for this change is:
Whenever the docker image needs to be updated, test these changes on the CI
Then we enable building the docker image and run it for each job, as jobs in the workflow don't share the local docker registry.
This change is to build the docker and export it to be used across the workflow jobs.
