### PR TITLE
Track and test dependencies' 'next' branch

### DIFF
--- a/.github/actions/ci_script/action.yml
+++ b/.github/actions/ci_script/action.yml
@@ -1,0 +1,19 @@
+name: "Run CI Tests"
+description: "Run the ci.sh script with the specified flags"
+inputs:
+    ci-flags:
+      required: true
+      description: "Flags with which to run the ci.sh tests"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Load Docker
+      uses: ./.github/actions/load_docker
+      if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
+      with:
+        image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
+        image-path: "/tmp"
+    - name: Run the container to execute the test script
+      run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh ${{ inputs.ci-flags }}
+      shell: bash

--- a/.github/actions/load_docker/action.yml
+++ b/.github/actions/load_docker/action.yml
@@ -7,7 +7,7 @@ inputs:
    image-path:
       required: true
       description: "Path to save the docker image"
-# ...name, description and inputs as above
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,11 @@ jobs:
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
-        with:
-          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
-          image-path: "/tmp"
+      - uses: actions/checkout@v3
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh all
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "all"
 
   build-all-providers:
     name: Cargo check all-providers (current Rust stable & old compiler)
@@ -52,15 +48,11 @@ jobs:
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
-        with:
-          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
-          image-path: "/tmp"
+      - uses: actions/checkout@v3
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh cargo-check
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "cargo-check"
 
   mbed-crypto-provider:
     name: Integration tests using Mbed Crypto provider
@@ -68,15 +60,11 @@ jobs:
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
-        with:
-          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
-          image-path: "/tmp"
+      - uses: actions/checkout@v3
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh mbed-crypto
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "mbed-crypto"
 
   pkcs11-provider:
     name: Integration tests using PKCS 11 provider
@@ -84,15 +72,11 @@ jobs:
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
-        with:
-          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
-          image-path: "/tmp"
+      - uses: actions/checkout@v3
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh pkcs11 --no-stress-test
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "pkcs11 --no-stress-test"
 
   tpm-provider:
     name: Integration tests using TPM provider
@@ -100,15 +84,11 @@ jobs:
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
-        with:
-          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
-          image-path: "/tmp"
+      - uses: actions/checkout@v3
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh tpm
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "tpm"
 
   trusted-service-provider:
     name: Integration tests using Crypto Trusted Service provider
@@ -116,15 +96,11 @@ jobs:
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
-        with:
-          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
-          image-path: "/tmp"
+      - uses: actions/checkout@v3
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh trusted-service
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "trusted-service"
 
   cryptoauthlib-provider:
     name: Integration tests using CryptoAuthentication Library provider
@@ -132,15 +108,11 @@ jobs:
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
-        with:
-          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
-          image-path: "/tmp"
+      - uses: actions/checkout@v3
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh cryptoauthlib --no-stress-test
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "cryptoauthlib --no-stress-test"
 
   fuzz-test-checker:
     name: Check that the fuzz testing framework is still working
@@ -170,15 +142,11 @@ jobs:
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Load Docker
-        uses: ./.github/actions/load_docker
-        if: ${{ env.TEST_ALL_DOCKER_IMAGE == 'parsec-service-test-all' }}
-        with:
-          image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
-          image-path: "/tmp"
+      - uses: actions/checkout@v3
       - name: Run the container to execute the test script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh on-disk-kim
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "on-disk-kim"
 
   cross-compilation:
     # Currently only the Mbed Crypto, PKCS 11, and TPM providers are tested as the other ones need to cross-compile other libraries.

--- a/.github/workflows/nightly-next.yml
+++ b/.github/workflows/nightly-next.yml
@@ -1,0 +1,89 @@
+name: Nightly Next Branch Checks
+
+on:
+  schedule:
+    # Every night at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      rev:
+        description: "Revision hash to run against"
+        required: false
+        default: ""
+
+
+env:
+  TEST_ALL_DOCKER_IMAGE: 'ghcr.io/parallaxsecond/parsec-service-test-all'
+
+jobs:
+  all-providers:
+    name: Various tests targeting a Parsec image with all providers included
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Run the container to execute the test script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "all --test-next-branch-tracking"
+
+  build-all-providers:
+    name: Cargo check all-providers (current Rust stable & old compiler)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Run the container to execute the test script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "cargo-check --test-next-branch-tracking"
+
+  mbed-crypto-provider:
+    name: Integration tests using Mbed Crypto provider
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Run the container to execute the test script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "mbed-crypto --test-next-branch-tracking"
+
+  pkcs11-provider:
+    name: Integration tests using PKCS 11 provider
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Run the container to execute the test script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "pkcs11 --no-stress-test --test-next-branch-tracking"
+
+  tpm-provider:
+    name: Integration tests using TPM provider
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Run the container to execute the test script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "tpm --test-next-branch-tracking"
+
+  trusted-service-provider:
+    name: Integration tests using Crypto Trusted Service provider
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Run the container to execute the test script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "trusted-service --test-next-branch-tracking"

