### PR TITLE
tpm/tests: Ignore test_root_key_check case

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -396,6 +396,11 @@ fi
 echo "Unit, doc and integration tests"
 RUST_BACKTRACE=1 cargo test $FEATURES
 
+# Ignored unit tests that we want to manually run should be run here!
+if [ "$PROVIDER_NAME" = "tpm" ] || [ "$PROVIDER_NAME" = "all" ]; then
+    RUST_BACKTRACE=1 cargo test $FEATURES -- --ignored test_root_key_check
+fi
+
 # Removing any mappings or on disk keys left over from integration tests
 rm -rf mappings/
 rm -rf kim-mappings/

--- a/src/providers/tpm/mod.rs
+++ b/src/providers/tpm/mod.rs
@@ -535,8 +535,12 @@ mod test {
     };
     use parsec_interface::requests::AuthType;
 
+    // This test can only be run with a TPM already available in your system.
+    // Ignored unless specified
+    #[ignore]
     #[test]
     fn test_root_key_check() {
+        // Test configuration should be changed to adapt to your system's TPM
         let tcti = "mssim:host=127.0.0.1,port=2321";
         let owner_hierarchy_auth = "hex:74706d5f70617373";
         let endorsement_hierarchy_auth = "str:endorsement_pass".to_string();


### PR DESCRIPTION
Current situation:

 1. The test depends on a TPM being available in the system.
 2. The connection settings to the TPM have to be changed to be in line with the TPM available in the system. Currently, the hardcoded settings are set to test with the software TPM enabled by the CI.

Therefore:

 * Ignore the test by default. Each developer can run their tests according to the TPM configuration if it's needed.
 * Explicitly run the test in CI to make sure this is tested at least with the software TPM.