### PR TITLE
e2e_tests/wrong_permitted_algorithm: Change used sha for hw compatibi…

### DIFF
--- a/e2e_tests/Cargo.lock
+++ b/e2e_tests/Cargo.lock
@@ -303,12 +303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,11 +1666,10 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
- "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -1685,15 +1678,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -522,6 +522,17 @@ impl TestClient {
         )
     }
 
+    /// Signs a short digest with an RSA key.
+    pub fn sign_with_rsa_sha384(&mut self, key_name: String, hash: Vec<u8>) -> Result<Vec<u8>> {
+        self.sign(
+            key_name,
+            AsymmetricSignature::RsaPkcs1v15Sign {
+                hash_alg: Hash::Sha384.into(),
+            },
+            hash,
+        )
+    }
+
     /// Signs a short digest with an ECDSA key.
     pub fn sign_with_ecdsa_sha256(&mut self, key_name: String, hash: Vec<u8>) -> Result<Vec<u8>> {
         self.sign(

--- a/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
+++ b/e2e_tests/tests/per_provider/normal_tests/key_attributes.rs
@@ -134,7 +134,7 @@ fn wrong_permitted_algorithm() {
     // Do not permit RSA PKCS 1v15 signing algorithm with SHA-256.
     let permitted_algorithm =
         Algorithm::AsymmetricSignature(AsymmetricSignature::RsaPkcs1v15Sign {
-            hash_alg: Hash::Sha512.into(),
+            hash_alg: Hash::Sha256.into(),
         });
     let mut usage_flags: UsageFlags = Default::default();
     let _ = usage_flags.set_sign_hash();
@@ -159,7 +159,7 @@ fn wrong_permitted_algorithm() {
         .unwrap();
 
     let status = client
-        .sign_with_rsa_sha256(key_name, vec![0xDE; 32])
+        .sign_with_rsa_sha384(key_name, vec![0xDE; 32])
         .unwrap_err();
 
     assert_eq!(status, ResponseStatus::PsaErrorNotPermitted);


### PR DESCRIPTION
…lity

TPM 2.0 specifies in
https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-v1p05p_r14_pub.pdf#%5B%7B%22num%22%3A82%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C33%2C375%2C0%5D "A conformant TPM SHALL support SHA-384 (0x000C) and SHA-256 (0x000B)"

 * Use this SHAs for testing.
 * Update the Cargo.lock file to guarantee compilation of tests with MSRV.