### PR TITLE
Cargo.toml: Bump tss-esapi to 7.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1871,12 +1871,13 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de234df360c349f78ecd33f0816ab3842db635732212b5cfad67f2638336864e"
+checksum = "d36722a0888ff29225d11ea205f10319d6cb4d072ef3c91bf3509f7f476d89e3"
 dependencies = [
  "bitfield",
  "enumflags2",
+ "getrandom",
  "hostname-validator",
  "log",
  "mbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.14", features = ["serde"] }
 cryptoki = { version = "0.6.0", optional = true, default-features = false }
 picky-asn1-der = { version = "0.4.0", optional = true }
 picky-asn1 = { version = "0.8.0", optional = true }
-tss-esapi = { version = "7.4.0", optional = true }
+tss-esapi = { version = "7.5.0", optional = true }
 bincode = "1.3.1"
 structopt = { version = "0.3.26", default-features = false}
 derivative = "2.2.0"

--- a/e2e_tests/Cargo.lock
+++ b/e2e_tests/Cargo.lock
@@ -523,7 +523,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1215,7 +1226,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -1238,7 +1249,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1708,12 +1719,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tss-esapi"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de234df360c349f78ecd33f0816ab3842db635732212b5cfad67f2638336864e"
+checksum = "d36722a0888ff29225d11ea205f10319d6cb4d072ef3c91bf3509f7f476d89e3"
 dependencies = [
  "bitfield",
  "enumflags2",
+ "getrandom 0.2.12",
  "hostname-validator",
  "log",
  "mbox",
@@ -1833,6 +1845,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.14"
 rand = "0.7.3"
 env_logger = "0.10.0"
 stdext = "0.3.1"
-tss-esapi = { version = "7.4.0", optional = true }
+tss-esapi = { version = "7.5.0", optional = true }
 
 [dev-dependencies]
 ring = "0.16.20"

--- a/e2e_tests/src/lib.rs
+++ b/e2e_tests/src/lib.rs
@@ -9,7 +9,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/e2e_tests/tests/mod.rs
+++ b/e2e_tests/tests/mod.rs
@@ -10,7 +10,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1890,12 +1890,13 @@ dependencies = [
 
 [[package]]
 name = "tss-esapi"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de234df360c349f78ecd33f0816ab3842db635732212b5cfad67f2638336864e"
+checksum = "d36722a0888ff29225d11ea205f10319d6cb4d072ef3c91bf3509f7f476d89e3"
 dependencies = [
  "bitfield",
  "enumflags2",
+ "getrandom",
  "hostname-validator",
  "log",
  "mbox",

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -9,7 +9,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -18,7 +18,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/src/key_info_managers/on_disk_manager/mod.rs
+++ b/src/key_info_managers/on_disk_manager/mod.rs
@@ -79,8 +79,8 @@ impl ApplicationName {
 }
 
 #[allow(deprecated)]
-impl std::fmt::Display for ApplicationName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ApplicationName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)
     }
 }