--- a/ci.sh
+++ b/ci.sh
@@ -212,8 +212,7 @@ done
 
 if [ "$TEST_NEXT_BRANCH_TRACKING" ]; then
     echo "Track next branches for parallaxsecond repositories"
-    mkdir -p /tmp/clonings
-    python3 $(pwd)/utils/release_tracking.py --clone_dir /tmp/clonings $(pwd)/Cargo.toml $(pwd)/e2e_tests/Cargo.toml
+    python3 $(pwd)/utils/release_tracking.py $(pwd)/Cargo.toml $(pwd)/e2e_tests/Cargo.toml
     next_branch_result=$?
     if [ "$next_branch_result" -ne 0 ]; then
         error_msg "Failed to track next branches of parallaxsecond repositories."

--- a/ci.sh
+++ b/ci.sh
@@ -162,6 +162,7 @@ MSRV=1.66.0
 NO_CARGO_CLEAN=
 NO_STRESS_TEST=
 PROVIDER_NAME=
+TEST_NEXT_BRANCH_TRACKING=
 CONFIG_PATH=$(pwd)/e2e_tests/provider_cfg/tmp_config.toml
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -170,6 +171,9 @@ while [ "$#" -gt 0 ]; do
         ;;
         --no-stress-test )
             NO_STRESS_TEST="True"
+        ;;
+        --test-next-branch-tracking )
+            TEST_NEXT_BRANCH_TRACKING="True"
         ;;
         mbed-crypto | pkcs11 | tpm | trusted-service | cryptoauthlib | all | cargo-check | on-disk-kim)
             if [ -n "$PROVIDER_NAME" ]; then
@@ -205,6 +209,16 @@ while [ "$#" -gt 0 ]; do
     esac
     shift
 done
+
+if [ "$TEST_NEXT_BRANCH_TRACKING" ]; then
+    echo "Track next branches for parallaxsecond repositories"
+    mkdir -p /tmp/clonings
+    python3 $(pwd)/utils/release_tracking.py --clone_dir /tmp/clonings $(pwd)/Cargo.toml $(pwd)/e2e_tests/Cargo.toml
+    next_branch_result=$?
+    if [ "$next_branch_result" -ne 0 ]; then
+        error_msg "Failed to track next branches of parallaxsecond repositories."
+    fi
+fi
 
 # Check if the PROVIDER_NAME was given.
 if [ -z "$PROVIDER_NAME" ]; then

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -10,7 +10,7 @@ def run_cargo_tree(path):
     cmd += '--features tss-esapi/generate-bindings,cryptoki/generate-bindings -d'
     prev_dir = os.getcwd()
     os.chdir(os.path.join(path))
-    return subprocess.check_output(cmd.split(' ')).decode()
+    return subprocess.check_output(cmd, shell=True).decode()
 
 
 def run_deps_mismatcher(lines):

--- a/utils/release_tracking.py
+++ b/utils/release_tracking.py
@@ -8,44 +8,40 @@ import sys
 def run_cargo_build(path):
     print(f"cargo build, path: {path}")
     command = f'cargo build'
-    subprocess.check_output(command.split(), cwd=path)
+    return subprocess.check_output(command, shell=True, cwd=path)
 
 
-def clone_repo(clone_dir, repo_name, branch):
-    git_repo = f"https://github.com/parallaxsecond/{repo_name}.git"
-    future_repo_dir = os.path.join(clone_dir, repo_name)
-    if not os.path.isdir(future_repo_dir):
-        command = f"git clone {git_repo} -b {branch} {future_repo_dir}"
-        subprocess.check_output(command.split())
-        command = f"git submodule update --init"
-        subprocess.check_output(command.split(), cwd=future_repo_dir)
+def run_cargo_update(path, dep):
+    print(f"cargo update, dep: {dep}")
+    command = f'cargo update --package {dep}'
+    return subprocess.check_output(command, shell=True, cwd=path)
 
 
-def git_toml_deps(toml_path, updatable_deps, deps_repos):
+def git_toml_deps(toml_path, deps_repo_links, deps_branches):
     lines = None
     with open(toml_path, 'r') as f:
         lines = f.readlines()
 
