### PR TITLE
Dependency mismatcher Comparison option

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -231,10 +231,6 @@ trap cleanup EXIT
 
 if [ "$PROVIDER_NAME" = "mismatcher" ]; then
     python3 $(pwd)/utils/dependency_cross_matcher.py --deps_dir $(pwd)
-    mismatcher_result=$?
-    if [ "$mismatcher_result" -ne 0 ]; then
-        error_msg "Found dependencies version mismatches"
-    fi
 
     exit 0
 fi

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -11,9 +11,10 @@ import subprocess
 import sys
 
 
-def run_cargo_tree(path):
-    cmd = 'cargo tree --all-features '
-    cmd += '--features tss-esapi/generate-bindings,cryptoki/generate-bindings -d'
+def run_cargo_tree(path, flags=None):
+    cmd = 'cargo tree'
+    if flags is not None:
+        cmd += ' ' + flags
     prev_dir = os.getcwd()
     os.chdir(os.path.join(path))
     return subprocess.check_output(cmd, shell=True).decode()
@@ -56,7 +57,9 @@ def main(argv=[], prog_name=''):
                              'dependencies')
     args = parser.parse_args()
 
-    mismatches = run_deps_mismatcher(run_cargo_tree(args.deps_dir))
+    parsec_flags = '--all-features' + ' '
+    parsec_flags += '--features tss-esapi/generate-bindings,cryptoki/generate-bindings -d'
+    mismatches = run_deps_mismatcher(run_cargo_tree(args.deps_dir, parsec_flags))
     print_deps(mismatches)
 
     mismatches = get_deps_with_more_than_1v(mismatches)

--- a/utils/dependency_cross_matcher.py
+++ b/utils/dependency_cross_matcher.py
@@ -1,3 +1,9 @@
+# Copyright 2023 Contributors to the Parsec project.
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks the version mismatches for dependencies in Cargo based repositories:
+# * In parsec itself
+# * Between parsec and parsec-tool
 import argparse
 import re
 import os


### PR DESCRIPTION
 * Add an option to the dependency mismatcher job to compare both parsec and parsec-tool repository.
 * Minor improvements to the "generics" of the code and its maintainability