### PR TITLE
Bump sd-notify to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ base64 = "0.13.0"
 uuid = "0.8.2"
 threadpool = "1.8.1"
 signal-hook = "0.3.4"
-sd-notify = "0.2.0"
+sd-notify = "0.4.1"
 toml = "0.5.8"
 serde = { version = "1.0.123", features = ["derive"] }
 env_logger = "0.8.3"


### PR DESCRIPTION
In order to package Parsec in Debian we need to package up the dependencies. One dependency is sd-notify which, when updated, has a breaking API change.

Specifically, listen_fds() now returns an iterator of fds rather than a count of fds. Also SD_LISTEN_FDS_START is no longer exposed publicly and is instead the first value in the iterator returned by listen_fds().

Signed-off-by: Steve Capper <steve.capper@arm.com>