### PR TITLE
Add `Eq` to the types with `PartialEq`

### DIFF
--- a/src/providers/cryptoauthlib/key_slot.rs
+++ b/src/providers/cryptoauthlib/key_slot.rs
@@ -7,7 +7,7 @@ use parsec_interface::operations::psa_algorithm::{
 use parsec_interface::operations::psa_key_attributes::{Attributes, EccFamily, Type};
 use parsec_interface::requests::{Opcode, ResponseStatus};
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// Software status of a ATECC slot
 pub enum KeySlotStatus {
     /// Slot is free

--- a/src/providers/trusted_service/context/error.rs
+++ b/src/providers/trusted_service/context/error.rs
@@ -86,7 +86,7 @@ impl ErrorTrait for Error {
 
 /// Native representation of errors returned by the
 /// RPC caller
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RpcCallerError {
     /// endpoint for connecting to Trusted Services does not exist
     EndpointDoesNotExist,
@@ -170,7 +170,7 @@ impl fmt::Display for RpcCallerError {
 impl ErrorTrait for RpcCallerError {}
 
 /// Errors returned by this wrapper layer
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WrapperError {
     /// call handle returned by RPC layer was null
     CallHandleNull,


### PR DESCRIPTION
New clippy lint demands that all types with `PartialEq` derived should
also have `Eq`.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>