### PR TITLE
Fix Clippy warnings for rustc version 1.65

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -393,7 +393,8 @@ if [ "$PROVIDER_NAME" = "all" ]; then
     # Needed because parsec-client-1 and 2 write to those locations owned by root
     chmod 777 /tmp/parsec/e2e_tests
     chmod 777 /tmp/
-    chmod -R 777 /opt/rust/registry
+    chmod -R 775 /opt/rust/registry
+    chgrp -R parsec-clients /opt/rust/registry
 
     # PATH is defined before each command for user to use their own version of the Rust toolchain
     su -c "PATH=\"/home/parsec-client-1/.cargo/bin:${PATH}\";RUST_BACKTRACE=1 cargo test $TEST_FEATURES --manifest-path ./e2e_tests/Cargo.toml --target-dir /home/parsec-client-1 all_providers::multitenancy::client1_before" parsec-client-1

--- a/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
+++ b/e2e_tests/docker_image/parsec-service-test-all.Dockerfile
@@ -16,7 +16,6 @@ RUN apt install -y --fix-missing wget python3 cmake clang
 RUN apt install -y libini-config-dev libcurl4-openssl-dev curl libgcc1
 RUN apt install -y python3-distutils libclang-6.0-dev protobuf-compiler python3-pip
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
-
 WORKDIR /tmp
 
 # Download and install TSS 2.0
@@ -107,8 +106,13 @@ COPY _exec_wrapper /usr/local/bin/
 RUN ls /opt/rust/bin | xargs -n1 -I% ln -s /usr/local/bin/_exec_wrapper /usr/local/bin/$(basename %)
 
 # Add users for multitenancy tests
-RUN useradd -m parsec-client-1
-RUN useradd -m parsec-client-2
+RUN useradd -m parsec-client-1 \
+ && useradd -m parsec-client-2 \
+ && groupadd parsec-clients \
+ && usermod -g parsec-clients parsec-client-1 \
+ && usermod -g parsec-clients parsec-client-2 \
+ && sed -i '/^UMASK/s/022/002/' /etc/login.defs
+
 
 # Add `/usr/local/lib` to library path for Trusted service provider
 ENV LD_LIBRARY_PATH="/usr/local/lib"

--- a/src/back/backend_handler.rs
+++ b/src/back/backend_handler.rs
@@ -97,8 +97,7 @@ impl BackEndHandler {
         }
 
         if opcode.is_admin() {
-            let app =
-                unwrap_or_else_return!((&app).as_ref().ok_or(ResponseStatus::NotAuthenticated));
+            let app = unwrap_or_else_return!(app.as_ref().ok_or(ResponseStatus::NotAuthenticated));
 
             if !app.is_admin() {
                 warn!(

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -395,7 +395,7 @@ impl OnDiskKeyInfoManager {
             for provider_dir_path in list_dirs(app_name_dir_path)?.iter() {
                 for key_name_file_path in list_files(provider_dir_path)?.iter() {
                     let mut key_info = Vec::new();
-                    let mut key_info_file = File::open(&key_name_file_path).with_context(|| {
+                    let mut key_info_file = File::open(key_name_file_path).with_context(|| {
                         format!(
                             "Failed to open Key Info Mappings file at {:?}",
                             key_name_file_path

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -191,7 +191,7 @@ impl Provider {
             }
         }
 
-        if None == cryptoauthlib_provider.set_opcodes() {
+        if cryptoauthlib_provider.set_opcodes().is_none() {
             warn!("Failed to setup opcodes for cryptoauthlib_provider");
         }
 


### PR DESCRIPTION
Two warnings have been introduced, and both are from the category: needless_borrow
This commit is to remove the needless borrow

```
error: this expression borrows a value the compiler would automatically borrow
   --> src/back/backend_handler.rs:101:40
    |
101 |                 unwrap_or_else_return!((&app).as_ref().ok_or(ResponseStatus::NotAuthenticated));
    |                                        ^^^^^^ help: change this to: `app`
    |
    = note: `-D clippy::needless-borrow` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
   --> src/key_info_managers/on_disk_manager/mod.rs:398:56
    |
398 |                     let mut key_info_file = File::open(&key_name_file_path).with_context(|| {
    |                                                        ^^^^^^^^^^^^^^^^^^^ help: change this to: `key_name_file_path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: could not compile `parsec-service` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `parsec-service` due to 2 previous errors
```

Signed-off-by: Mohamed Omar Asaker <mohamed.omarasaker@arm.com>