### PR TITLE
Update maintainers list

### DIFF
--- a/MAINTAINERS.toml
+++ b/MAINTAINERS.toml
@@ -21,6 +21,7 @@
       "anta5010",
       "gowthamsk-arm",
       "mohamedasaker-arm",
+      "tgonzalezorlandoarm",
     ]
 
 [people]
@@ -71,3 +72,8 @@
     Name = "Mohamed Omar Asaker"
     Email = "mohamed.omarasaker@arm.com"
     GitHub = "mohamedasaker-arm"
+
+    [people.tgonzalezorlandoarm]
+    Name = "Tomás Agustín González Orlando"
+    Email = "tomasagustin.gonzalezorlando@arm.com"
+    GitHub = "tgonzalezorlandoarm"


### PR DESCRIPTION
Add tgonzalezorlandoarm as maintainer.

Signed-off-by: Tomás González <tomasagustin.gonzalezorlando@arm.com>