### PR TITLE
Fix cargo-tarpaulin version to 0.26.1

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -156,6 +156,7 @@ setup_mappings() {
 
 # Use the newest version of the Rust toolchain
 rustup update
+MSRV=1.66.0
 
 # Parse arguments
 NO_CARGO_CLEAN=
@@ -247,12 +248,12 @@ fi
 git submodule update --init
 
 if [ "$PROVIDER_NAME" = "coverage" ]; then
-    rustup toolchain install 1.66.0
+    rustup toolchain install ${MSRV}
     PROVIDERS="trusted-service mbed-crypto tpm pkcs11"
     EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/authenticators/jwt_svid_authenticator/*"
     UNIT_TEST_FEATURES="unix-peer-credentials-authenticator,direct-authenticator"
     # Install tarpaulin
-    cargo +1.66.0 install cargo-tarpaulin
+    cargo +${MSRV} install cargo-tarpaulin
 
     mkdir -p reports
 
@@ -268,7 +269,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
         cp -r $(pwd)/e2e_tests/fake_mappings/* mappings
 
         # Start service
-        RUST_LOG=info cargo +1.66.0 tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
+        RUST_LOG=info cargo +${MSRV} tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
             --output-dir $(pwd)/reports/$provider --features="$provider-provider,direct-authenticator" \
             --run-types bins --timeout 3600 -- -c $CONFIG_PATH &
         wait_for_service
@@ -286,7 +287,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
         fi
 
         # Start service
-        RUST_LOG=info cargo +1.66.0 tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
+        RUST_LOG=info cargo +${MSRV} tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
             --output-dir $(pwd)/reports/$provider --features="$provider-provider,direct-authenticator" \
             --run-types bins --timeout 3600 -- -c $CONFIG_PATH &
         wait_for_service
@@ -297,7 +298,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
 
     # Run unit tests
     mkdir -p reports/unit
-    cargo +1.66.0 tarpaulin --tests --out Xml --features=$UNIT_TEST_FEATURES --exclude-files="$EXCLUDES" --output-dir $(pwd)/reports/unit
+    cargo +${MSRV} tarpaulin --tests --out Xml --features=$UNIT_TEST_FEATURES --exclude-files="$EXCLUDES" --output-dir $(pwd)/reports/unit
 
     exit 0
 fi
@@ -332,9 +333,9 @@ if [ "$PROVIDER_NAME" = "cargo-check" ]; then
     # - openSUSE Tumbleweed
     # - openSUSE Leap 15.4
 
-    rustup toolchain install 1.66.0
+    rustup toolchain install ${MSRV}
     # TODO: The "jwt-svid-authenticator" is currently not being used.
-    RUST_BACKTRACE=1 cargo +1.66.0 check --release --features=all-providers,direct-authenticator,unix-peer-credentials-authenticator
+    RUST_BACKTRACE=1 cargo +${MSRV} check --release --features=all-providers,direct-authenticator,unix-peer-credentials-authenticator
 
     # Latest stable
     rustup toolchain install stable

--- a/ci.sh
+++ b/ci.sh
@@ -253,7 +253,8 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
     EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/authenticators/jwt_svid_authenticator/*"
     UNIT_TEST_FEATURES="unix-peer-credentials-authenticator,direct-authenticator"
     # Install tarpaulin
-    cargo +${MSRV} install cargo-tarpaulin
+    # TODO: Stop using the --version parameter when MSRV is upgraded.
+    cargo +${MSRV} install cargo-tarpaulin --version 0.26.1
 
     mkdir -p reports
 


### PR DESCRIPTION
     * Create an environment variable to define the MSRV so that only
       one change is needed to update it.
     * Fix the version of cargo-tarpaulin to 0.26.1

Signed-off-by: Tomás González <tomasagustin.gonzalezorlando@arm.com>
