### PR TITLE
Remove dependency on crate "version"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,6 @@ dependencies = [
  "tss-esapi",
  "users",
  "uuid",
- "version",
  "zeroize",
 ]
 
@@ -1905,12 +1904,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a449064fee414fcc201356a3e6c1510f6c8829ed28bb06b91c54ebe208ce065"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ tss-esapi = { version = "7.1.0", optional = true }
 bincode = "1.3.1"
 structopt = "0.3.21"
 derivative = "2.2.0"
-version = "3.0.0"
 hex = { version = "0.4.2", optional = true }
 psa-crypto = { version = "0.9.2", default-features = false, features = ["operations"], optional = true }
 zeroize = { version = "1.2.0", features = ["zeroize_derive"] }


### PR DESCRIPTION
The crate called "version" takes the environment variable CARGO_PKG_VERSION and returns the values of major, minor, and patch as integers. Do that ourselves instead of using an external dependency just for this. The main reason for this change is making the Debian packaging efforts easier: in Debian, each dependency must be packaged individually, and each individual package must provide a non-trivial amount of functionality. Splitting a string and converting the results to integer is clearly simple enough to be done without an additional dependency.