### PR TITLE
Remove the psa-crypto-conversions feature from the cryptoki dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,6 @@ dependencies = [
  "derivative",
  "libloading",
  "log",
- "psa-crypto",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,21 +248,23 @@ dependencies = [
 
 [[package]]
 name = "cryptoki"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570006e51d08ec89ce5bbfdcf428ad96111636d524bf2447bee6377fd0e1d889"
+checksum = "95d9fb68c88020896fa3741a10e41f206b2ace927724170a753a3f2ba5f77c2b"
 dependencies = [
+ "bitflags",
  "cryptoki-sys",
- "derivative",
  "libloading",
  "log",
+ "paste",
+ "secrecy 0.8.0",
 ]
 
 [[package]]
 name = "cryptoki-sys"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d12231889cbf7e11d2965a063d9518bc7aac60c5b125dc61c8ff2111a160eae"
+checksum = "4bc9943e09928a84ed6e76dbaea1699b7678e95b2487b0de31075af300221095"
 dependencies = [
  "libloading",
  "target-lexicon",
@@ -1013,7 +1015,7 @@ dependencies = [
  "num-traits",
  "prost",
  "psa-crypto",
- "secrecy",
+ "secrecy 0.7.0",
  "serde",
  "uuid",
  "zeroize",
@@ -1055,6 +1057,12 @@ dependencies = [
  "uuid",
  "zeroize",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "peeking_take_while"
@@ -1494,6 +1502,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0673d6a6449f5e7d12a1caf424fd9363e2af3a4953023ed455e3c4beef4597c0"
 dependencies = [
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.5.8"
 serde = { version = "1.0.123", features = ["derive"] }
 env_logger = "0.8.3"
 log = { version = "0.4.14", features = ["serde"] }
-cryptoki = { version = "0.3.1", optional = true, features = ["psa-crypto-conversions"] }
+cryptoki = { version = "0.3.1", optional = true, default-features = false }
 picky-asn1-der = { version = "0.4.0", optional = true }
 picky-asn1 = { version = "0.7.2", optional = true }
 tss-esapi = { version = "7.2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.5.8"
 serde = { version = "1.0.123", features = ["derive"] }
 env_logger = "0.8.3"
 log = { version = "0.4.14", features = ["serde"] }
-cryptoki = { version = "0.3.1", optional = true, default-features = false }
+cryptoki = { version = "0.5.0", optional = true, default-features = false }
 picky-asn1-der = { version = "0.4.0", optional = true }
 picky-asn1 = { version = "0.7.2", optional = true }
 tss-esapi = { version = "7.2.0", optional = true }

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -30,7 +30,7 @@ picky-asn1 = "0.3.1"
 sha2 = "0.9.3"
 serial_test = "0.5.1"
 regex = "1.6.0"
-cryptoki = { version = "0.3.1", default-features = false }
+cryptoki = { version = "0.5.0", default-features = false }
 snailquote = "0.3.1"
 
 [features]

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -30,7 +30,7 @@ picky-asn1 = "0.3.1"
 sha2 = "0.9.3"
 serial_test = "0.5.1"
 regex = "1.6.0"
-cryptoki = "0.3.1"
+cryptoki = { version = "0.3.1", default-features = false }
 snailquote = "0.3.1"
 
 [features]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -278,22 +278,23 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cryptoki"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570006e51d08ec89ce5bbfdcf428ad96111636d524bf2447bee6377fd0e1d889"
+checksum = "95d9fb68c88020896fa3741a10e41f206b2ace927724170a753a3f2ba5f77c2b"
 dependencies = [
+ "bitflags",
  "cryptoki-sys",
- "derivative",
  "libloading",
  "log",
- "psa-crypto",
+ "paste",
+ "secrecy 0.8.0",
 ]
 
 [[package]]
 name = "cryptoki-sys"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d12231889cbf7e11d2965a063d9518bc7aac60c5b125dc61c8ff2111a160eae"
+checksum = "4bc9943e09928a84ed6e76dbaea1699b7678e95b2487b0de31075af300221095"
 dependencies = [
  "libloading",
  "target-lexicon",
@@ -1053,7 +1054,7 @@ dependencies = [
  "num-traits",
  "prost",
  "psa-crypto",
- "secrecy",
+ "secrecy 0.7.0",
  "serde",
  "uuid",
  "zeroize",
@@ -1090,6 +1091,12 @@ dependencies = [
  "uuid",
  "zeroize",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "peeking_take_while"
@@ -1464,6 +1471,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0673d6a6449f5e7d12a1caf424fd9363e2af3a4953023ed455e3c4beef4597c0"
 dependencies = [
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
  "zeroize",
 ]
 

--- a/src/providers/pkcs11/asym_encryption.rs
+++ b/src/providers/pkcs11/asym_encryption.rs
@@ -58,7 +58,6 @@ impl Provider {
         let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
-
         let mech = algorithm_to_mechanism(Algorithm::from(op.alg)).map_err(to_response_status)?;
 
         let session = self.new_session()?;

--- a/src/providers/pkcs11/asym_encryption.rs
+++ b/src/providers/pkcs11/asym_encryption.rs
@@ -1,18 +1,16 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use super::utils::to_response_status;
+use super::utils::{algorithm_to_mechanism, to_response_status};
 use super::KeyPairType;
 use super::Provider;
 use crate::authenticators::ApplicationIdentity;
 use crate::key_info_managers::KeyIdentity;
 use cryptoki::error::Error;
 use cryptoki::error::RvError;
-use cryptoki::mechanism::Mechanism;
 use log::{info, trace};
 use parsec_interface::operations::psa_algorithm::{Algorithm, AsymmetricEncryption};
 use parsec_interface::operations::{psa_asymmetric_decrypt, psa_asymmetric_encrypt};
 use parsec_interface::requests::{ResponseStatus, Result};
-use std::convert::TryFrom;
 
 impl Provider {
     pub(super) fn psa_asymmetric_encrypt_internal(
@@ -30,7 +28,7 @@ impl Provider {
 
         op.validate(key_attributes)?;
 
-        let mech = Mechanism::try_from(Algorithm::from(op.alg)).map_err(to_response_status)?;
+        let mech = algorithm_to_mechanism(Algorithm::from(op.alg)).map_err(to_response_status)?;
 
         let session = self.new_session()?;
 
@@ -61,7 +59,7 @@ impl Provider {
 
         op.validate(key_attributes)?;
 
-        let mech = Mechanism::try_from(Algorithm::from(op.alg)).map_err(to_response_status)?;
+        let mech = algorithm_to_mechanism(Algorithm::from(op.alg)).map_err(to_response_status)?;
 
         let session = self.new_session()?;
 

--- a/src/providers/pkcs11/asym_sign.rs
+++ b/src/providers/pkcs11/asym_sign.rs
@@ -66,7 +66,6 @@ impl Provider {
         let key_attributes = self.key_info_store.get_key_attributes(&key_identity)?;
 
         op.validate(key_attributes)?;
-
         let mech = algorithm_to_mechanism(Algorithm::from(op.alg)).map_err(to_response_status)?;
 
         let session = self.new_session()?;

--- a/src/providers/pkcs11/asym_sign.rs
+++ b/src/providers/pkcs11/asym_sign.rs
@@ -1,17 +1,15 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use super::utils::to_response_status;
+use super::utils::{algorithm_to_mechanism, to_response_status};
 use super::Provider;
 use super::{utils, KeyPairType};
 use crate::authenticators::ApplicationIdentity;
 use crate::key_info_managers::KeyIdentity;
-use cryptoki::mechanism::Mechanism;
 use log::{info, trace};
 use parsec_interface::operations::psa_algorithm::Algorithm;
 use parsec_interface::operations::psa_key_attributes::Type;
 use parsec_interface::operations::{psa_sign_hash, psa_verify_hash};
 use parsec_interface::requests::{ResponseStatus, Result};
-use std::convert::TryFrom;
 
 impl Provider {
     pub(super) fn psa_sign_hash_internal(
@@ -30,7 +28,7 @@ impl Provider {
 
         op.validate(key_attributes)?;
 
-        let mech = Mechanism::try_from(Algorithm::from(op.alg)).map_err(to_response_status)?;
+        let mech = algorithm_to_mechanism(Algorithm::from(op.alg)).map_err(to_response_status)?;
 
         let session = self.new_session()?;
 
@@ -69,7 +67,7 @@ impl Provider {
 
         op.validate(key_attributes)?;
 
-        let mech = Mechanism::try_from(Algorithm::from(op.alg)).map_err(to_response_status)?;
+        let mech = algorithm_to_mechanism(Algorithm::from(op.alg)).map_err(to_response_status)?;
 
         let session = self.new_session()?;
 

--- a/src/providers/pkcs11/capability_discovery.rs
+++ b/src/providers/pkcs11/capability_discovery.rs
@@ -77,8 +77,8 @@ impl CanDoCrypto for Provider {
             .get_mechanism_info(self.slot_number, mechanism.mechanism_type())
             .map_err(to_response_status)?;
         if std::any::type_name::<Ulong>() == std::any::type_name::<u64>() {
-            if !((attributes.bits as u64) >= (*mechanism_info.min_key_size()).into()
-                && (attributes.bits as u64) <= (*mechanism_info.max_key_size()).into())
+            if !((attributes.bits as u64) >= (mechanism_info.min_key_size() as u64)
+                && (attributes.bits as u64) <= (mechanism_info.max_key_size()) as u64)
             {
                 info!(
                     "Incorrect key size {} for mechanism {:?}",
@@ -87,8 +87,8 @@ impl CanDoCrypto for Provider {
                 return Err(PsaErrorNotSupported);
             }
         } else {
-            if !((attributes.bits as u64) >= (*mechanism_info.min_key_size() as u64)
-                && (attributes.bits as u64) <= (*mechanism_info.max_key_size() as u64))
+            if !((attributes.bits as u64) >= (mechanism_info.min_key_size() as u64)
+                && (attributes.bits as u64) <= (mechanism_info.max_key_size() as u64))
             {
                 info!(
                     "Incorrect key size {} for mechanism {:?}",

--- a/src/providers/pkcs11/capability_discovery.rs
+++ b/src/providers/pkcs11/capability_discovery.rs
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(trivial_numeric_casts)]
+use super::utils::algorithm_to_mechanism;
 use super::{utils, Provider};
 use crate::authenticators::ApplicationIdentity;
 use crate::providers::crypto_capability::CanDoCrypto;
 use crate::providers::pkcs11::to_response_status;
-use cryptoki::mechanism::{Mechanism, MechanismInfo, MechanismType};
+use cryptoki::mechanism::{MechanismInfo, MechanismType};
 use cryptoki::types::Ulong;
 use log::{info, trace};
 use parsec_interface::operations::can_do_crypto;
@@ -14,7 +15,6 @@ use parsec_interface::operations::psa_algorithm::*;
 use parsec_interface::operations::psa_key_attributes::{Attributes, Type};
 use parsec_interface::requests::ResponseStatus::PsaErrorNotSupported;
 use parsec_interface::requests::Result;
-use std::convert::TryFrom;
 
 impl CanDoCrypto for Provider {
     fn can_do_crypto_internal(
@@ -65,7 +65,7 @@ impl CanDoCrypto for Provider {
             .backend
             .get_mechanism_list(self.slot_number)
             .map_err(to_response_status)?;
-        let mechanism = Mechanism::try_from(attributes.policy.permitted_algorithms)
+        let mechanism = algorithm_to_mechanism(attributes.policy.permitted_algorithms)
             .map_err(to_response_status)?;
         if !(supported_mechanisms.contains(&mechanism.mechanism_type())) {
             info!("Mechanism {:?} is not supported", mechanism);

--- a/src/providers/pkcs11/key_management.rs
+++ b/src/providers/pkcs11/key_management.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use super::utils::to_response_status;
+use super::utils::{algorithm_to_mechanism, to_response_status};
 use super::{utils, KeyPairType, Provider};
 use crate::authenticators::ApplicationIdentity;
 use crate::key_info_managers::KeyIdentity;
@@ -17,7 +17,7 @@ use parsec_interface::requests::{ResponseStatus, Result};
 use parsec_interface::secrecy::ExposeSecret;
 use picky_asn1::wrapper::{IntegerAsn1, OctetStringAsn1};
 use picky_asn1_x509::RsaPublicKey;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 
 impl Provider {
     /// Find the PKCS 11 object handle corresponding to the key ID and the key type (public,
@@ -117,7 +117,7 @@ impl Provider {
         let mut pub_template = vec![
             Attribute::Id(key_id.to_be_bytes().to_vec()),
             Attribute::Token(true.into()),
-            Attribute::AllowedMechanisms(vec![Mechanism::try_from(
+            Attribute::AllowedMechanisms(vec![algorithm_to_mechanism(
                 key_attributes.policy.permitted_algorithms,
             )
             .map_err(to_response_status)?

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -11,8 +11,9 @@ use crate::providers::crypto_capability::CanDoCrypto;
 use crate::providers::ProviderIdentity;
 use cryptoki::context::{CInitializeArgs, Pkcs11};
 use cryptoki::error::{Error as Pkcs11Error, RvError};
-use cryptoki::session::{Session, SessionFlags, UserType};
+use cryptoki::session::{Session, UserType};
 use cryptoki::slot::Slot;
+use cryptoki::types::AuthPin;
 use derivative::Derivative;
 use log::{error, info, trace, warn};
 use parsec_interface::operations::{
@@ -211,12 +212,9 @@ impl Provider {
     // * logged in if the pin is set
     // * set on the slot in the provider
     fn new_session(&self) -> Result<Session> {
-        let mut flags = SessionFlags::new();
-        let _ = flags.set_rw_session(true).set_serial_session(true);
-
         let session = self
             .backend
-            .open_session_no_callback(self.slot_number, flags)
+            .open_rw_session(self.slot_number)
             .map_err(to_response_status)?;
 
         if self.user_pin.is_some() {
@@ -231,7 +229,7 @@ impl Provider {
             }
 
             session
-                .login(UserType::User, Some(&pin))
+                .login(UserType::User, Some(&AuthPin::new(pin.to_string())))
                 .or_else(|e| {
                     if let Pkcs11Error::Pkcs11(RvError::UserAlreadyLoggedIn) = e {
                         Ok(())
@@ -529,11 +527,11 @@ impl ProviderBuilder {
                         format_error!("Failed parsing token info", e);
                         Error::new(ErrorKind::InvalidData, "Failed parsing token info")
                     })?;
-                    let sn =
-                        String::from_utf8(current_token.serialNumber.to_vec()).map_err(|e| {
-                            format_error!("Failed parsing token serial number", e);
-                            Error::new(ErrorKind::InvalidData, "Failed parsing token serial number")
-                        })?;
+                    let sn = String::from_utf8(current_token.serial_number().as_bytes().to_vec())
+                        .map_err(|e| {
+                        format_error!("Failed parsing token serial number", e);
+                        Error::new(ErrorKind::InvalidData, "Failed parsing token serial number")
+                    })?;
                     if sn.trim() == serial_number.trim() {
                         slot = Some(current_slot);
                         break;

--- a/src/providers/pkcs11/utils.rs
+++ b/src/providers/pkcs11/utils.rs
@@ -166,7 +166,7 @@ pub fn pkcsmgftype_from_psa_crypto_hash(alg: Hash) -> Result<rsa::PkcsMgfType, E
 #[allow(deprecated)]
 pub fn algorithm_to_mechanism(
     alg: psa_crypto::types::algorithm::Algorithm,
-) -> Result<Mechanism, Error> {
+) -> Result<Mechanism<'static>, Error> {
     use psa_crypto::types::algorithm::{Algorithm, AsymmetricEncryption};
 
     match alg {
@@ -187,13 +187,11 @@ pub fn algorithm_to_mechanism(
         })),
         Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa { .. }) => Ok(Mechanism::Ecdsa),
         Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaOaep { hash_alg }) => {
-            Ok(Mechanism::RsaPkcsOaep(rsa::PkcsOaepParams {
-                hash_alg: algorithm_to_mechanism(Algorithm::from(hash_alg))?.mechanism_type(),
-                mgf: pkcsmgftype_from_psa_crypto_hash(hash_alg)?,
-                source: rsa::PkcsOaepSourceType::DATA_SPECIFIED,
-                source_data: std::ptr::null(),
-                source_data_len: 0.into(),
-            }))
+            Ok(Mechanism::RsaPkcsOaep(rsa::PkcsOaepParams::new(
+                algorithm_to_mechanism(Algorithm::from(hash_alg))?.mechanism_type(),
+                pkcsmgftype_from_psa_crypto_hash(hash_alg)?,
+                rsa::PkcsOaepSource::empty(),
+            )))
         }
         alg => {
             error!("{:?} is not a supported algorithm", alg);

--- a/src/providers/pkcs11/utils.rs
+++ b/src/providers/pkcs11/utils.rs
@@ -1,18 +1,20 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use cryptoki::error::{Error, RvError};
+use cryptoki::mechanism::rsa;
+use cryptoki::mechanism::Mechanism;
 use cryptoki::object::Attribute;
 use log::error;
-use parsec_interface::operations::psa_algorithm::*;
+use parsec_interface::operations::psa_algorithm::{AsymmetricSignature, Hash, SignHash};
+
 use parsec_interface::operations::psa_key_attributes::*;
 use parsec_interface::requests::ResponseStatus;
-use parsec_interface::requests::Result;
+use parsec_interface::requests::Result as ResponseResult;
 use picky_asn1::wrapper::ObjectIdentifierAsn1;
 use picky_asn1_x509::{
     algorithm_identifier::EcParameters, AlgorithmIdentifier, DigestInfo, ShaVariant,
 };
 use std::convert::TryInto;
-
 // Public exponent value for all RSA keys.
 pub const PUBLIC_EXPONENT: [u8; 3] = [0x01, 0x00, 0x01];
 
@@ -99,7 +101,7 @@ pub fn key_pair_usage_flags_to_pkcs11_attributes(
 }
 
 /// Format the input data into ASN1 DigestInfo bytes
-pub fn digest_info(alg: AsymmetricSignature, hash: Vec<u8>) -> Result<Vec<u8>> {
+pub fn digest_info(alg: AsymmetricSignature, hash: Vec<u8>) -> ResponseResult<Vec<u8>> {
     let oid = match alg {
         AsymmetricSignature::RsaPkcs1v15Sign {
             hash_alg: SignHash::Specific(Hash::Sha224),
@@ -123,7 +125,7 @@ pub fn digest_info(alg: AsymmetricSignature, hash: Vec<u8>) -> Result<Vec<u8>> {
     .map_err(|_| ResponseStatus::PsaErrorGenericError)
 }
 
-pub fn ec_params(ecc_family: EccFamily, bits: usize) -> Result<EcParameters> {
+pub fn ec_params(ecc_family: EccFamily, bits: usize) -> ResponseResult<EcParameters> {
     Ok(EcParameters::NamedCurve(match (ecc_family, bits) {
         // The following "unwrap()" should be ok, as they cover constant conversions
         (EccFamily::SecpR1, 192) => {
@@ -143,4 +145,59 @@ pub fn ec_params(ecc_family: EccFamily, bits: usize) -> Result<EcParameters> {
         }
         _ => return Err(ResponseStatus::PsaErrorNotSupported),
     }))
+}
+
+#[allow(deprecated)]
+/// Convert a PSA Crypto Hash algorithm to a MGF type
+pub fn pkcsmgftype_from_psa_crypto_hash(alg: Hash) -> Result<rsa::PkcsMgfType, Error> {
+    match alg {
+        Hash::Sha1 => Ok(rsa::PkcsMgfType::MGF1_SHA1),
+        Hash::Sha224 => Ok(rsa::PkcsMgfType::MGF1_SHA224),
+        Hash::Sha256 => Ok(rsa::PkcsMgfType::MGF1_SHA256),
+        Hash::Sha384 => Ok(rsa::PkcsMgfType::MGF1_SHA384),
+        Hash::Sha512 => Ok(rsa::PkcsMgfType::MGF1_SHA512),
+        alg => {
+            error!("{:?} is not a supported MGF1 algorithm", alg);
+            Err(Error::NotSupported)
+        }
+    }
+}
+
+#[allow(deprecated)]
+pub fn algorithm_to_mechanism(
+    alg: psa_crypto::types::algorithm::Algorithm,
+) -> Result<Mechanism, Error> {
+    use psa_crypto::types::algorithm::{Algorithm, AsymmetricEncryption};
+
+    match alg {
+        Algorithm::Hash(Hash::Sha1) => Ok(Mechanism::Sha1),
+        Algorithm::Hash(Hash::Sha256) => Ok(Mechanism::Sha256),
+        Algorithm::Hash(Hash::Sha384) => Ok(Mechanism::Sha384),
+        Algorithm::Hash(Hash::Sha512) => Ok(Mechanism::Sha512),
+        Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign { .. })
+        | Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaPkcs1v15Crypt { .. }) => {
+            Ok(Mechanism::RsaPkcs)
+        }
+        Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPss {
+            hash_alg: SignHash::Specific(hash_alg),
+        }) => Ok(Mechanism::RsaPkcsPss(rsa::PkcsPssParams {
+            hash_alg: algorithm_to_mechanism(Algorithm::from(hash_alg))?.mechanism_type(),
+            mgf: pkcsmgftype_from_psa_crypto_hash(hash_alg)?,
+            s_len: hash_alg.hash_length().try_into()?,
+        })),
+        Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa { .. }) => Ok(Mechanism::Ecdsa),
+        Algorithm::AsymmetricEncryption(AsymmetricEncryption::RsaOaep { hash_alg }) => {
+            Ok(Mechanism::RsaPkcsOaep(rsa::PkcsOaepParams {
+                hash_alg: algorithm_to_mechanism(Algorithm::from(hash_alg))?.mechanism_type(),
+                mgf: pkcsmgftype_from_psa_crypto_hash(hash_alg)?,
+                source: rsa::PkcsOaepSourceType::DATA_SPECIFIED,
+                source_data: std::ptr::null(),
+                source_data_len: 0.into(),
+            }))
+        }
+        alg => {
+            error!("{:?} is not a supported algorithm", alg);
+            Err(Error::NotSupported)
+        }
+    }
 }


### PR DESCRIPTION
 * Remove the psa-crypto-conversions feature from the cryptoki dependency in the Cargo.toml file. The psa-crypto crate is already being brought up in the Cargo.toml file and this would have lead to a crate conflict when upgrading.
 * Remove parsec's dependency on cryptoki's psa-crypto by creating helping functions to perform type conversions.

Signed-off-by: Tomás González <tomasagustin.gonzalezorlando@arm.com>
