### PR TITLE
Allow uninlined format arguments clippy error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::multiple_crate_versions, unused)]
+#![allow(clippy::uninlined_format_args)]
 use std::env;
 use std::fs::read_dir;
 use std::io::{Error, ErrorKind, Result};

--- a/e2e_tests/tests/mod.rs
+++ b/e2e_tests/tests/mod.rs
@@ -28,6 +28,7 @@
 )]
 // This one is hard to avoid.
 #![allow(clippy::multiple_crate_versions)]
+#![allow(clippy::uninlined_format_args)]
 
 #[cfg(feature = "all-providers")]
 mod all_providers;

--- a/src/authenticators/mod.rs
+++ b/src/authenticators/mod.rs
@@ -9,6 +9,8 @@
 //! is the `RequestAuth` field of a request, which is parsed by the authenticator specified in the header.
 //! The authentication functionality is abstracted through an `Authenticate` trait.
 
+#![allow(clippy::uninlined_format_args)]
+
 #[cfg(not(any(
     feature = "direct-authenticator",
     feature = "unix-peer-credentials-authenticator",

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -37,6 +37,7 @@
 )]
 // This one is hard to avoid.
 #![allow(clippy::multiple_crate_versions)]
+#![allow(clippy::uninlined_format_args)]
 
 use anyhow::Result;
 use log::{info, trace};

--- a/src/front/domain_socket.rs
+++ b/src/front/domain_socket.rs
@@ -4,6 +4,8 @@
 //!
 //! Expose Parsec functionality using Unix domain sockets as an IPC layer.
 //! The local socket is created at a predefined location.
+#![allow(clippy::uninlined_format_args)]
+
 use super::listener;
 use anyhow::{Context, Result};
 use listener::Listen;

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -12,6 +12,9 @@
 //! example, for operating systems having a limit of 255 characters for filenames (Unix systems),
 //! names will be limited to 188 bytes of UTF-8 characters.
 //! For security reasons, only the PARSEC service should have the ability to modify these files.
+
+#![allow(clippy::uninlined_format_args)]
+
 use crate::authenticators::{Application, ApplicationIdentity};
 use crate::utils::config::KeyInfoManagerType;
 

--- a/src/key_info_managers/sqlite_manager/mod.rs
+++ b/src/key_info_managers/sqlite_manager/mod.rs
@@ -3,6 +3,8 @@
 //! A key info manager storing key identity to key info mappings using a SQLite database.
 //!
 //! For security reasons, only the PARSEC service should have the ability to modify these files.
+#![allow(clippy::uninlined_format_args)]
+
 use super::{KeyIdentity, KeyInfo, ManageKeyInfo};
 use crate::authenticators::ApplicationIdentity;
 use crate::providers::ProviderIdentity;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -6,6 +6,8 @@
 //! are the real implementors of the operations that Parsec claims to support. They map to
 //! functionality in the underlying hardware which allows the PSA Crypto operations to be
 //! backed by a hardware root of trust.
+#![allow(clippy::uninlined_format_args)]
+
 use log::trace;
 use parsec_interface::requests::Opcode;
 use std::collections::HashSet;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! Service utilities
+#![allow(clippy::uninlined_format_args)]
+
 pub mod cli;
 pub mod config;
 mod global_config;


### PR DESCRIPTION
The new rust 1.67 release adds a new Clippy error and this causes CI failure.
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

This MR allows the Clippy warning.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>