### PR TITLE
dependency_cross_matcher job: Move to PR runs and minor refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,3 +191,15 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
+
+  mismatcher:
+    name: Check for mismatched dependencies (those that have more than one version)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "${{ github.event.inputs.rev }}"
+      - name: Run the container to execute the dependency mismatcher script
+        uses: ./.github/actions/ci_script
+        with:
+          ci-flags: "mismatcher"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,13 +55,3 @@ jobs:
         run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec --security-opt seccomp=unconfined --env RUST_TOOLCHAIN_VERSION=1.66.0 ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh coverage
       - name: Collect coverage results
         run: bash <(curl -s https://codecov.io/bash)
-
-  mismatcher:
-    name: Check for mismatched dependencies (those that have more than one version)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: "${{ github.event.inputs.rev }}"
-      - name: Run the container to execute the dependency mismatcher script
-        run: docker run -v $(pwd):/tmp/parsec -w /tmp/parsec ghcr.io/parallaxsecond/parsec-service-test-all /tmp/parsec/ci.sh mismatcher

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -61,7 +61,7 @@ def main(argv=[], prog_name=''):
     exceptions = {
         'base64': ['v0.13.1', 'v0.21.4'],
         'bindgen': ['v0.57.0', 'v0.66.1'],
-        'bitflags': ['v1.3.2', 'v2.4.0'],
+        'bitflags': ['v1.3.2', 'v2.4.1'],
         'cexpr': ['v0.4.0', 'v0.6.0'],
         'nom': ['v5.1.3', 'v7.1.3'],
         'shlex': ['v0.1.1', 'v1.2.0'],

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -55,9 +55,7 @@ def main(argv=[], prog_name=''):
 
     mismatches = get_deps_with_more_than_1v(mismatches)
 
-    print('---------------------mistmatches----------------------\n\n')
-    print_deps(mismatches)
-
+    print('---------------------exceptions-----------------------\n\n')
     exceptions = {
         'base64': ['v0.13.1', 'v0.21.4'],
         'bindgen': ['v0.57.0', 'v0.66.1'],
@@ -67,6 +65,10 @@ def main(argv=[], prog_name=''):
         'shlex': ['v0.1.1', 'v1.2.0'],
         'syn': ['v1.0.109', 'v2.0.38'],
     }
+    print_deps(exceptions)
+
+    print('---------------------mistmatches----------------------\n\n')
+    print_deps(mismatches)
 
     if exceptions != mismatches:
         return 1


### PR DESCRIPTION
bitflags crate was recently updated to 2.4.1 in the Cargo.lock files. This has shown potential improvements on the job, as a new mismatch appeared in the nightly when we could easily have discovered it in a normal CI run.

 * Update the mismatcher job so that it's run on each PR instead of on a nightly
 * Print both mismatches and exception lists so that it's easy to spot the issue from the logs 
 * Update the exceptions list in dependency_cross_matcher.py to reflect the bitflags version change (For more information, see https://github.com/parallaxsecond/parsec/pull/741)