### PR TITLE
Disable the optional features for the 'structopt' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,15 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,13 +211,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim",
  "textwrap",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -1631,12 +1618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,12 +1905,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ picky-asn1-der = { version = "0.2.4", optional = true }
 picky-asn1 = { version = "0.3.0", optional = true }
 tss-esapi = { version = "7.2.0", optional = true }
 bincode = "1.3.1"
-structopt = "0.3.21"
+structopt = { version = "0.3.21", default-features = false}
 derivative = "2.2.0"
 hex = { version = "0.4.2", optional = true }
 psa-crypto = { version = "0.10.0", default-features = false, features = ["operations"], optional = true }


### PR DESCRIPTION
The 'ansi_term' crate is currrently being flagged as unmaintained. The dependency tree that is bringing this crate is:

ansi_term 0.12.1
└── clap 2.34.0
    └── structopt 0.3.26
        └── parsec-service 1.2.0

ansi_term is an optional dependency that we are bringing along. Remove this and other optional dependencies by disabling the default-features for structopt.