### PR TITLE
Replace unmaintained 'users' crate with 'nix' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1053,7 @@ dependencies = [
  "hex",
  "libc",
  "log",
+ "nix",
  "num-traits",
  "parsec-interface",
  "picky-asn1",
@@ -1060,7 +1073,6 @@ dependencies = [
  "threadpool",
  "toml",
  "tss-esapi",
- "users",
  "uuid",
  "zeroize",
 ]
@@ -1631,6 +1643,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,16 +1919,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
-]
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ threadpool = "1.8.1"
 signal-hook = "0.3.4"
 sd-notify = "0.3.0"
 toml = "0.5.8"
+nix = { version = "0.26.2", default-features = false, features = ["user"]}
 serde = { version = "1.0.123", features = ["derive"] }
 env_logger = "0.8.3"
 log = { version = "0.4.14", features = ["serde"] }
@@ -37,7 +38,6 @@ hex = { version = "0.4.2", optional = true }
 psa-crypto = { version = "0.10.0", default-features = false, features = ["operations"], optional = true }
 zeroize = { version = "1.2.0", features = ["zeroize_derive"] }
 picky-asn1-x509 = { version = "0.6.1", optional = true }
-users = "0.11.0"
 libc = "0.2.86"
 anyhow = "1.0.38"
 rust-cryptoauthlib = { version = "0.4.4", optional = true }

--- a/src/authenticators/unix_peer_credentials_authenticator/mod.rs
+++ b/src/authenticators/unix_peer_credentials_authenticator/mod.rs
@@ -109,11 +109,11 @@ mod test {
     use super::UnixPeerCredentialsAuthenticator;
     use crate::front::domain_socket::peer_credentials;
     use crate::front::listener::ConnectionMetadata;
+    use nix::unistd::getuid;
     use parsec_interface::requests::request::RequestAuth;
     use parsec_interface::requests::ResponseStatus;
     use rand::Rng;
     use std::os::unix::net::UnixStream;
-    use users::get_current_uid;
 
     #[test]
     fn successful_authentication() {
@@ -143,7 +143,7 @@ mod test {
             .authenticate(&req_auth, conn_metadata)
             .expect("Failed to authenticate");
 
-        assert_eq!(application.identity.name, get_current_uid().to_string());
+        assert_eq!(application.identity.name, getuid().as_raw().to_string());
         assert!(!application.is_admin);
     }
 
@@ -230,7 +230,7 @@ mod test {
             peer_credentials::peer_cred(&_sock_b).unwrap(),
         );
 
-        let admin = toml::from_str(&format!("name = '{}'", get_current_uid())).unwrap();
+        let admin = toml::from_str(&format!("name = '{}'", getuid().as_raw())).unwrap();
         let authenticator = UnixPeerCredentialsAuthenticator {
             admins: vec![admin].into(),
         };
@@ -247,7 +247,7 @@ mod test {
             .authenticate(&req_auth, conn_metadata)
             .expect("Failed to authenticate");
 
-        assert_eq!(application.identity.name, get_current_uid().to_string());
+        assert_eq!(application.identity.name, getuid().as_raw().to_string());
         assert!(application.is_admin);
     }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -40,6 +40,7 @@
 
 use anyhow::Result;
 use log::{info, trace};
+use nix::unistd::getuid;
 use parsec_service::utils::cli::Opts;
 use parsec_service::utils::{config::ServiceConfig, ServiceBuilder};
 use signal_hook::{consts::SIGHUP, consts::SIGINT, consts::SIGTERM, flag};
@@ -50,7 +51,6 @@ use std::sync::{
 };
 use std::time::Duration;
 use structopt::StructOpt;
-use users::get_current_uid;
 
 const MAIN_LOOP_DEFAULT_SLEEP: u64 = 10;
 
@@ -82,7 +82,7 @@ fn main() -> Result<()> {
     // Guard against running as root. This check can be overridden by changing `allow_root` inside
     // the config file.
     let allow_root = config.core_settings.allow_root.unwrap_or(false);
-    if !allow_root && get_current_uid() == 0 {
+    if !allow_root && getuid().as_raw() == 0 {
         return Err(Error::new(
             ErrorKind::Other,
             "Insecure configuration; the Parsec service should not be running as root! You can \


### PR DESCRIPTION
This PR opens a discussion thread to fix the issue of the 'users' crate currently being flagged as 'unmaintained' by our CI (which is currently failing):
See:

https://rustsec.org/advisories/RUSTSEC-2023-0040.html

Currently we only use the users crate to the method [get_current_id()](https://docs.rs/users/0.11.0/users/fn.get_current_uid.html), which makes an unsafe call to libc's getuid(). parsec-client-rust and parsec-tool repos are also affected by this, all of them using the same function call from the users crate and no other call that I can tell.
There are several options to fix this issue.

 - Mark this as okay in the CI and leave it "as is", as the only function that we are using is [get_current_id()](https://docs.rs/users/0.11.0/users/fn.get_current_uid.html) which makes a call to getuid() and nothing else, so the fact that the crate is unmaintained would not affect us. The [users crate dependencies](https://crates.io/crates/users/0.11.0/dependencies) are only libc (the log one is optional).
 - Use libc unsafe calls directly instead.
 - Change the users crate to a different crate.

    - The suggested solution by [RustSec](https://rustsec.org/advisories/RUSTSEC-2023-0040.html) is to use [sysinfo](https://crates.io/crates/sysinfo), but this one has a lot of [dependencies](https://crates.io/crates/sysinfo/0.29.4/dependencies) that have their own dependencies and from which we don't need most of them. This may lead to potential problems in the future as [RustSec](https://rustsec.org/) may flag these as a problem and we may have more versioning problems as well.
   - I found the [nix](https://crates.io/crates/nix/0.26.2) crate that has [dependencies](https://crates.io/crates/nix/0.26.2/dependencies) that are only macro related and have no nested dependencies (so there is a very limited potential for dependency problems in the future). If we take into account the ones that are already being used by parsec as dependencies from other crates, [static_assertions](https://crates.io/crates/static_assertions/1.1.0) would be the only dependency that is added by nix. Most of the dependencies and used code is controlled by enabling only the needed features. This solution would remove the CI issue and has very limited potential for future problems that may arise by dependencies.

This is a patch to replace the users crate with the nix crate that currently has no issues of that kind and implements the same needed functionality (calling libc::getuid() ). This shows that this may be implemented if needed, and this is applicable to the rest of the crates as well.

I will submit a different MR with another one of the solutions implemented as well.