-    for i in range(len(lines)):
-        line = lines[i]
-        for dep in updatable_deps.keys():
-            if line.startswith(dep + " ="):
-                # All occurences
-                line = line.replace("'", '"')
-                if "{" not in line:
-                    # First occurence
-                    line = line.replace('"', '{ version = "', 1)
-                    line = line.rstrip() + ' }\n'
+    to_update = []
+    output_lines = lines + ['[patch.crates-io]\n']
+    for line in lines:
+        for dep in deps_repo_links.keys():
+            starter = dep + " ="
+            if line.startswith(starter):
+                to_update.append(dep)
+                new_line = f'git = "{deps_repo_links[dep]}", branch = "{deps_branches[dep]}"'
+                new_line = starter + ' { ' + new_line + ' }\n'
+                output_lines.append(new_line)
 
-                if 'path' not in line:
-                    line = re.sub(r'version = "[0-9\.]+"', f'path = "{deps_repos[dep]}"', line)
-                lines[i] = line
-
-                dirname = os.path.relpath('.')
+    for updatable in to_update:
+        run_cargo_update(os.path.dirname(toml_path), updatable)
 
     with open(toml_path, 'w') as f:
-        f.writelines(lines)
-    print(subprocess.check_output(['git', 'diff'], cwd=os.path.dirname(toml_path)).decode('utf-8'))
+        f.writelines(output_lines)
+    git_cmd = 'git diff'
+    print(subprocess.check_output(git_cmd,
+                                  shell=True,
+                                  cwd=os.path.dirname(toml_path)).decode('utf-8'))
 
 
 def main(argv=[], prog_name=''):
@@ -53,10 +49,7 @@ def main(argv=[], prog_name=''):
                                      description='Modifies the parsec Cargo.toml files to use the '
                                                  'main branches of parallaxsecond dependencies in '
                                                  'preparation for their publishing and release')
-    parser.add_argument('--clone_dir',
-                        required=True,
-                        help='Existing directory into which repositories should be cloned')
-    parser.add_argument('paths', nargs='+', help='Paths to Cargo.toml files to be modified')
+    parser.add_argument('paths', nargs='+', help='Absolute paths to the Cargo.toml files')
     args = parser.parse_args()
 
     # The order is important!
@@ -71,25 +64,15 @@ def main(argv=[], prog_name=''):
         'parsec-client': 'parsec-client-rust',
     }
 
