### PR TITLE
Use Rust version 1.60.0 when building for coverage in the CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -247,12 +247,14 @@ fi
 git submodule update --init
 
 if [ "$PROVIDER_NAME" = "coverage" ]; then
-    rustup toolchain install 1.57.0
+    rustup toolchain install 1.60.0
     PROVIDERS="trusted-service mbed-crypto tpm pkcs11"
     EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/authenticators/jwt_svid_authenticator/*"
     UNIT_TEST_FEATURES="unix-peer-credentials-authenticator,direct-authenticator"
     # Install tarpaulin
-    cargo +1.57.0 install cargo-tarpaulin
+    #TODO: Remove the fixed version of cargo-tarpaulin when a new rust version
+    # is used (and the MSRV gets upgraded).
+    cargo +1.60.0 install cargo-tarpaulin --version 0.24.0
 
     mkdir -p reports
 
@@ -268,7 +270,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
         cp -r $(pwd)/e2e_tests/fake_mappings/* mappings
 
         # Start service
-        RUST_LOG=info cargo +1.57.0 tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
+        RUST_LOG=info cargo +1.60.0 tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
             --output-dir $(pwd)/reports/$provider --features="$provider-provider,direct-authenticator" \
             --run-types bins --timeout 3600 -- -c $CONFIG_PATH &
         wait_for_service
@@ -286,7 +288,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
         fi
 
         # Start service
-        RUST_LOG=info cargo +1.57.0 tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
+        RUST_LOG=info cargo +1.60.0 tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
             --output-dir $(pwd)/reports/$provider --features="$provider-provider,direct-authenticator" \
             --run-types bins --timeout 3600 -- -c $CONFIG_PATH &
         wait_for_service
@@ -296,7 +298,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
 
     # Run unit tests
     mkdir -p reports/unit
-    cargo +1.57.0 tarpaulin --tests --out Xml --features=$UNIT_TEST_FEATURES --exclude-files="$EXCLUDES" --output-dir $(pwd)/reports/unit
+    cargo +1.60.0 tarpaulin --tests --out Xml --features=$UNIT_TEST_FEATURES --exclude-files="$EXCLUDES" --output-dir $(pwd)/reports/unit
 
     exit 0
 fi


### PR DESCRIPTION
cargo-tarpaulin needs at least Rust 1.60.0 to compile with a version that is newer than two years old. The version is fixed to 0.24.0 because newer versions need at least Rust 1.64.0.

 * To provide coverage with an up-to-date tool, use Rust 1.60.0 for the coverage build in ci.sh.
 * Fix the cargo-tarpaulin version to 0.24.0. This one should be upgraded when the coverage build is upgraded as well.