### PR TITLE
Update tss-esapi version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2cca751996d707a593074a115d40a285179f7929f912a4e81d2a8c2404c7e7c"
+checksum = "891582e26e83f2cbd608b18cbd7ffb921482740524187a2bca20cf44a286547b"
 dependencies = [
  "bitfield",
  "enumflags2",
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2f37914ec4d494d145cfa18bb8429498b238d63c47a08b89d09c1ec2545ff0"
+checksum = "e7b8be553262e0924410fe96404830252477f175f228081f21cb0bd87f2ccebe"
 dependencies = [
  "pkg-config",
  "target-lexicon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.14", features = ["serde"] }
 cryptoki = { version = "0.3.0", optional = true, features = ["psa-crypto-conversions"] }
 picky-asn1-der = { version = "0.2.4", optional = true }
 picky-asn1 = { version = "0.3.0", optional = true }
-tss-esapi = { version = "7.1.0", optional = true }
+tss-esapi = { version = "7.2.0", optional = true }
 bincode = "1.3.1"
 structopt = "0.3.21"
 derivative = "2.2.0"

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.14"
 rand = "0.7.3"
 env_logger = "0.8.3"
 stdext = "0.3.1"
-tss-esapi = { version = "7.1.0", optional = true }
+tss-esapi = { version = "7.2.0", optional = true }
 
 [dev-dependencies]
 ring = "0.16.20"


### PR DESCRIPTION
The tmp2-tss version on meta-security has been updated to 4.0.1 from 3.2.0. This is not compatible with the current tss-esapi crate. The newer version 7.2.0 of the crate is now available which resolves the issue.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>

Closes #663