@@ -152,7 +152,7 @@ impl fmt::Display for KeyTriple {
 impl TryFrom<KeyIdentity> for KeyTriple {
     type Error = String;
 
-    fn try_from(key_identity: KeyIdentity) -> ::std::result::Result<Self, Self::Error> {
+    fn try_from(key_identity: KeyIdentity) -> std::result::Result<Self, Self::Error> {
         let provider_id = match key_identity.provider.uuid().as_str() {
             CoreProvider::PROVIDER_UUID => Ok(ProviderId::Core),
             #[cfg(feature = "cryptoauthlib-provider")]
@@ -188,7 +188,7 @@ impl TryFrom<(KeyTriple, ProviderIdentity, AuthType)> for KeyIdentity {
 
     fn try_from(
         (key_triple, provider_identity, auth_type): (KeyTriple, ProviderIdentity, AuthType),
-    ) -> ::std::result::Result<Self, Self::Error> {
+    ) -> std::result::Result<Self, Self::Error> {
         // Result types required by clippy as Err result has the possibility of not being compiled.
         let provider_uuid = match key_triple.provider_id {
             ProviderId::Core => Ok::<String, Self::Error>(
@@ -489,7 +489,7 @@ impl OnDiskKeyInfoManager {
             fs::remove_file(&key_name_file_path)?;
         }
 
-        let mut mapping_file = fs::File::create(&key_name_file_path).map_err(|e| {
+        let mut mapping_file = File::create(&key_name_file_path).map_err(|e| {
             error!(
                 "Failed to create Key Info Mapping file at {:?}",
                 key_name_file_path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/src/providers/cryptoauthlib/mod.rs
+++ b/src/providers/cryptoauthlib/mod.rs
@@ -653,7 +653,7 @@ impl ProviderBuilder {
         };
         Provider::new(
             self.provider_name.ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "missing provider name")
+                std::io::Error::new(ErrorKind::InvalidData, "missing provider name")
             })?,
             self.key_info_store
                 .ok_or_else(|| Error::new(ErrorKind::InvalidData, "missing key info store"))?,

--- a/src/providers/mbed_crypto/key_management.rs
+++ b/src/providers/mbed_crypto/key_management.rs
@@ -175,7 +175,7 @@ impl Provider {
             .expect("Grabbing key handle mutex failed");
 
         let id = key::Id::from_persistent_key_id(key_id)?;
-        let key_attributes = key::Attributes::from_key_id(id)?;
+        let key_attributes = Attributes::from_key_id(id)?;
         let buffer_size = key_attributes.export_public_key_output_size()?;
         let mut buffer = vec![0u8; buffer_size];
 
@@ -206,7 +206,7 @@ impl Provider {
             .expect("Grabbing key handle mutex failed");
 
         let id = key::Id::from_persistent_key_id(key_id)?;
-        let key_attributes = key::Attributes::from_key_id(id)?;
+        let key_attributes = Attributes::from_key_id(id)?;
         let buffer_size = key_attributes.export_key_output_size()?;
         let mut buffer = vec![0u8; buffer_size];
 

--- a/src/providers/mbed_crypto/mod.rs
+++ b/src/providers/mbed_crypto/mod.rs
@@ -375,9 +375,8 @@ impl ProviderBuilder {
     /// Build into a MbedProvider
     pub fn build(self) -> std::io::Result<Provider> {
         Provider::new(
-            self.provider_name.ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "missing provider name")
-            })?,
+            self.provider_name
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "missing provider name"))?,
             self.key_info_store
                 .ok_or_else(|| Error::new(ErrorKind::InvalidData, "missing key info store"))?,
         )

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -86,16 +86,16 @@ impl ProviderIdentity {
 impl TryFrom<ProviderIdentity> for ProviderId {
     type Error = String;
 
-    fn try_from(provider_identity: ProviderIdentity) -> ::std::result::Result<Self, Self::Error> {
+    fn try_from(provider_identity: ProviderIdentity) -> std::result::Result<Self, Self::Error> {
         let provider_id = match provider_identity.uuid.as_str() {
             #[cfg(feature = "cryptoauthlib-provider")]
             crate::providers::cryptoauthlib::Provider::PROVIDER_UUID => Ok(ProviderId::CryptoAuthLib),
             #[cfg(feature = "mbed-crypto-provider")]
-            crate::providers::mbed_crypto::Provider::PROVIDER_UUID => Ok(ProviderId::MbedCrypto),
+            mbed_crypto::Provider::PROVIDER_UUID => Ok(ProviderId::MbedCrypto),
             #[cfg(feature = "pkcs11-provider")]
-            crate::providers::pkcs11::Provider::PROVIDER_UUID => Ok(ProviderId::Pkcs11),
+            pkcs11::Provider::PROVIDER_UUID => Ok(ProviderId::Pkcs11),
             #[cfg(feature = "tpm-provider")]
-            crate::providers::tpm::Provider::PROVIDER_UUID => Ok(ProviderId::Tpm),
+            tpm::Provider::PROVIDER_UUID => Ok(ProviderId::Tpm),
             #[cfg(feature = "trusted-service-provider")]
             crate::providers::trusted_service::Provider::PROVIDER_UUID => Ok(ProviderId::TrustedService),
             _ => Err(format!("Cannot convert from ProviderIdentity to ProviderId.\nProvider \"{}\" is not recognised.\nCould be it does not exist, or Parsec was not compiled with the required provider feature flags.", provider_identity.uuid)),

--- a/src/providers/pkcs11/mod.rs
+++ b/src/providers/pkcs11/mod.rs
@@ -586,9 +586,8 @@ impl ProviderBuilder {
         };
 
         Ok(Provider::new(
-            self.provider_name.ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "missing provider name")
-            })?,
+            self.provider_name
+                .ok_or_else(|| Error::new(ErrorKind::InvalidData, "missing provider name"))?,
             self.key_info_store
                 .ok_or_else(|| Error::new(ErrorKind::InvalidData, "missing key info store"))?,
             backend,

--- a/src/providers/tpm/mod.rs
+++ b/src/providers/tpm/mod.rs
@@ -418,7 +418,7 @@ impl ProviderBuilder {
         }
         Ok(Provider::new(
             self.provider_name.ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "missing provider name")
+                std::io::Error::new(ErrorKind::InvalidData, "missing provider name")
             })?,
             self.key_info_store.ok_or_else(|| {
                 std::io::Error::new(ErrorKind::InvalidData, "missing key info store")

--- a/src/utils/cli.rs
+++ b/src/utils/cli.rs
@@ -5,6 +5,7 @@
 // WARNING: This file should be only updated in a non-breaking way. CLI flags should not be
 // removed, new flags should be tested.
 // See https://github.com/parallaxsecond/parsec/issues/392 for details.
+#![allow(unused_qualifications)]
 
 use structopt::StructOpt;
 

--- a/src/utils/service_builder.rs
+++ b/src/utils/service_builder.rs
@@ -362,7 +362,7 @@ unsafe fn get_provider(
             );
 
             let tcti_name_conf = TctiNameConf::from_str(tcti).map_err(|_| {
-                std::io::Error::new(ErrorKind::InvalidData, "Invalid TCTI configuration string")
+                Error::new(ErrorKind::InvalidData, "Invalid TCTI configuration string")
             })?;
             if *skip_if_no_tpm == Some(true) {
                 // TODO: When the TPM Provider uses the new TctiContext, pass it directly to the


### PR DESCRIPTION
The new version of tss-esapi contains a required security fix.