-    repo_paths = { repo_name: f'{args.clone_dir}/{repo_folder}/{repo_name}' \
+    repo_links = { repo_name: f"https://github.com/parallaxsecond/{repo_folder}.git" \
                    for repo_name, repo_folder in parallaxsecond_deps.items() }
-    repo_paths['parsec-interface'] = f'{args.clone_dir}/parsec-interface-rs'
-    repo_paths['parsec-client'] = f'{args.clone_dir}/parsec-client-rust'
 
     repo_branches = { repo_name: 'main' for repo_name in parallaxsecond_deps.keys() }
     repo_branches['tss-esapi-sys'] = '7.x.y'
     repo_branches['tss-esapi'] = '7.x.y'
 
-    for repo_name, repo_folder in parallaxsecond_deps.items():
-        clone_repo(args.clone_dir, repo_folder, repo_branches[repo_name])
-        toml_path = os.path.join(repo_paths[repo_name], 'Cargo.toml')
-        git_toml_deps(toml_path, parallaxsecond_deps, repo_paths)
-
-    for repo_path in repo_paths.values():
-        run_cargo_build(repo_path)
-
     for path in args.paths:
-        git_toml_deps(path, parallaxsecond_deps, repo_paths)
+        git_toml_deps(path, repo_links, repo_branches)
         run_cargo_build(os.path.dirname(path))
 
     return 0

--- a/utils/release_tracking.py
+++ b/utils/release_tracking.py
@@ -1,0 +1,99 @@
+import argparse
+import re
+import os
+import subprocess
+import sys
+
+
+def run_cargo_build(path):
+    print(f"cargo build, path: {path}")
+    command = f'cargo build'
+    subprocess.check_output(command.split(), cwd=path)
+
+
+def clone_repo(clone_dir, repo_name, branch):
+    git_repo = f"https://github.com/parallaxsecond/{repo_name}.git"
+    future_repo_dir = os.path.join(clone_dir, repo_name)
+    if not os.path.isdir(future_repo_dir):
+        command = f"git clone {git_repo} -b {branch} {future_repo_dir}"
+        subprocess.check_output(command.split())
+        command = f"git submodule update --init"
+        subprocess.check_output(command.split(), cwd=future_repo_dir)
+
+
+def git_toml_deps(toml_path, updatable_deps, deps_repos):
+    lines = None
+    with open(toml_path, 'r') as f:
+        lines = f.readlines()
+
+    for i in range(len(lines)):
+        line = lines[i]
+        for dep in updatable_deps.keys():
+            if line.startswith(dep + " ="):
+                # All occurences
+                line = line.replace("'", '"')
+                if "{" not in line:
+                    # First occurence
+                    line = line.replace('"', '{ version = "', 1)
+                    line = line.rstrip() + ' }\n'
+
+                if 'path' not in line:
+                    line = re.sub(r'version = "[0-9\.]+"', f'path = "{deps_repos[dep]}"', line)
+                lines[i] = line
+
+                dirname = os.path.relpath('.')
+
+    with open(toml_path, 'w') as f:
+        f.writelines(lines)
+    print(subprocess.check_output(['git', 'diff'], cwd=os.path.dirname(toml_path)).decode('utf-8'))
+
+
+def main(argv=[], prog_name=''):
+    parser = argparse.ArgumentParser(prog='ReleaseTracker',
+                                     description='Modifies the parsec Cargo.toml files to use the '
+                                                 'main branches of parallaxsecond dependencies in '
+                                                 'preparation for their publishing and release')
+    parser.add_argument('--clone_dir',
+                        required=True,
+                        help='Existing directory into which repositories should be cloned')
+    parser.add_argument('paths', nargs='+', help='Paths to Cargo.toml files to be modified')
+    args = parser.parse_args()
+
+    # The order is important!
+    parallaxsecond_deps = {
+        'psa-crypto-sys': 'rust-psa-crypto',
+        'psa-crypto': 'rust-psa-crypto',
+        'tss-esapi-sys': 'rust-tss-esapi',
+        'tss-esapi': 'rust-tss-esapi',
+        'cryptoki-sys': 'rust-cryptoki',
+        'cryptoki': 'rust-cryptoki',
+        'parsec-interface': 'parsec-interface-rs',
+        'parsec-client': 'parsec-client-rust',
+    }
+
+    repo_paths = { repo_name: f'{args.clone_dir}/{repo_folder}/{repo_name}' \
+                   for repo_name, repo_folder in parallaxsecond_deps.items() }
+    repo_paths['parsec-interface'] = f'{args.clone_dir}/parsec-interface-rs'
+    repo_paths['parsec-client'] = f'{args.clone_dir}/parsec-client-rust'
+
+    repo_branches = { repo_name: 'main' for repo_name in parallaxsecond_deps.keys() }
+    repo_branches['tss-esapi-sys'] = '7.x.y'
+    repo_branches['tss-esapi'] = '7.x.y'
+
+    for repo_name, repo_folder in parallaxsecond_deps.items():
+        clone_repo(args.clone_dir, repo_folder, repo_branches[repo_name])
+        toml_path = os.path.join(repo_paths[repo_name], 'Cargo.toml')
+        git_toml_deps(toml_path, parallaxsecond_deps, repo_paths)
+
+    for repo_path in repo_paths.values():
+        run_cargo_build(repo_path)
+
+    for path in args.paths:
+        git_toml_deps(path, parallaxsecond_deps, repo_paths)
+        run_cargo_build(os.path.dirname(path))
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:], sys.argv[0]))


### PR DESCRIPTION
parsec depends on several repositories under the parallaxsecond organization.

Currently, when testing the main branch of parsec, fixed versions of the latest released crates of those repositories are being used.
A problem may arise when there is a change introduced in the main/'next' branch of those repositories that would break parsec when updating/incorporating that change. This is currently not being tested in our CI.
As parsec release is dependent on having published the dependencies' crates, there are issues that will not be caught until the publishing of said crates.

* Add nightly jobs that use ci.sh --next-branch-tracking to test the
  next release branches of parallaxsecond repositories and spot
  issues before release. These jobs make use of previously defined
  re-usable actions and utils/release_tracking.py
