### PR TITLE
Cargo.toml: Remove uuid crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,6 @@ dependencies = [
  "threadpool",
  "toml",
  "tss-esapi",
- "uuid",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/bin/main.rs"
 parsec-interface = "0.28.0"
 rand = { version = "0.8.3", features = ["small_rng"], optional = true }
 base64 = "0.21.0"
-uuid = "0.8.2"
 threadpool = "1.8.1"
 signal-hook = "0.3.4"
 sd-notify = "0.3.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1087,7 +1087,6 @@ dependencies = [
  "threadpool",
  "toml 0.5.9",
  "tss-esapi",
- "uuid",
  "zeroize",
 ]
 

--- a/src/providers/core/mod.rs
+++ b/src/providers/core/mod.rs
@@ -9,6 +9,7 @@ use super::Provide;
 use crate::authenticators::ApplicationIdentity;
 use derivative::Derivative;
 use log::{error, trace};
+use parsec_interface::operations::list_providers::Uuid;
 use parsec_interface::operations::{
     delete_client, list_authenticators, list_clients, list_keys, list_opcodes, list_providers,
     ping, psa_destroy_key,
@@ -21,7 +22,6 @@ use std::collections::{HashMap, HashSet};
 use std::io::{Error, ErrorKind};
 use std::num::ParseIntError;
 use std::sync::Arc;
-use uuid::Uuid;
 
 const SUPPORTED_OPCODES: [Opcode; 5] = [
     Opcode::ListProviders,

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -12,11 +12,11 @@ use crate::providers::ProviderIdentity;
 use derivative::Derivative;
 use log::{error, trace, warn};
 use parsec_interface::operations::list_providers::ProviderInfo;
+use parsec_interface::operations::list_providers::Uuid;
 use parsec_interface::operations::{list_clients, list_keys};
 use parsec_interface::requests::{Opcode, ProviderId, ResponseStatus, Result};
 use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
-use uuid::Uuid;
 
 use parsec_interface::operations::{
     psa_aead_decrypt, psa_aead_encrypt, psa_cipher_decrypt, psa_cipher_encrypt, psa_destroy_key,

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -10,6 +10,7 @@ use crate::providers::crypto_capability::CanDoCrypto;
 use crate::providers::ProviderIdentity;
 use derivative::Derivative;
 use log::{error, trace};
+use parsec_interface::operations::list_providers::Uuid;
 use parsec_interface::operations::{
     can_do_crypto, psa_aead_decrypt, psa_aead_encrypt, psa_asymmetric_decrypt,
     psa_asymmetric_encrypt, psa_destroy_key, psa_export_key, psa_export_public_key,
@@ -25,7 +26,6 @@ use std::sync::{
     atomic::{AtomicU32, Ordering::Relaxed},
     Mutex,
 };
-use uuid::Uuid;
 
 mod aead;
 mod asym_encryption;

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -15,6 +15,7 @@ use cryptoki::session::{Session, SessionFlags, UserType};
 use cryptoki::slot::Slot;
 use derivative::Derivative;
 use log::{error, info, trace, warn};
+use parsec_interface::operations::list_providers::Uuid;
 use parsec_interface::operations::{
     can_do_crypto, psa_asymmetric_decrypt, psa_asymmetric_encrypt, psa_destroy_key,
     psa_export_public_key, psa_generate_key, psa_generate_random, psa_import_key, psa_sign_hash,
@@ -30,7 +31,6 @@ use std::io::{Error, ErrorKind};
 use std::str::FromStr;
 use std::sync::RwLock;
 use utils::{to_response_status, KeyPairType};
-use uuid::Uuid;
 use zeroize::{Zeroize, Zeroizing};
 
 type LocalIdStore = HashSet<u32>;

--- a/src/providers/tpm/mod.rs
+++ b/src/providers/tpm/mod.rs
@@ -11,6 +11,7 @@ use crate::providers::crypto_capability::CanDoCrypto;
 use crate::providers::ProviderIdentity;
 use derivative::Derivative;
 use log::{info, trace};
+use parsec_interface::operations::list_providers::Uuid;
 use parsec_interface::operations::{
     attest_key, can_do_crypto, prepare_key_attestation, psa_asymmetric_decrypt,
     psa_asymmetric_encrypt, psa_destroy_key, psa_export_public_key, psa_generate_key,
@@ -26,7 +27,6 @@ use tss_esapi::interface_types::algorithm::HashingAlgorithm;
 use tss_esapi::interface_types::resource_handles::Hierarchy;
 use tss_esapi::structures::{SymmetricCipherParameters, SymmetricDefinitionObject};
 use tss_esapi::Tcti;
-use uuid::Uuid;
 use zeroize::Zeroize;
 
 mod asym_encryption;

--- a/src/providers/trusted_service/mod.rs
+++ b/src/providers/trusted_service/mod.rs
@@ -11,6 +11,7 @@ use context::Context;
 use derivative::Derivative;
 use log::{error, trace};
 use parsec_interface::operations::list_providers::ProviderInfo;
+use parsec_interface::operations::list_providers::Uuid;
 use parsec_interface::operations::{
     can_do_crypto, list_clients, list_keys, psa_asymmetric_decrypt, psa_asymmetric_encrypt,
     psa_destroy_key, psa_export_key, psa_export_public_key, psa_generate_key, psa_generate_random,
@@ -20,7 +21,6 @@ use parsec_interface::requests::{Opcode, ProviderId, Result};
 use psa_crypto::types::key;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU32, Ordering};
-use uuid::Uuid;
 
 mod asym_encryption;
 mod asym_sign;


### PR DESCRIPTION
The uuid crate is already being exposed by the parsec interface, so:

 * Stop importing the uuid crate and used the exposed structures from parsec_interface::operations::list_providers::Uuid