### PR TITLE
Upgrade proc-macro2 package

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@ This file aims to acknowledge the specific contributors referred to in the "Cont
 * Mohamed Omar Asaker (@mohamedasaker-arm)
 * Gowtham Suresh Kumar (@gowthamsk-arm)
 * William Brown (@firstyear)
+* Tomas Agustin Gonzalez Orlando (@tgonzalezorlandoarm)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
proc-macro2 introduces a regression that breaks our Nightly Checks on rust nightly builds that are post `nightly-2023-06-27`, as explained in [this issue](https://github.com/rust-lang/rust/issues/113152).

- Upgrade the `proc-macro2` package to fix the issue as indicated in [this comment of the same issue](https://github.com/rust-lang/rust/issues/113152#issuecomment-1612580132).
- Update CONTRIBUTORS.md to include myself.