### PR TITLE
ci/coverage: Fix cargo-tarpaulin to its locked version

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -254,7 +254,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
     UNIT_TEST_FEATURES="unix-peer-credentials-authenticator,direct-authenticator"
     # Install tarpaulin
     # TODO: Stop using the --version parameter when MSRV is upgraded.
-    cargo +${MSRV} install cargo-tarpaulin --version 0.26.1
+    cargo +${MSRV} install cargo-tarpaulin --version 0.26.1 --locked
 
     mkdir -p reports
 


### PR DESCRIPTION
cargo-tarpaulin's dependency toml_datetime has made a patch update to v0.6.5 which requires rust version 1.67 or newer. As our MSRV is currently 1.66.0:
 * use the '--locked' option to build cargo-tarpaulin instead.