### PR TITLE
Remove unmaintained 'users' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,6 @@ dependencies = [
  "threadpool",
  "toml",
  "tss-esapi",
- "users",
  "uuid",
  "zeroize",
 ]
@@ -1893,16 +1892,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
-]
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ hex = { version = "0.4.2", optional = true }
 psa-crypto = { version = "0.10.0", default-features = false, features = ["operations"], optional = true }
 zeroize = { version = "1.2.0", features = ["zeroize_derive"] }
 picky-asn1-x509 = { version = "0.6.1", optional = true }
-users = "0.11.0"
 libc = "0.2.86"
 anyhow = "1.0.38"
 rust-cryptoauthlib = { version = "0.4.4", optional = true }

--- a/src/authenticators/unix_peer_credentials_authenticator/mod.rs
+++ b/src/authenticators/unix_peer_credentials_authenticator/mod.rs
@@ -109,11 +109,11 @@ mod test {
     use super::UnixPeerCredentialsAuthenticator;
     use crate::front::domain_socket::peer_credentials;
     use crate::front::listener::ConnectionMetadata;
+    use libc::{getuid, uid_t};
     use parsec_interface::requests::request::RequestAuth;
     use parsec_interface::requests::ResponseStatus;
     use rand::Rng;
     use std::os::unix::net::UnixStream;
-    use users::get_current_uid;
 
     #[test]
     fn successful_authentication() {
@@ -143,7 +143,8 @@ mod test {
             .authenticate(&req_auth, conn_metadata)
             .expect("Failed to authenticate");
 
-        assert_eq!(application.identity.name, get_current_uid().to_string());
+        let current_uid: uid_t = unsafe { getuid() };
+        assert_eq!(application.identity.name, current_uid.to_string());
         assert!(!application.is_admin);
     }
 
@@ -230,7 +231,8 @@ mod test {
             peer_credentials::peer_cred(&_sock_b).unwrap(),
         );
 
-        let admin = toml::from_str(&format!("name = '{}'", get_current_uid())).unwrap();
+        let current_uid: uid_t = unsafe { getuid() };
+        let admin = toml::from_str(&format!("name = '{}'", current_uid)).unwrap();
         let authenticator = UnixPeerCredentialsAuthenticator {
             admins: vec![admin].into(),
         };
@@ -247,7 +249,7 @@ mod test {
             .authenticate(&req_auth, conn_metadata)
             .expect("Failed to authenticate");
 
-        assert_eq!(application.identity.name, get_current_uid().to_string());
+        assert_eq!(application.identity.name, current_uid.to_string());
         assert!(application.is_admin);
     }
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -39,6 +39,7 @@
 #![allow(clippy::multiple_crate_versions)]
 
 use anyhow::Result;
+use libc::{getuid, uid_t};
 use log::{info, trace};
 use parsec_service::utils::cli::Opts;
 use parsec_service::utils::{config::ServiceConfig, ServiceBuilder};
@@ -50,7 +51,6 @@ use std::sync::{
 };
 use std::time::Duration;
 use structopt::StructOpt;
-use users::get_current_uid;
 
 const MAIN_LOOP_DEFAULT_SLEEP: u64 = 10;
 
@@ -82,7 +82,8 @@ fn main() -> Result<()> {
     // Guard against running as root. This check can be overridden by changing `allow_root` inside
     // the config file.
     let allow_root = config.core_settings.allow_root.unwrap_or(false);
-    if !allow_root && get_current_uid() == 0 {
+    let current_id: uid_t = unsafe { getuid() };
+    if !allow_root && current_id == 0 {
         return Err(Error::new(
             ErrorKind::Other,
             "Insecure configuration; the Parsec service should not be running as root! You can \


### PR DESCRIPTION
The 'users' crate is currrently being flagged as unmaintained in https://rustsec.org/advisories/RUSTSEC-2023-0040.html . It is currently only being used to get the uid of the user of a running process.

 * Replace all users::get_current_uid() calls with libc::getuid() calls.
 * Remove the users crate from Cargo.toml and Cargo.lock

Please refer to #683 for more information on this issue and the corresponding fix options