### PR TITLE
ci: Fix coverage builds, nightly issues

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -250,7 +250,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
     rustup toolchain install 1.66.0
     PROVIDERS="trusted-service mbed-crypto tpm pkcs11"
     EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/authenticators/jwt_svid_authenticator/*"
-    UNIT_TEST_COMMON_FEATURES="unix-peer-credentials-authenticator,direct-authenticator"
+    UNIT_TEST_FEATURES="unix-peer-credentials-authenticator,direct-authenticator"
     # Install tarpaulin
     cargo +1.66.0 install cargo-tarpaulin
 
@@ -260,7 +260,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
         # Set up run
         PROVIDER_NAME=$provider
         TEST_FEATURES="--features=$provider-provider"
-        UNIT_TEST_FEATURES="$UNIT_TEST_COMMON_FEATURES,$provider-provider"
+        UNIT_TEST_FEATURES="$UNIT_TEST_FEATURES,$provider-provider"
         cp $(pwd)/e2e_tests/provider_cfg/$provider/config.toml $CONFIG_PATH
         mkdir -p reports/$provider
 

--- a/ci.sh
+++ b/ci.sh
@@ -292,6 +292,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
         wait_for_service
 
         run_key_mappings_tests
+        stop_service
     done
 
     # Run unit tests


### PR DESCRIPTION
The final service in each provider iteration of the coverage build
is left running before the next iteration begins.
This is causing clashes when running tests.
Stop the service before starting the new provider build.
Also, revert an error made when in a previous commit on the UNIT_TEST_FEATURES.
The variable is changed in each iteration but is used after the iterations.