### PR TITLE
Use infallible conversion into instead of try_into

### DIFF
--- a/src/providers/trusted_service/context/asym_encryption.rs
+++ b/src/providers/trusted_service/context/asym_encryption.rs
@@ -6,22 +6,16 @@ use super::ts_protobuf::{
 use super::Context;
 use parsec_interface::operations::psa_algorithm::AsymmetricEncryption;
 use parsec_interface::requests::ResponseStatus;
-use std::convert::TryInto;
-use zeroize::Zeroize;
 
 impl Context {
     pub fn asym_encrypt(
         &self,
         key_id: u32,
         alg: AsymmetricEncryption,
-        mut plaintext: Vec<u8>,
-        mut salt: Vec<u8>,
+        plaintext: Vec<u8>,
+        salt: Vec<u8>,
     ) -> Result<Vec<u8>, ResponseStatus> {
-        let alg = alg.try_into().map_err(|e| {
-            plaintext.zeroize();
-            salt.zeroize();
-            e
-        })?;
+        let alg = alg.into();
         let req = AsymmetricEncryptIn {
             id: key_id,
             alg,
@@ -37,14 +31,10 @@ impl Context {
         &self,
         key_id: u32,
         alg: AsymmetricEncryption,
-        mut ciphertext: Vec<u8>,
-        mut salt: Vec<u8>,
+        ciphertext: Vec<u8>,
+        salt: Vec<u8>,
     ) -> Result<Vec<u8>, ResponseStatus> {
-        let alg = alg.try_into().map_err(|e| {
-            ciphertext.zeroize();
-            salt.zeroize();
-            e
-        })?;
+        let alg = alg.into();
         let req = AsymmetricDecryptIn {
             id: key_id,
             alg,

--- a/src/providers/trusted_service/context/asym_sign.rs
+++ b/src/providers/trusted_service/context/asym_sign.rs
@@ -5,7 +5,6 @@ use super::ts_protobuf::{SignHashIn, SignHashOut, VerifyHashIn};
 use super::Context;
 use log::info;
 use psa_crypto::types::algorithm::AsymmetricSignature;
-use std::convert::TryInto;
 
 impl Context {
     /// Sign a hash with an asymmetric key given its ID and the signing algorithm.
@@ -19,7 +18,7 @@ impl Context {
         let proto_req = SignHashIn {
             id: key_id,
             hash,
-            alg: algorithm.try_into()?,
+            alg: algorithm.into(),
         };
         let SignHashOut { signature } = self.send_request(&proto_req)?;
 
@@ -39,7 +38,7 @@ impl Context {
             id: key_id,
             hash,
             signature,
-            alg: algorithm.try_into()?,
+            alg: algorithm.into(),
         };
         self.send_request(&proto_req)?;
 

--- a/src/providers/trusted_service/context/key_management.rs
+++ b/src/providers/trusted_service/context/key_management.rs
@@ -25,7 +25,7 @@ impl Context {
                 lifetime: KeyLifetime::Persistent as u32,
                 id,
                 policy: Some(KeyPolicy {
-                    usage: key_attrs.policy.usage_flags.try_into()?,
+                    usage: key_attrs.policy.usage_flags.into(),
                     alg: key_attrs.policy.permitted_algorithms.try_into()?,
                 }),
             }),

--- a/src/providers/trusted_service/context/ts_protobuf.rs
+++ b/src/providers/trusted_service/context/ts_protobuf.rs
@@ -83,3 +83,17 @@ impl Drop for VerifyHashIn {
         self.signature.zeroize();
     }
 }
+
+impl Drop for AsymmetricEncryptIn {
+    fn drop(&mut self) {
+        self.plaintext.zeroize();
+        self.salt.zeroize();
+    }
+}
+
+impl Drop for AsymmetricDecryptIn {
+    fn drop(&mut self) {
+        self.ciphertext.zeroize();
+        self.salt.zeroize();
+    }
+}


### PR DESCRIPTION
A new clippy lint https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_fallible_conversions has been added to rust 1.75.0 that is causing the CI failure. The use of try_into when into is available will be reported by the lint now.

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>