### PR TITLE
cargo-check: Run with both stable and MSRV Compilers

### DIFF
--- a/.github/actions/ci_script/action.yml
+++ b/.github/actions/ci_script/action.yml
@@ -4,6 +4,10 @@ inputs:
     ci-flags:
       required: true
       description: "Flags with which to run the ci.sh tests"
+    rs-version:
+      required: true
+      default: "stable"
+      description: "Rust version with which to run the tests"
 
 runs:
   using: "composite"
@@ -15,5 +19,5 @@ runs:
         image-name: "${{ env.TEST_ALL_DOCKER_IMAGE }}"
         image-path: "/tmp"
     - name: Run the container to execute the test script
-      run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh ${{ inputs.ci-flags }}
+      run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec --env RUST_TOOLCHAIN_VERSION=${{ inputs.rs-version }} -t ${{ env.TEST_ALL_DOCKER_IMAGE }} /tmp/parsec/ci.sh ${{ inputs.ci-flags }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,21 @@ jobs:
         with:
           ci-flags: "all"
 
-  build-all-providers:
-    name: Cargo check all-providers (current Rust stable & old compiler)
+  build-all-providers-msrv:
+    name: MSRV - Cargo check all-providers
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [build-and-export-test-all-docker]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run the container to execute the test script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "cargo-check"
+          rs-version: "1.66.0"
+
+  build-all-providers-stable:
+    name: Cargo check all-providers (current Rust stable)
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs: [build-and-export-test-all-docker]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           ref: "${{ github.event.inputs.rev }}"
       - name: Run the container to execute the coverage script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec --security-opt seccomp=unconfined ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh coverage
+        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec --security-opt seccomp=unconfined --env RUST_TOOLCHAIN_VERSION=1.66.0 ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh coverage
       - name: Collect coverage results
         run: bash <(curl -s https://codecov.io/bash)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,12 +304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,11 +1794,10 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
- "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -1813,15 +1806,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]

--- a/ci.sh
+++ b/ci.sh
@@ -274,7 +274,7 @@ fi
 git submodule update --init
 
 if [ "$PROVIDER_NAME" = "coverage" ]; then
-    rustup toolchain install ${MSRV}
+    rustup default ${MSRV}
     PROVIDERS="trusted-service mbed-crypto tpm pkcs11"
     EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/authenticators/jwt_svid_authenticator/*"
     UNIT_TEST_FEATURES="unix-peer-credentials-authenticator,direct-authenticator"
@@ -360,12 +360,12 @@ if [ "$PROVIDER_NAME" = "cargo-check" ]; then
     # - openSUSE Tumbleweed
     # - openSUSE Leap 15.4
 
-    rustup toolchain install ${MSRV}
+    rustup default ${MSRV}
     # TODO: The "jwt-svid-authenticator" is currently not being used.
     RUST_BACKTRACE=1 cargo +${MSRV} check --release --features=all-providers,direct-authenticator,unix-peer-credentials-authenticator
 
     # Latest stable
-    rustup toolchain install stable
+    rustup default stable
     RUST_BACKTRACE=1 cargo +stable check --release $FEATURES
 
     # We test that each feature still exist.

--- a/ci.sh
+++ b/ci.sh
@@ -360,13 +360,10 @@ if [ "$PROVIDER_NAME" = "cargo-check" ]; then
     # - openSUSE Tumbleweed
     # - openSUSE Leap 15.4
 
-    rustup default ${MSRV}
     # TODO: The "jwt-svid-authenticator" is currently not being used.
-    RUST_BACKTRACE=1 cargo +${MSRV} check --release --features=all-providers,direct-authenticator,unix-peer-credentials-authenticator
+    RUST_BACKTRACE=1 cargo check --release --features=all-providers,direct-authenticator,unix-peer-credentials-authenticator
 
-    # Latest stable
-    rustup default stable
-    RUST_BACKTRACE=1 cargo +stable check --release $FEATURES
+    RUST_BACKTRACE=1 cargo check --release $FEATURES
 
     # We test that each feature still exist.
     RUST_BACKTRACE=1 cargo check

--- a/ci.sh
+++ b/ci.sh
@@ -154,7 +154,11 @@ setup_mappings() {
     fi
 }
 
-# Use the newest version of the Rust toolchain
+# Change rust toolchain version
+if [[ ! -z ${RUST_TOOLCHAIN_VERSION:+x} ]]; then
+	rustup override set ${RUST_TOOLCHAIN_VERSION}
+fi
+
 rustup update
 MSRV=1.66.0
 

--- a/ci.sh
+++ b/ci.sh
@@ -160,7 +160,6 @@ if [[ ! -z ${RUST_TOOLCHAIN_VERSION:+x} ]]; then
 fi
 
 rustup update
-MSRV=1.66.0
 
 # Parse arguments
 NO_CARGO_CLEAN=
@@ -278,13 +277,12 @@ fi
 git submodule update --init
 
 if [ "$PROVIDER_NAME" = "coverage" ]; then
-    rustup default ${MSRV}
     PROVIDERS="trusted-service mbed-crypto tpm pkcs11"
     EXCLUDES="fuzz/*,e2e_tests/*,src/providers/cryptoauthlib/*,src/authenticators/jwt_svid_authenticator/*"
     UNIT_TEST_FEATURES="unix-peer-credentials-authenticator,direct-authenticator"
     # Install tarpaulin
-    # TODO: Stop using the --version parameter when MSRV is upgraded.
-    cargo +${MSRV} install cargo-tarpaulin --version 0.26.1 --locked
+    # TODO: Stop using the --version parameter when MSRV is upgraded (>1.66.0)
+    cargo install cargo-tarpaulin --version 0.26.1 --locked
 
     mkdir -p reports
 
@@ -300,7 +298,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
         cp -r $(pwd)/e2e_tests/fake_mappings/* mappings
 
         # Start service
-        RUST_LOG=info cargo +${MSRV} tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
+        RUST_LOG=info cargo tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
             --output-dir $(pwd)/reports/$provider --features="$provider-provider,direct-authenticator" \
             --run-types bins --timeout 3600 -- -c $CONFIG_PATH &
         wait_for_service
@@ -318,7 +316,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
         fi
 
         # Start service
-        RUST_LOG=info cargo +${MSRV} tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
+        RUST_LOG=info cargo tarpaulin --out Xml --forward --command build --exclude-files="$EXCLUDES" \
             --output-dir $(pwd)/reports/$provider --features="$provider-provider,direct-authenticator" \
             --run-types bins --timeout 3600 -- -c $CONFIG_PATH &
         wait_for_service
@@ -329,7 +327,7 @@ if [ "$PROVIDER_NAME" = "coverage" ]; then
 
     # Run unit tests
     mkdir -p reports/unit
-    cargo +${MSRV} tarpaulin --tests --out Xml --features=$UNIT_TEST_FEATURES --exclude-files="$EXCLUDES" --output-dir $(pwd)/reports/unit
+    cargo tarpaulin --tests --out Xml --features=$UNIT_TEST_FEATURES --exclude-files="$EXCLUDES" --output-dir $(pwd)/reports/unit
 
     exit 0
 fi


### PR DESCRIPTION
- Introduce a RUST_TOOLCHAIN_VERSION environment variable that gets used in ci.sh to decide on the compiler to use.
- Use this variable when running variable on nightly (coverage) or build checks on each pr.
- cargo check will now cover all feature cases with both MSRV and stable, which it was not doing. Fix the cargo check build with MSRV for certain options that were not being covered by fixing versions on the Cargo.lock file.