### PR TITLE
tests: avoid install errors due to stale cache

### DIFF
--- a/e2e_tests/docker_image/parsec-service-test-cross-compile.Dockerfile
+++ b/e2e_tests/docker_image/parsec-service-test-cross-compile.Dockerfile
@@ -23,6 +23,7 @@ RUN cd trusted-services/deployments/libts/arm-linux/ \
 RUN rm -rf trusted-services
 
 # Install cross-compilers
+RUN apt update
 RUN apt install -y gcc-multilib
 RUN apt install -y gcc-arm-linux-gnueabihf
 RUN apt install -y gcc-aarch64-linux-gnu


### PR DESCRIPTION
Since the `ci` (Continuous Integration) workflow can be triggered just using the `parsec-service-test-cross-compile` option, then the docker image should not assume that the apt cache which is included in the `ghcr.io/parallaxsecond/parsec-service-test-all` image is still up to date.

Without updating the cache, then the installation of the cross-compilers can fail if the apt package versions have changed in the external apt repo.