### PR TITLE
Add sqlite stability tests

### DIFF
--- a/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
+++ b/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
@@ -117,9 +117,9 @@ ENV LD_LIBRARY_PATH="/usr/local/lib"
 # Individual tests might change that, but set the default after.
 ENV PARSEC_SERVICE_ENDPOINT="unix:/tmp/parsec.sock"
 
-# Generate keys for the key mappings test
+# Generate keys for the key mappings test for ondisk KIM
 COPY generate-keys.sh /tmp/
-RUN ./generate-keys.sh
+RUN ./generate-keys.sh ondisk
 
 # Install mock Trusted Services
 RUN git clone https://git.trustedfirmware.org/TS/trusted-services.git --branch integration \
@@ -132,6 +132,9 @@ RUN cd trusted-services/deployments/libts/linux-pc/ \
 	&& make \
 	&& cp libts.so* nanopb_install/lib/libprotobuf-nanopb.a mbedtls_install/lib/libmbedcrypto.a /usr/local/lib/
 RUN rm -rf trusted-services
+
+# Generate keys for the key mappings test for sqlite KIM
+RUN ./generate-keys.sh sqlite
 
 # Import an old version of the e2e tests
 COPY import-old-e2e-tests.sh /tmp/

--- a/e2e_tests/provider_cfg/all/config.toml
+++ b/e2e_tests/provider_cfg/all/config.toml
@@ -20,7 +20,7 @@ admins = [ { name = "list_clients test" }, { name = "1000" }, { name = "client1"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "MbedCrypto"

--- a/e2e_tests/provider_cfg/cryptoauthlib/config-sqlite.toml
+++ b/e2e_tests/provider_cfg/cryptoauthlib/config-sqlite.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
+[listener]
+listener_type = "DomainSocket"
+timeout = 200 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "sqlite-manager"
+manager_type = "SQLite"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+
+[[provider]]
+provider_type = "CryptoAuthLib"
+key_info_manager = "sqlite-manager"
+device_type = "unimplemented-fail"
+iface_type = "test-interface"

--- a/e2e_tests/provider_cfg/mbed-crypto/config-sqlite.toml
+++ b/e2e_tests/provider_cfg/mbed-crypto/config-sqlite.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
+[listener]
+listener_type = "DomainSocket"
+# The timeout needs to be smaller than the test client timeout (five seconds) as it is testing
+# that the service does not hang for very big values of body or authentication length.
+timeout = 3000 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "sqlite-manager"
+manager_type = "SQLite"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+
+[[provider]]
+provider_type = "MbedCrypto"
+key_info_manager = "sqlite-manager"

--- a/e2e_tests/provider_cfg/pkcs11/config-sqlite.toml
+++ b/e2e_tests/provider_cfg/pkcs11/config-sqlite.toml
@@ -1,0 +1,34 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
+[listener]
+listener_type = "DomainSocket"
+# The timeout needs to be smaller than the test client timeout (five seconds) as it is testing
+# that the service does not hang for very big values of body or authentication length.
+timeout = 3000 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "sqlite-manager"
+manager_type = "SQLite"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+
+[[provider]]
+provider_type = "Pkcs11"
+key_info_manager = "sqlite-manager"
+library_path = "/usr/local/lib/softhsm/libsofthsm2.so"
+user_pin = "123456"
+software_public_operations = false
+# The slot_number optional field is going to replace the following line with a valid number
+# slot_number
+# The token serial_number optional field is going to replace the following line with a valid number
+# serial_number

--- a/e2e_tests/provider_cfg/tpm/config-sqlite.toml
+++ b/e2e_tests/provider_cfg/tpm/config-sqlite.toml
@@ -1,0 +1,30 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
+[listener]
+listener_type = "DomainSocket"
+# The timeout needs to be smaller than the test client timeout (five seconds) as it is testing
+# that the service does not hang for very big values of body or authentication length.
+timeout = 3000 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "sqlite-manager"
+manager_type = "SQLite"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+
+[[provider]]
+provider_type = "Tpm"
+key_info_manager = "sqlite-manager"
+tcti = "mssim:host=127.0.0.1,port=2321"
+owner_hierarchy_auth = "hex:74706d5f70617373" # "tpm_pass" in hex
+endorsement_hierarchy_auth = "str:endorsement_pass"

--- a/e2e_tests/provider_cfg/trusted-service/config-sqlite.toml
+++ b/e2e_tests/provider_cfg/trusted-service/config-sqlite.toml
@@ -1,0 +1,27 @@
+[core_settings]
+# The CI already timestamps the logs
+log_timestamp = false
+log_error_details = true
+
+# The container runs the Parsec service as root, so make sure we disable root
+# checks.
+allow_root = true
+
+[listener]
+listener_type = "DomainSocket"
+# The timeout needs to be smaller than the test client timeout (five seconds) as it is testing
+# that the service does not hang for very big values of body or authentication length.
+timeout = 3000 # in milliseconds
+socket_path = "/tmp/parsec.sock"
+
+[authenticator]
+auth_type = "Direct"
+
+[[key_manager]]
+name = "sqlite-manager"
+manager_type = "SQLite"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+
+[[provider]]
+provider_type = "TrustedService"
+key_info_manager = "sqlite-manager"

--- a/e2e_tests/tests/all_providers/config/tomls/allow_export.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/allow_export.toml
@@ -14,7 +14,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_1.toml
@@ -14,7 +14,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "MbedCrypto"

--- a/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/list_providers_2.toml
@@ -14,7 +14,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/no_endorsement_auth.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_endorsement_auth.toml
@@ -20,7 +20,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Tpm"

--- a/e2e_tests/tests/all_providers/config/tomls/no_serial_or_slot_number.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_serial_or_slot_number.toml
@@ -20,7 +20,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/no_tpm_support.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_tpm_support.toml
@@ -14,7 +14,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "MbedCrypto"

--- a/e2e_tests/tests/all_providers/config/tomls/no_user_pin.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/no_user_pin.toml
@@ -20,7 +20,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/pkcs11_software.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/pkcs11_software.toml
@@ -21,7 +21,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/serial_number_only.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/serial_number_only.toml
@@ -20,7 +20,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/serial_number_padding.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/serial_number_padding.toml
@@ -20,7 +20,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/slot_number_only.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/slot_number_only.toml
@@ -20,7 +20,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/slot_numbers_mismatch.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/slot_numbers_mismatch.toml
@@ -20,7 +20,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "Pkcs11"

--- a/e2e_tests/tests/all_providers/config/tomls/ts_pkcs11_cross.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/ts_pkcs11_cross.toml
@@ -20,7 +20,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "sqlite-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "TrustedService"

--- a/e2e_tests/tests/all_providers/config/tomls/various_field_check.toml
+++ b/e2e_tests/tests/all_providers/config/tomls/various_field_check.toml
@@ -21,7 +21,7 @@ auth_type = "Direct"
 [[key_manager]]
 name = "I-want-to-speak-to-the-manager"
 manager_type = "SQLite"
-database_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
+sqlite_db_path = "./kim-mappings/sqlite/sqlite-key-info-manager.sqlite3"
 
 [[provider]]
 provider_type = "MbedCrypto"

--- a/e2e_tests/tests/per_provider/key_mappings.rs
+++ b/e2e_tests/tests/per_provider/key_mappings.rs
@@ -30,7 +30,7 @@ fn use_and_check() -> Result<()> {
     assert!(!keys.is_empty());
 
     for key in keys {
-        if key.name == "rsa" {
+        if key.name.contains("rsa") {
             let ciphertext = client
                 .asymmetric_encrypt_message_with_rsapkcs1v15(
                     key.name.clone(),
@@ -41,7 +41,7 @@ fn use_and_check() -> Result<()> {
                 .asymmetric_decrypt_message_with_rsapkcs1v15(key.name.clone(), ciphertext)
                 .unwrap();
             assert_eq!(PLAINTEXT_MESSAGE.to_vec(), plaintext);
-        } else if key.name == "ecc" {
+        } else if key.name.contains("ecc") {
             let signature = client.sign_with_ecdsa_sha256(key.name.clone(), HASH.to_vec())?;
             client.verify_with_ecdsa_sha256(key.name.clone(), HASH.to_vec(), signature)?;
         } else {

--- a/src/key_info_managers/mod.rs
+++ b/src/key_info_managers/mod.rs
@@ -105,7 +105,7 @@ impl KeyIdentity {
         &self.application
     }
 
-    /// Get the application identity of the key
+    /// Get the provider identity of the key
     pub fn provider(&self) -> &ProviderIdentity {
         &self.provider
     }

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -126,7 +126,7 @@ impl ServiceBuilder {
             warn!("Direct authenticator has been set as the default one. It is only secure under specific requirements. Please make sure to read the Recommendations on a Secure Parsec Deployment at https://parallaxsecond.github.io/parsec-book/parsec_security/secure_deployment.html");
         }
 
-        let key_info_manager_builders = gey_key_info_manager_builders(
+        let key_info_manager_builders = get_key_info_manager_builders(
             config.key_manager.as_ref().unwrap_or(&Vec::new()),
             authenticators[0].0,
         )?;
@@ -454,7 +454,7 @@ unsafe fn get_provider(
     }
 }
 
-fn gey_key_info_manager_builders(
+fn get_key_info_manager_builders(
     configs: &[KeyInfoManagerConfig],
     default_auth_type: AuthType,
 ) -> Result<HashMap<String, KeyInfoManagerFactory>> {


### PR DESCRIPTION
This MR will add stability tests for the sqlite key info managers. The generate keys script has been modified to generate the sqlite 
 database keys and then use them for testing.

Closes #[519](https://github.com/parallaxsecond/parsec/issues/519)

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>