### PR TITLE
Make wrong_permitted_algorithm test use a non-deprecated Hash

### DIFF
--- a/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
@@ -132,10 +132,9 @@ fn wrong_permitted_algorithm() {
     }
     let key_type = Type::RsaKeyPair;
     // Do not permit RSA PKCS 1v15 signing algorithm with SHA-256.
-    #[allow(deprecated)]
     let permitted_algorithm =
         Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
-            hash_alg: Hash::Sha1.into(),
+            hash_alg: Hash::Sha512.into(),
         });
     let mut usage_flags: UsageFlags = Default::default();
     let _ = usage_flags.set_sign_hash();


### PR DESCRIPTION
Currently, the wrong_permitted_algorithm test checks if, creating a key that uses sha1, that key is rejected when calling sign_with_rsa_sha256. However, as sha1 is deprecated, there is currently an error when creating the key for the test.

 * Change the key generation to use sha512 instead.