### PR TITLE
Remove unused_qualifications

### DIFF
--- a/fuzz/fuzz_targets/fuzz_service.rs
+++ b/fuzz/fuzz_targets/fuzz_service.rs
@@ -15,7 +15,7 @@ lazy_static! {
         log_setup();
         let config_file = String::from("./run_config.toml");
         let config_file =
-            ::std::fs::read_to_string(config_file).expect("Failed to read configuration file");
+            std::fs::read_to_string(config_file).expect("Failed to read configuration file");
         let config: ServiceConfig =
             toml::from_str(&config_file).expect("Failed to parse service configuration");
         ServiceBuilder::build_service(&config).expect("Failed to initialize service")

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
     let _ = flag::register(SIGINT, kill_signal.clone())?;
     let _ = flag::register(SIGHUP, reload_signal.clone())?;
 
-    let mut config_file = ::std::fs::read_to_string(opts.config.clone()).map_err(|e| {
+    let mut config_file = std::fs::read_to_string(opts.config.clone()).map_err(|e| {
         Error::new(
             e.kind(),
             format!("Failed to read config file from path: {}", opts.config),
@@ -122,7 +122,7 @@ fn main() -> Result<()> {
             drop(listener);
             drop(threadpool);
 
-            config_file = ::std::fs::read_to_string(opts.config.clone()).map_err(|e| {
+            config_file = std::fs::read_to_string(opts.config.clone()).map_err(|e| {
                 Error::new(
                     e.kind(),
                     format!("Failed to read config file from path: {}", opts.config),
@@ -149,7 +149,7 @@ fn main() -> Result<()> {
                 trace!("handle_request egress");
             });
         } else {
-            ::std::thread::sleep(Duration::from_millis(
+            std::thread::sleep(Duration::from_millis(
                 config
                     .core_settings
                     .idle_listener_sleep_duration

--- a/src/utils/tests/mod.rs
+++ b/src/utils/tests/mod.rs
@@ -22,7 +22,7 @@ fn config_to_toml(file_name: String) -> ServiceConfig {
         panic!();
     }
 
-    let config_file = ::std::fs::read_to_string(new_config_path.clone())
+    let config_file = std::fs::read_to_string(new_config_path.clone())
         .map_err(|e| {
             error!(
                 "Failed to read config file from path: {:#?}\nError: {:#?}",


### PR DESCRIPTION
Following the unused_qualifications lint when building with Rust Nightly, remove the errors caused by the lint.