### PR TITLE
Cargo.toml: Specify rust-version=1.66.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["security", "service"]
 categories = ["cryptography", "hardware-support"]
 edition = "2018"
+rust-version = "1.66.0"
 
 [[bin]]
 name = "parsec"


### PR DESCRIPTION
Mark MSRV (Minimum Supported Rust Version) as 1.66.0